### PR TITLE
fix: GSI scan pagination breaks after the first page

### DIFF
--- a/src/actions/scan.rs
+++ b/src/actions/scan.rs
@@ -414,9 +414,12 @@ pub fn execute(storage: &Storage, mut request: ScanRequest) -> Result<ScanRespon
         (None, None)
     };
 
-    // For LSI scans, extract the base table key from ExclusiveStartKey
-    // for composite cursor pagination.
-    let (start_base_pk, start_base_sk) = if is_lsi {
+    // For index scans (LSI and GSI), extract the base table key from
+    // ExclusiveStartKey for composite cursor pagination. The GSI/LSI
+    // tables have a composite primary key that includes the base table
+    // keys, so the cursor must include them to avoid skipping rows that
+    // share the same index key.
+    let (start_base_pk, start_base_sk) = if is_lsi || request.index_name.is_some() {
         if let Some(ref esk) = exclusive_start_key {
             let base_pk = esk
                 .get(&table_key_schema.partition_key)

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1002,14 +1002,35 @@ impl Storage {
         if let (Some(start_pk), Some(start_sk)) =
             (params.exclusive_start_pk, params.exclusive_start_sk)
         {
-            where_clauses.push(format!(
-                "(gsi_pk, gsi_sk) > (?{}, ?{})",
-                param_idx,
-                param_idx + 1
-            ));
-            params_vec.push(Box::new(start_pk.to_string()));
-            params_vec.push(Box::new(start_sk.to_string()));
-            param_idx += 2;
+            // The GSI table's primary key is (gsi_pk, gsi_sk, table_pk, table_sk).
+            // Using only (gsi_pk, gsi_sk) for the cursor skips rows that share the
+            // same GSI key but have different base table keys.
+            if let (Some(base_pk), Some(base_sk)) = (
+                params.exclusive_start_base_pk,
+                params.exclusive_start_base_sk,
+            ) {
+                where_clauses.push(format!(
+                    "(gsi_pk, gsi_sk, table_pk, table_sk) > (?{}, ?{}, ?{}, ?{})",
+                    param_idx,
+                    param_idx + 1,
+                    param_idx + 2,
+                    param_idx + 3
+                ));
+                params_vec.push(Box::new(start_pk.to_string()));
+                params_vec.push(Box::new(start_sk.to_string()));
+                params_vec.push(Box::new(base_pk.to_string()));
+                params_vec.push(Box::new(base_sk.to_string()));
+                param_idx += 4;
+            } else {
+                where_clauses.push(format!(
+                    "(gsi_pk, gsi_sk) > (?{}, ?{})",
+                    param_idx,
+                    param_idx + 1
+                ));
+                params_vec.push(Box::new(start_pk.to_string()));
+                params_vec.push(Box::new(start_sk.to_string()));
+                param_idx += 2;
+            }
         }
 
         // For GSI parallel scan, hash on the base table pk (table_pk column)
@@ -1028,7 +1049,7 @@ impl Storage {
             sql.push_str(&where_clauses.join(" AND "));
         }
 
-        sql.push_str(" ORDER BY gsi_pk ASC, gsi_sk ASC");
+        sql.push_str(" ORDER BY gsi_pk ASC, gsi_sk ASC, table_pk ASC, table_sk ASC");
 
         if let Some(lim) = params.limit {
             sql.push_str(&format!(" LIMIT {lim}"));

--- a/tests/gsi.rs
+++ b/tests/gsi.rs
@@ -667,3 +667,153 @@ fn test_gsi_sort_order() {
         .collect();
     assert_eq!(timestamps, vec!["2024-03-01", "2024-02-01", "2024-01-01"]);
 }
+
+// ---------------------------------------------------------------------------
+// Bug: GSI scan pagination breaks after the first page
+// ---------------------------------------------------------------------------
+
+/// Paginated scan on a GSI should return all items across multiple pages.
+///
+/// Root cause: `scan_gsi_items` used `(gsi_pk, gsi_sk) > (?, ?)` for the
+/// cursor, but the GSI table's primary key is `(gsi_pk, gsi_sk, table_pk,
+/// table_sk)`. When multiple items share the same GSI key, the 2-column
+/// cursor skips all remaining rows with that key on the second page.
+#[test]
+fn test_gsi_scan_pagination_returns_all_items() {
+    let db = Database::memory().unwrap();
+
+    // Table: pk=ID(S), GSI1: pk=Type(S) sk=ID(S), projection=ALL
+    let req: serde_json::Value = serde_json::json!({
+        "TableName": "Items",
+        "KeySchema": [{"AttributeName": "ID", "KeyType": "HASH"}],
+        "AttributeDefinitions": [
+            {"AttributeName": "ID", "AttributeType": "S"},
+            {"AttributeName": "Type", "AttributeType": "S"}
+        ],
+        "GlobalSecondaryIndexes": [{
+            "IndexName": "TypeIndex",
+            "KeySchema": [
+                {"AttributeName": "Type", "KeyType": "HASH"},
+                {"AttributeName": "ID", "KeyType": "RANGE"}
+            ],
+            "Projection": {"ProjectionType": "ALL"}
+        }]
+    });
+    db.create_table(serde_json::from_value(req).unwrap()).unwrap();
+
+    // Insert 50 items all with the same GSI PK ("widget")
+    for i in 0..50 {
+        let req: serde_json::Value = serde_json::json!({
+            "TableName": "Items",
+            "Item": {
+                "ID": {"S": format!("item-{:03}", i)},
+                "Type": {"S": "widget"},
+                "Data": {"S": format!("payload-{}", i)}
+            }
+        });
+        db.put_item(serde_json::from_value(req).unwrap()).unwrap();
+    }
+
+    // Paginated scan on GSI with limit=10, should get all 50 items across 5 pages
+    let mut all_items = Vec::new();
+    let mut exclusive_start_key: Option<std::collections::HashMap<String, AttributeValue>> = None;
+    let mut pages = 0;
+
+    loop {
+        let mut req: serde_json::Value = serde_json::json!({
+            "TableName": "Items",
+            "IndexName": "TypeIndex",
+            "Limit": 10
+        });
+        if let Some(ref esk) = exclusive_start_key {
+            req["ExclusiveStartKey"] = serde_json::to_value(esk).unwrap();
+        }
+
+        let resp = db.scan(serde_json::from_value(req).unwrap()).unwrap();
+        pages += 1;
+
+        if let Some(items) = &resp.items {
+            all_items.extend(items.clone());
+        }
+
+        match resp.last_evaluated_key {
+            Some(lek) => exclusive_start_key = Some(lek),
+            None => break,
+        }
+
+        assert!(pages <= 10, "too many pages — pagination may be looping");
+    }
+
+    assert_eq!(all_items.len(), 50, "expected all 50 items across paginated GSI scan, got {}", all_items.len());
+}
+
+/// Paginated scan on a GSI with a filter expression should still paginate correctly.
+#[test]
+fn test_gsi_scan_pagination_with_filter() {
+    let db = Database::memory().unwrap();
+
+    let req: serde_json::Value = serde_json::json!({
+        "TableName": "Filtered",
+        "KeySchema": [{"AttributeName": "ID", "KeyType": "HASH"}],
+        "AttributeDefinitions": [
+            {"AttributeName": "ID", "AttributeType": "S"},
+            {"AttributeName": "Type", "AttributeType": "S"}
+        ],
+        "GlobalSecondaryIndexes": [{
+            "IndexName": "TypeIndex",
+            "KeySchema": [
+                {"AttributeName": "Type", "KeyType": "HASH"},
+                {"AttributeName": "ID", "KeyType": "RANGE"}
+            ],
+            "Projection": {"ProjectionType": "ALL"}
+        }]
+    });
+    db.create_table(serde_json::from_value(req).unwrap()).unwrap();
+
+    // Insert 100 items, every 5th one is "special"
+    for i in 0..100 {
+        let req: serde_json::Value = serde_json::json!({
+            "TableName": "Filtered",
+            "Item": {
+                "ID": {"S": format!("item-{:03}", i)},
+                "Type": {"S": "widget"},
+                "Special": {"BOOL": i % 5 == 0}
+            }
+        });
+        db.put_item(serde_json::from_value(req).unwrap()).unwrap();
+    }
+
+    // Paginated scan on GSI with filter, limit=10 per page
+    let mut all_items = Vec::new();
+    let mut exclusive_start_key: Option<std::collections::HashMap<String, AttributeValue>> = None;
+    let mut pages = 0;
+
+    loop {
+        let mut req: serde_json::Value = serde_json::json!({
+            "TableName": "Filtered",
+            "IndexName": "TypeIndex",
+            "Limit": 10,
+            "FilterExpression": "Special = :t",
+            "ExpressionAttributeValues": {":t": {"BOOL": true}}
+        });
+        if let Some(ref esk) = exclusive_start_key {
+            req["ExclusiveStartKey"] = serde_json::to_value(esk).unwrap();
+        }
+
+        let resp = db.scan(serde_json::from_value(req).unwrap()).unwrap();
+        pages += 1;
+
+        if let Some(items) = &resp.items {
+            all_items.extend(items.clone());
+        }
+
+        match resp.last_evaluated_key {
+            Some(lek) => exclusive_start_key = Some(lek),
+            None => break,
+        }
+
+        assert!(pages <= 20, "too many pages — pagination may be looping");
+    }
+
+    assert_eq!(all_items.len(), 20, "expected 20 special items out of 100, got {}", all_items.len());
+}

--- a/tests/gsi.rs
+++ b/tests/gsi.rs
@@ -699,7 +699,8 @@ fn test_gsi_scan_pagination_returns_all_items() {
             "Projection": {"ProjectionType": "ALL"}
         }]
     });
-    db.create_table(serde_json::from_value(req).unwrap()).unwrap();
+    db.create_table(serde_json::from_value(req).unwrap())
+        .unwrap();
 
     // Insert 50 items all with the same GSI PK ("widget")
     for i in 0..50 {
@@ -744,7 +745,12 @@ fn test_gsi_scan_pagination_returns_all_items() {
         assert!(pages <= 10, "too many pages — pagination may be looping");
     }
 
-    assert_eq!(all_items.len(), 50, "expected all 50 items across paginated GSI scan, got {}", all_items.len());
+    assert_eq!(
+        all_items.len(),
+        50,
+        "expected all 50 items across paginated GSI scan, got {}",
+        all_items.len()
+    );
 }
 
 /// Paginated scan on a GSI with a filter expression should still paginate correctly.
@@ -768,7 +774,8 @@ fn test_gsi_scan_pagination_with_filter() {
             "Projection": {"ProjectionType": "ALL"}
         }]
     });
