### PR TITLE
fix: not-equals on missing attribute returns false instead of true

### DIFF
--- a/src/expressions/condition.rs
+++ b/src/expressions/condition.rs
@@ -102,7 +102,11 @@ pub fn evaluate(
             let rv = resolve_operand(right, item, tracker)?;
             match (lv, rv) {
                 (Some(l), Some(r)) => Ok(compare_values(&l, op, &r)),
-                _ => Ok(false),
+                // When either operand is missing (attribute doesn't exist):
+                // - <> (not-equals) returns true: a missing value is not equal to anything
+                // - All other comparisons return false: a missing value can't be
+                //   compared for equality, ordering, etc.
+                _ => Ok(matches!(op, CompOp::Ne)),
             }
         }
 
@@ -1304,5 +1308,29 @@ mod tests {
         let item: HashMap<String, AttributeValue> = HashMap::new();
         let av = vals(&[(":val", AttributeValue::S("x".into()))]);
         assert!(!evaluate_without_tracking(&expr, &item, &None, &av).unwrap());
+    }
+
+    #[test]
+    fn test_missing_attribute_ne_is_true() {
+        let item: HashMap<String, AttributeValue> = HashMap::new();
+        let av = vals(&[(":val", AttributeValue::S("working".into()))]);
+        let expr = parse("nonexistent <> :val").unwrap();
+        assert!(evaluate_without_tracking(&expr, &item, &None, &av).unwrap());
+    }
+
+    #[test]
+    fn test_missing_attribute_comparisons() {
+        let item: HashMap<String, AttributeValue> = HashMap::new();
+        let av = vals(&[(":val", AttributeValue::S("x".into()))]);
+        for (op, expected) in [("=", false), ("<>", true), ("<", false), ("<=", false), (">", false), (">=", false)] {
+            let expr = parse(&format!("nonexistent {} :val", op)).unwrap();
+            assert_eq!(
+                evaluate_without_tracking(&expr, &item, &None, &av).unwrap(),
+                expected,
+                "operator {} on missing attribute should be {}",
+                op,
+                expected
+            );
+        }
     }
 }

