### PR TITLE
docs: add contributor and agent guidance files

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!-- Thanks for the PR. A short description and the checklist below
+are usually enough. For anything non-trivial, please link the issue
+where direction was agreed. -->
+
+## What this changes
+
+<!-- One or two sentences. What does this PR do and why? -->
+
+## Checklist
+
+- [ ] Tests added or updated
+- [ ] `cargo fmt --check` and `cargo clippy -- -D warnings` pass locally
+- [ ] `CHANGELOG.md` updated if this is a user-visible change
+- [ ] If AI tools drafted or materially shaped this change, disclosed
+  in the description above
+- [ ] Linked issue, discussion, or a short note explaining the
+  motivation
+
+## DynamoDB compatibility note (delete if not applicable)
+
+<!-- Does this change Dynoxide's observable behaviour relative to AWS
+DynamoDB? If yes, summarise the difference and link the AWS doc or
+behaviour note that motivates it. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,114 @@
+# AGENTS.md
+
+Guidance for AI coding tools (Codex, Cursor, Aider, Claude Code, and
+others) contributing to Dynoxide. Humans are welcome to read it too;
+`CONTRIBUTING.md` covers the same ground in prose.
+
+## What Dynoxide is
+
+A DynamoDB-compatible engine written in Rust, backed by SQLite. It runs
+as an HTTP server, as an MCP server for coding agents, or embeds
+directly into Rust and iOS applications as a library. Compatibility
+with AWS DynamoDB's observable behaviour is the headline goal.
+
+## Ground rules for contributions
+
+1. **Compatibility first.** Dynoxide exists to behave like DynamoDB. A
+   change that diverges from AWS DynamoDB's observable behaviour needs
+   an explicit justification in the PR description and a link to the
+   AWS doc or behaviour note that motivates it. "Cleaner API" is not a
+   reason.
+2. **Discuss before coding for anything non-trivial.** Open a GitHub
+   issue describing the change before writing it. Small bug fixes and
+   obvious cleanups are fine without a prior issue; anything that adds
+   a feature, changes public behaviour, or touches more than a handful
+   of files is worth a short issue first.
+3. **No new dependencies without discussion.** Open an issue so we can
+   weigh binary size, build time, and licence.
+4. **Disclose AI assistance.** If an AI tool drafted or materially
+   shaped the change, note it in the PR description. A single line
+   is enough; the bar is "tell us, any level", not "match a specific
+   phrasing". Examples:
+   - "Drafted by Cursor; I reviewed and ran the tests."
+   - "Copilot autocomplete on the glue code, otherwise hand-written."
+   - "Hand-written; Claude Code reviewed it and flagged two edits I
+     took."
+   This keeps maintainer review calibrated; it is not a gate.
+
+## Rust conventions
+
+- Edition: 2024 (declared in `Cargo.toml`).
+- MSRV: 1.85 (declared as `rust-version` in `Cargo.toml`). Do not use
+  features that raise it.
+- Formatting: `cargo fmt --check` must pass.
+- Linting: `cargo clippy -- -D warnings` must pass. Warnings are
+  errors; fix them rather than silencing.
+- Testing: `cargo test` on the default feature set. Other feature
+  combinations are exercised in CI; if you change feature gates,
+  mirror what `.github/workflows/ci.yml` runs.
+
+## Testing expectations
+
+- New behaviour ships with tests in `tests/` or inline module tests.
+- Bug fixes ship with a regression test that fails before the fix.
+- `cargo test` on default features is what most contributors run
+  locally. CI goes further and runs a feature matrix across four
+  configurations:
+  - default (all default features)
+  - `--no-default-features --features native-sqlite --lib`
+  - `--no-default-features --features encryption --lib`
+  - `--no-default-features --features encryption,http-server`
+  A separate feature-guard job checks that deliberately incompatible
+  feature combinations fail to compile (for example
+  `native-sqlite + encryption`). If you change feature gates or
+  anything cross-cutting, running the relevant matrix leg locally
+  saves a CI round-trip. `.github/workflows/ci.yml` is the
+  authoritative list.
+- The external conformance suite lives at
+  <https://github.com/nubo-db/dynamodb-conformance>. It is run in CI
+  for release candidates; you do not need to run it locally for every
+  PR, but it is a useful check when changing request or response
+  shapes.
+
+## Benchmarks
+
+The benchmark PR check has two layers and they do not carry equal
+weight:
+
+- **Criterion (wall-clock micro-benchmarks).** Advisory. These run on
+  shared GitHub Actions runners and can vary by up to roughly 3x
+  between runs because of noisy neighbours. A red Criterion row on
+  your PR is not by itself a blocker; re-run the workflow if the
+  result looks noisy.
+- **iai-callgrind (instruction-count benchmarks).** Deterministic and
+  blocking. If iai-callgrind flags a regression it means the code
+  path does measurably more work; investigate before merging.
+
+In short: trust iai-callgrind, treat Criterion as a smoke signal.
+
+## Commit style
+
+Short subject (ideally imperative, "add X" / "fix Y"), lower-case. A
+Conventional Commits-style prefix is common and preferred when one
+fits: `feat:`, `fix:`, `docs:`, `refactor:`, `chore:`, `ci:`. You
+will also see `release:` and `merge:` on release-pipeline commits;
+leave those to the maintainer.
+
+Prefixes are a convention, not a gate. If a prefix genuinely does not
+fit, a plain short subject is fine. Bodies are welcome when context
+helps a reviewer but are not required.
+
+## Storage layer boundary
+
+The storage layer (`src/storage.rs` and related) is scheduled for a
+significant refactor before 1.0: the `Database` type will become
+generic over a `StorageBackend` trait. Please open an issue before
+submitting changes in this area; we can advise whether your change
+fits the current architecture, the planned one, or is best deferred.
+
+## Where to discuss
+
+- GitHub Issues: <https://github.com/nubo-db/dynoxide/issues>
+
+Discussions are not currently enabled. If that changes, this section
+will be updated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing to Dynoxide
+
+Thanks for considering a contribution. Dynoxide is a DynamoDB-compatible
+engine in Rust backed by SQLite, and behaves like AWS DynamoDB by
+design. That guides most of what follows.
+
+If you are using an AI coding tool (Codex, Cursor, Aider, Claude Code,
+or similar), please also read [AGENTS.md](AGENTS.md); it covers the
+same ground in a form those tools pick up automatically.
+
+## Before you start
+
+- Open a GitHub issue describing the change if it is more than a small
+  bug fix or obvious cleanup. A short paragraph is enough. This catches
+  direction questions before a PR round-trips.
+- The storage layer (`src/storage.rs` and related) is scheduled for a
+  significant refactor before 1.0: the `Database` type will become
+  generic over a `StorageBackend` trait. Please open an issue before
+  submitting changes in this area so we can advise whether your change
+  fits the current architecture, the planned one, or is best deferred.
+- If you want to add a new dependency, open an issue so we can weigh
+  binary size, build time, and licence.
+
+## The compatibility principle
+
+Dynoxide exists to behave like AWS DynamoDB. If a PR would make
+Dynoxide's observable behaviour diverge from real DynamoDB, the PR
+description needs to say so explicitly and cite the AWS documentation
+or behaviour note that motivates the change. Cleaner ergonomics or
+"nicer" API shapes are not a reason on their own.
+
+## Local setup
+
+- Rust 2024 edition, MSRV 1.85 (both declared in `Cargo.toml`). Any
+  recent stable toolchain that satisfies the MSRV works.
+- `cargo build` to compile, `cargo test` to run the test suite.
+- `cargo fmt --check` and `cargo clippy -- -D warnings` must pass
+  before a PR is merge-ready; CI enforces both.
+
+## Tests
+
+- New behaviour ships with tests. Bug fixes ship with a regression
+  test that fails before the fix.
+- Tests live in `tests/` and as inline `#[cfg(test)]` modules.
+- The external conformance suite
+  (<https://github.com/nubo-db/dynamodb-conformance>) runs in CI for
+  release candidates. Running it locally is optional but useful when
+  you change request or response shapes.
+
+## Benchmarks
+
+The PR benchmark check has two layers. Criterion wall-clock numbers
+run on shared CI runners and are advisory; they can swing by up to
+roughly 3x on a noisy neighbour. iai-callgrind runs on the same PR
+and is deterministic and blocking. If Criterion looks red but
+iai-callgrind is clean, re-run the workflow before worrying.
+`AGENTS.md` has the short version of this.
+
+## Commit style
+
+Short subject, lower-case, imperative where possible. A Conventional
+Commits-style prefix (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`,
+`ci:`) is preferred when one fits but is not a gate; a plain short
+subject is fine if no prefix fits. Bodies are welcome for anything
+non-obvious.
+
+## AI-assisted contributions
+
+AI tools are welcome. If an AI tool drafted or materially shaped the
+change, say so in the PR description. A single line is enough and
+the bar is low: "drafted by Cursor, I ran the tests" or "Copilot
+autocomplete on the glue code" or "hand-written, Claude Code
+reviewed it" all work. The goal is that a maintainer knows what
+level of human review to apply, not that contributors match a
+specific phrasing.
+
+## Where to ask
+
+GitHub Issues: <https://github.com/nubo-db/dynoxide/issues>.
+Discussions are not currently enabled.


### PR DESCRIPTION
## What this changes

Adds AGENTS.md, CONTRIBUTING.md, and .github/PULL_REQUEST_TEMPLATE.md
so human and AI contributors have a self-contained picture of what
this project expects before they open a PR.

## Checklist

- [x] Tests added or updated (n/a, docs-only)
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` pass locally (n/a, no Rust changes)
- [x] `CHANGELOG.md` updated if this is a user-visible change (n/a, contributor-facing docs)
- [x] If AI tools drafted or materially shaped this change, disclosed in the description above
- [x] Linked issue, discussion, or a short note explaining the motivation (see below)

Motivation: Dynoxide started life as the sandbox engine for
[Nubo](https://nubo.sinovi.uk), so most planning and in-flight work
happened in a private companion repo with the public repo as the
publication surface. That's no longer the case. Dynoxide now stands
alone as a single public repo open to external contributors, so the
contributor-facing docs need to match. Neither AGENTS.md nor
CONTRIBUTING.md nor a PR template existed, and without them
contributors had to infer conventions from commit history, which
works poorly for things not visible in the diff (clippy strictness,
the DynamoDB-native compatibility principle, the scheduled
storage-backend refactor).

## DynamoDB compatibility note (delete if not applicable)

N/A, docs-only, no behavioural change.