-    db.create_table(serde_json::from_value(req).unwrap()).unwrap();
+    db.create_table(serde_json::from_value(req).unwrap())
+        .unwrap();
 
     // Insert 100 items, every 5th one is "special"
     for i in 0..100 {
@@ -815,5 +822,10 @@ fn test_gsi_scan_pagination_with_filter() {
         assert!(pages <= 20, "too many pages — pagination may be looping");
     }
 
-    assert_eq!(all_items.len(), 20, "expected 20 special items out of 100, got {}", all_items.len());
+    assert_eq!(
+        all_items.len(),
+        20,
+        "expected 20 special items out of 100, got {}",
+        all_items.len()
+    );
 }


### PR DESCRIPTION
## Summary

Paginated `Scan` on a GSI (with `Limit`) returns only the first page of results when multiple items share the same GSI partition key. The second page returns 0 items and no cursor, terminating pagination early.

**Version:** dynoxide 0.9.8

## Reproduction

```bash
dynoxide --port 8000 &

export AWS_ACCESS_KEY_ID=fake AWS_SECRET_ACCESS_KEY=fake \
       AWS_DEFAULT_REGION=us-east-1 EP=http://localhost:8000

# Create table with GSI
aws dynamodb create-table --endpoint-url $EP \
  --table-name test-gsi-page --billing-mode PAY_PER_REQUEST \
  --attribute-definitions \
    AttributeName=ID,AttributeType=S \
    AttributeName=Type,AttributeType=S \
  --key-schema AttributeName=ID,KeyType=HASH \
  --global-secondary-indexes '[{
    "IndexName": "TypeIndex",
    "KeySchema": [
      {"AttributeName": "Type", "KeyType": "HASH"},
      {"AttributeName": "ID", "KeyType": "RANGE"}
    ],
    "Projection": {"ProjectionType": "ALL"}
  }]'

# Insert 50 items all with the same GSI PK
for i in $(seq -w 0 49); do
  aws dynamodb put-item --endpoint-url $EP --table-name test-gsi-page \
    --item "{\"ID\":{\"S\":\"item-$i\"},\"Type\":{\"S\":\"widget\"}}"
done

# Page 1 — returns 10 items + LastEvaluatedKey
aws dynamodb scan --endpoint-url $EP --table-name test-gsi-page \
  --index-name TypeIndex --limit 10

# Page 2 — returns 0 items, no cursor. Should return next 10.
aws dynamodb scan --endpoint-url $EP --table-name test-gsi-page \
  --index-name TypeIndex --limit 10 \
  --exclusive-start-key '<LastEvaluatedKey from page 1>'
```

## Expected

All 50 items returned across 5+ pages.

## Root cause

`scan_gsi_items` in `storage.rs` uses `(gsi_pk, gsi_sk) > (?, ?)` for the pagination cursor, but the GSI table's primary key is `(gsi_pk, gsi_sk, table_pk, table_sk)`. When multiple items share the same `(gsi_pk, gsi_sk)`, the 2-column cursor skips all remaining rows with that key.

## Fix

- Use the full 4-tuple `(gsi_pk, gsi_sk, table_pk, table_sk)` for the WHERE clause cursor
- Match the ORDER BY to include `table_pk, table_sk`
- Extract base table keys from `ExclusiveStartKey` for GSI scans (was already done for LSIs)

Regression tests cover paginated GSI scan with and without FilterExpression. Also submitted as a conformance test: https://github.com/nubo-db/dynamodb-conformance/pull/1