### PR TITLE
fix: UpdateItem ignores ConditionExpression on non-existent items

### DIFF
--- a/src/actions/transact_write_items.rs
+++ b/src/actions/transact_write_items.rs
@@ -364,17 +364,10 @@ fn execute_update(storage: &Storage, update: &TransactUpdate) -> Result<()> {
     let (pk, sk) = helpers::extract_key_strings(&update.key, &key_schema)?;
 
     let existing_json = storage.get_item(&update.table_name, &pk, &sk)?;
-    let mut item: Item = existing_json
+    let existing_item: Item = existing_json
         .as_ref()
         .and_then(|j| serde_json::from_str(j).ok())
         .unwrap_or_default();
-
-    // If new item (upsert), populate key attrs
-    if existing_json.is_none() {
-        for (k, v) in &update.key {
-            item.insert(k.clone(), v.clone());
-        }
-    }
 
     let tracker = crate::expressions::TrackedExpressionAttributes::new(
         &update.expression_attribute_names,
@@ -391,17 +384,28 @@ fn execute_update(storage: &Storage, update: &TransactUpdate) -> Result<()> {
         tracker.track_update_expr(&parsed);
     }
 
-    // Evaluate condition if present
+    // Evaluate condition against the original existing item BEFORE populating
+    // key attributes for upsert. Otherwise attribute_exists(PK) would always
+    // pass because the key was pre-populated.
     if let Some(ref cond_expr) = update.condition_expression {
         let return_item = if update.return_values_on_condition_check_failure.as_deref()
             == Some("ALL_OLD")
             && existing_json.is_some()
         {
-            Some(item.clone())
+            Some(existing_item.clone())
         } else {
             None
         };
-        check_condition_tracked(cond_expr, &item, &tracker, return_item)?;
+        check_condition_tracked(cond_expr, &existing_item, &tracker, return_item)?;
+    }
+
+    // Build the mutable item for the update expression.
+    // If new item (upsert), populate key attrs.
+    let mut item = existing_item;
+    if existing_json.is_none() {
+        for (k, v) in &update.key {
+            item.insert(k.clone(), v.clone());
+        }
     }
 
     // Apply update expression

--- a/src/actions/update_item.rs
+++ b/src/actions/update_item.rs
@@ -400,30 +400,25 @@ pub fn execute(storage: &Storage, mut request: UpdateItemRequest) -> Result<Upda
     let transactional_work = || -> Result<UpdateWorkResult> {
         // Fetch existing item (or create empty one for upsert)
         let existing_json = storage.get_item(&request.table_name, &pk, &sk)?;
-        let mut item: HashMap<String, AttributeValue> = existing_json
+        let existing_item: HashMap<String, AttributeValue> = existing_json
             .as_ref()
             .and_then(|j| serde_json::from_str(j).ok())
             .unwrap_or_default();
 
-        // If item doesn't exist, populate key attributes for upsert
-        if existing_json.is_none() {
-            for (k, v) in &request.key {
-                item.insert(k.clone(), v.clone());
-            }
-        }
-
-        // Evaluate ConditionExpression against the existing item
+        // Evaluate ConditionExpression against the original existing item BEFORE
+        // populating key attributes for upsert. Otherwise attribute_exists(PK)
+        // would always pass because the key was pre-populated.
         if let Some(ref cond_expr) = request.condition_expression {
             let parsed = crate::expressions::condition::parse(cond_expr)
                 .map_err(DynoxideError::ValidationException)?;
-            let result = crate::expressions::condition::evaluate(&parsed, &item, &tracker)
+            let result = crate::expressions::condition::evaluate(&parsed, &existing_item, &tracker)
                 .map_err(DynoxideError::ValidationException)?;
             if !result {
                 let return_item = if request.return_values_on_condition_check_failure.as_deref()
                     == Some("ALL_OLD")
                     && existing_json.is_some()
                 {
-                    Some(item.clone())
+                    Some(existing_item.clone())
                 } else {
                     None
                 };
@@ -431,6 +426,15 @@ pub fn execute(storage: &Storage, mut request: UpdateItemRequest) -> Result<Upda
                     "The conditional request failed".to_string(),
                     return_item,
                 ));
+            }
+        }
+
+        // Build mutable item for the update expression.
+        // If item doesn't exist, populate key attributes for upsert.
+        let mut item = existing_item;
+        if existing_json.is_none() {
+            for (k, v) in &request.key {
+                item.insert(k.clone(), v.clone());
             }
         }
 

--- a/tests/transactions.rs
+++ b/tests/transactions.rs
@@ -742,7 +742,10 @@ fn test_transact_update_condition_rejects_nonexistent_item() {
     });
     let get_req = serde_json::from_value(get_req).unwrap();
     let resp = db.get_item(get_req).unwrap();
-    assert!(resp.item.is_none(), "item should not exist after failed condition");
+    assert!(
+        resp.item.is_none(),
+        "item should not exist after failed condition"
+    );
 }
 
 /// Standalone UpdateItem with `attribute_exists(PK)` should also fail when
@@ -774,5 +777,8 @@ fn test_update_item_condition_rejects_nonexistent_item() {
     });
     let get_req = serde_json::from_value(get_req).unwrap();
     let resp = db.get_item(get_req).unwrap();
-    assert!(resp.item.is_none(), "item should not exist after failed condition");
+    assert!(
+        resp.item.is_none(),
+        "item should not exist after failed condition"
+    );
 }