--- a/src/expressions/condition.rs
+++ b/src/expressions/condition.rs
@@ -1322,7 +1322,14 @@ mod tests {
     fn test_missing_attribute_comparisons() {
         let item: HashMap<String, AttributeValue> = HashMap::new();
         let av = vals(&[(":val", AttributeValue::S("x".into()))]);
-        for (op, expected) in [("=", false), ("<>", true), ("<", false), ("<=", false), (">", false), (">=", false)] {
+        for (op, expected) in [
+            ("=", false),
+            ("<>", true),
+            ("<", false),
+            ("<=", false),
+            (">", false),
+            (">=", false),
+        ] {
             let expr = parse(&format!("nonexistent {} :val", op)).unwrap();
             assert_eq!(
                 evaluate_without_tracking(&expr, &item, &None, &av).unwrap(),

--- a/tests/correctness_fixes.rs
+++ b/tests/correctness_fixes.rs
@@ -742,7 +742,8 @@ fn test_ne_on_missing_attribute_returns_true() {
         "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
         "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}]
     });
-    db.create_table(serde_json::from_value(req).unwrap()).unwrap();
+    db.create_table(serde_json::from_value(req).unwrap())
+        .unwrap();
 
     // PutItem with condition: status <> "working" on a non-existent item.
     let req: serde_json::Value = serde_json::json!({
@@ -779,5 +780,8 @@ fn test_ne_on_missing_attribute_returns_true() {
         "Key": {"pk": {"S": "item2"}}
     });
     let resp = db.get_item(serde_json::from_value(req).unwrap()).unwrap();
-    assert!(resp.item.is_some(), "item2 should have been created via OR short-circuit");
+    assert!(
+        resp.item.is_some(),
+        "item2 should have been created via OR short-circuit"
+    );
 }

--- a/tests/correctness_fixes.rs
+++ b/tests/correctness_fixes.rs
@@ -730,3 +730,54 @@ fn test_c3_partiql_number_comparison_precision() {
         "PartiQL comparison with different last digit should not match"
     );
 }
+
+/// PutItem with `<>` condition on a missing attribute should succeed.
+/// A missing attribute is not equal to any value, so `status <> "working"`
+/// is true when the item has no `status` attribute.
+#[test]
+fn test_ne_on_missing_attribute_returns_true() {
+    let db = Database::memory().unwrap();
+    let req: serde_json::Value = serde_json::json!({
+        "TableName": "ne-missing",
+        "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+        "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}]
+    });
+    db.create_table(serde_json::from_value(req).unwrap()).unwrap();
+
+    // PutItem with condition: status <> "working" on a non-existent item.
+    let req: serde_json::Value = serde_json::json!({
+        "TableName": "ne-missing",
+        "Item": {"pk": {"S": "item1"}, "status": {"S": "idle"}},
+        "ConditionExpression": "#s <> :v",
+        "ExpressionAttributeNames": {"#s": "status"},
+        "ExpressionAttributeValues": {":v": {"S": "working"}}
+    });
+    db.put_item(serde_json::from_value(req).unwrap()).unwrap();
+
+    let req: serde_json::Value = serde_json::json!({
+        "TableName": "ne-missing",
+        "Key": {"pk": {"S": "item1"}}
+    });
+    let resp = db.get_item(serde_json::from_value(req).unwrap()).unwrap();
+    assert!(resp.item.is_some(), "item should have been created");
+
+    // OR with <> and < on missing attributes — OR should short-circuit
+    let req: serde_json::Value = serde_json::json!({
+        "TableName": "ne-missing",
+        "Item": {"pk": {"S": "item2"}, "status": {"S": "new"}},
+        "ConditionExpression": "#s <> :v OR #u < :t",
+        "ExpressionAttributeNames": {"#s": "status", "#u": "updatedAt"},
+        "ExpressionAttributeValues": {
+            ":v": {"S": "working"},
+            ":t": {"S": "2099-01-01T00:00:00Z"}
+        }
+    });
+    db.put_item(serde_json::from_value(req).unwrap()).unwrap();
+
+    let req: serde_json::Value = serde_json::json!({
+        "TableName": "ne-missing",
+        "Key": {"pk": {"S": "item2"}}
+    });
+    let resp = db.get_item(serde_json::from_value(req).unwrap()).unwrap();
+    assert!(resp.item.is_some(), "item2 should have been created via OR short-circuit");
+}


### PR DESCRIPTION
## Summary

The `<>` (not-equals) comparison operator returns `false` when either operand is a missing attribute. DynamoDB returns `true` — a non-existent value is not equal to any value.

**Version:** dynoxide 0.9.8

## Reproduction

```bash
dynoxide --port 8000 &

export AWS_ACCESS_KEY_ID=fake AWS_SECRET_ACCESS_KEY=fake \
       AWS_DEFAULT_REGION=us-east-1 EP=http://localhost:8000

aws dynamodb create-table --endpoint-url $EP \
  --table-name test --billing-mode PAY_PER_REQUEST \
  --attribute-definitions AttributeName=pk,AttributeType=S \
  --key-schema AttributeName=pk,KeyType=HASH

# PutItem with condition: status <> "working" on a non-existent item
# Should succeed — missing attribute is not equal to "working"
aws dynamodb put-item --endpoint-url $EP --table-name test \
  --item '{"pk":{"S":"item1"},"status":{"S":"idle"}}' \
  --condition-expression '#s <> :v' \
  --expression-attribute-names '{"#s":"status"}' \
  --expression-attribute-values '{":v":{"S":"working"}}'
# => ConditionalCheckFailedException (should succeed)
```

## Expected

PutItem succeeds. `status <> "working"` is true because the item has no `status` attribute.

## Root cause

In `condition.rs`, the `Comparison` evaluator returns `false` for all operators when either operand resolves to `None`:

```rust
match (lv, rv) {
    (Some(l), Some(r)) => Ok(compare_values(&l, op, &r)),
    _ => Ok(false),  // ← should be true for Ne
}
```

## Fix

Return `true` for `<>` when either operand is missing, `false` for all other operators:

```rust
_ => Ok(matches!(op, CompOp::Ne)),
```

Regression tests cover all six comparison operators on missing attributes. Also submitted as a conformance test: https://github.com/nubo-db/dynamodb-conformance/pull/1