--- a/tests/transactions.rs
+++ b/tests/transactions.rs
@@ -684,3 +684,95 @@ fn test_transact_get_empty_items_rejected() {
         "Expected empty array error, got: {msg}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Bug: TransactWriteItems Update ignores ConditionExpression on non-existent items
+// ---------------------------------------------------------------------------
+
+fn create_pk_sk_table(db: &Database, name: &str) {
+    let req: serde_json::Value = json!({
+        "TableName": name,
+        "KeySchema": [
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"}
+        ],
+        "AttributeDefinitions": [
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"}
+        ]
+    });
+    let create_req = serde_json::from_value(req).unwrap();
+    db.create_table(create_req).unwrap();
+}
+
+/// TransactWriteItems Update with `attribute_exists(PK)` should fail when the
+/// item does not exist.
+///
+/// Root cause: `execute_update` populated key attributes on the item BEFORE
+/// evaluating the condition expression, so `attribute_exists(PK)` always
+/// returned true.
+#[test]
+fn test_transact_update_condition_rejects_nonexistent_item() {
+    let db = Database::memory().unwrap();
+    create_pk_sk_table(&db, "cond-test");
+
+    let req: serde_json::Value = json!({
+        "TransactItems": [{
+            "Update": {
+                "TableName": "cond-test",
+                "Key": {"PK": {"S": "does-not-exist"}, "SK": {"S": "nope"}},
+                "UpdateExpression": "ADD TagCount :inc",
+                "ExpressionAttributeValues": {":inc": {"N": "1"}},
+                "ConditionExpression": "attribute_exists(PK)"
+            }
+        }]
+    });
+    let transact_req = serde_json::from_value(req).unwrap();
+    let err = db.transact_write_items(transact_req).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("ConditionalCheckFailed"),
+        "Expected ConditionalCheckFailed for non-existent item, got: {msg}"
+    );
+
+    // Verify no ghost item was created.
+    let get_req: serde_json::Value = json!({
+        "TableName": "cond-test",
+        "Key": {"PK": {"S": "does-not-exist"}, "SK": {"S": "nope"}}
+    });
+    let get_req = serde_json::from_value(get_req).unwrap();
+    let resp = db.get_item(get_req).unwrap();
+    assert!(resp.item.is_none(), "item should not exist after failed condition");
+}
+
+/// Standalone UpdateItem with `attribute_exists(PK)` should also fail when
+/// the item does not exist (same bug, different code path).
+#[test]
+fn test_update_item_condition_rejects_nonexistent_item() {
+    let db = Database::memory().unwrap();
+    create_pk_sk_table(&db, "cond-test-single");
+
+    let req: serde_json::Value = json!({
+        "TableName": "cond-test-single",
+        "Key": {"PK": {"S": "ghost"}, "SK": {"S": "nope"}},
+        "UpdateExpression": "ADD TagCount :inc",
+        "ExpressionAttributeValues": {":inc": {"N": "1"}},
+        "ConditionExpression": "attribute_exists(PK)"
+    });
+    let update_req = serde_json::from_value(req).unwrap();
+    let err = db.update_item(update_req).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("conditional request failed"),
+        "Expected conditional check failure for non-existent item, got: {msg}"
+    );
+
+    // Verify no ghost item was created.
+    let get_req: serde_json::Value = json!({
+        "TableName": "cond-test-single",
+        "Key": {"PK": {"S": "ghost"}, "SK": {"S": "nope"}}
+    });
+    let get_req = serde_json::from_value(get_req).unwrap();
+    let resp = db.get_item(get_req).unwrap();
+    assert!(resp.item.is_none(), "item should not exist after failed condition");
+}


### PR DESCRIPTION
## Summary

`UpdateItem` and `TransactWriteItems` Update with `ConditionExpression: attribute_exists(PK)` succeed and create a new item when the key does not exist. DynamoDB (and DynamoDB Local) correctly reject with `ConditionalCheckFailed`.

**Version:** dynoxide 0.9.8

## Reproduction

```bash
dynoxide --port 8000 &

export AWS_ACCESS_KEY_ID=fake AWS_SECRET_ACCESS_KEY=fake \
       AWS_DEFAULT_REGION=us-east-1 EP=http://localhost:8000

# Create table
aws dynamodb create-table --endpoint-url $EP \
  --table-name test-condition --billing-mode PAY_PER_REQUEST \
  --attribute-definitions AttributeName=PK,AttributeType=S AttributeName=SK,AttributeType=S \
  --key-schema AttributeName=PK,KeyType=HASH AttributeName=SK,KeyType=RANGE

# TransactWrite Update with attribute_exists on a key that does NOT exist
aws dynamodb transact-write-items --endpoint-url $EP \
  --transact-items '[{
    "Update": {
      "TableName": "test-condition",
      "Key": {"PK": {"S": "does-not-exist"}, "SK": {"S": "nope"}},
      "UpdateExpression": "ADD TagCount :inc",
      "ExpressionAttributeValues": {":inc": {"N": "1"}},
      "ConditionExpression": "attribute_exists(PK)"
    }
  }]'
# => succeeds (should fail)

# Ghost record was created
aws dynamodb get-item --endpoint-url $EP \
  --table-name test-condition \
  --key '{"PK": {"S": "does-not-exist"}, "SK": {"S": "nope"}}'
# => {PK: "does-not-exist", SK: "nope", TagCount: 1}
```

## Expected

`TransactionCanceledException` with `ConditionalCheckFailed`. Same for standalone `UpdateItem`.

## Root cause

Both `execute_update` in `transact_write_items.rs` and the `UpdateItem` handler in `update_item.rs` populate key attributes on the item for the upsert path **before** evaluating the `ConditionExpression`. This makes `attribute_exists(PK)` always pass because PK was just inserted.

## Fix

Evaluate the condition against the original existing item (empty for non-existent keys) before populating key attributes. The PR includes regression tests for both code paths.