### PR TITLE
fix: close DNS rebinding CVE-2026-42559 in MCP HTTP transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.13] - 2026-05-11
+
+### Security
+
+- Close a DNS rebinding vulnerability in the MCP HTTP transport
+  ([GHSA-89vp-x53w-74fx](https://github.com/modelcontextprotocol/rust-sdk/security/advisories/GHSA-89vp-x53w-74fx) /
+  [CVE-2026-42559](https://www.cve.org/CVERecord?id=CVE-2026-42559)) by upgrading `rmcp`
+  from 1.1.1 to 1.6.0 in both lockfiles. A malicious page could make the
+  user's browser send requests to a loopback MCP server with a non-loopback
+  `Host` header, which the server would then process. Affects 0.9.3 to 0.9.12.
+  Users running `dynoxide mcp --http` or `dynoxide serve --mcp` should
+  upgrade; stdio transport is unaffected.
+
+- Close a related cross-origin CSRF gap: a page could `fetch` the loopback
+  endpoint with `mode: 'no-cors'`, and the Host check would pass while the
+  Origin header went unchecked. Affected write tools: `put_item`,
+  `update_item`, `delete_item`, `create_table`, and `batch_write_item`.
+  Fixed by setting an explicit Host and Origin allowlist on
+  `StreamableHttpServerConfig`. Native MCP clients (Claude Code, Cursor,
+  the dynoxide CLI) don't send an Origin header and are unaffected.
+
 ## [0.9.12] - 2026-05-04
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,7 +999,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1846,7 +1846,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2307,9 +2307,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.1.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4950422f87cf98fffc36946ad672c3024750b3c301491599715b7d6497dfbc"
+checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2338,9 +2338,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.1.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f9a2cbdcc704fa56c3fe79c681bd8f739d77c68ede3a670faeb6df50f836874"
+checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -2382,7 +2382,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2845,7 +2845,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,7 +928,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "dynoxide-rs"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "aws-config",
  "aws-credential-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dynoxide-rs"
-version = "0.9.12"
+version = "0.9.13"
 edition = "2024"
 description = "A lightweight, embeddable DynamoDB emulator backed by SQLite"
 license = "MIT OR Apache-2.0"

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "dynoxide-rs"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "axum",
  "base64",

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -1179,7 +1179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1659,7 +1659,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1879,7 +1879,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2047,7 +2047,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2440,9 +2440,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.1.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4950422f87cf98fffc36946ad672c3024750b3c301491599715b7d6497dfbc"
+checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
 dependencies = [
  "async-trait",
  "base64",
@@ -2471,9 +2471,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.1.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f9a2cbdcc704fa56c3fe79c681bd8f739d77c68ede3a670faeb6df50f836874"
+checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -2515,7 +2515,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2939,7 +2939,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3489,7 +3489,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -56,6 +56,8 @@ pub async fn serve_http_with_shutdown(
     let ct = shutdown.unwrap_or_default();
     let db = Arc::new(db);
 
+    // load-bearing: rmcp's config struct is #[non_exhaustive], so struct-literal
+    // init does not compile. Keep the field-reassign block.
     #[allow(clippy::field_reassign_with_default)]
     let http_config = {
         let mut c = StreamableHttpServerConfig::default();
@@ -63,6 +65,13 @@ pub async fn serve_http_with_shutdown(
         c.json_response = true;
         c.sse_keep_alive = None;
         c.cancellation_token = ct.clone();
+        // Explicit DNS rebinding defences. Stating the lists protects against an
+        // rmcp default flip. Native clients pass because rmcp skips Origin
+        // validation when the header is absent (rmcp 1.6.0 tower.rs:385-387).
+        // allowed_origins is IPv4-loopback-only; add http://[::1] when dynoxide
+        // binds [::1] and https://* if TLS-on-loopback lands.
+        c.allowed_hosts = vec!["localhost".into(), "127.0.0.1".into(), "::1".into()];
+        c.allowed_origins = vec!["http://localhost".into(), "http://127.0.0.1".into()];
         c
     };
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1,7 +1,7 @@
 //! MCP server implementation with tool definitions.
 
 use rmcp::ErrorData as McpError;
-use rmcp::handler::server::{router::tool::ToolRouter, wrapper::Parameters};
+use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::*;
 use rmcp::schemars;
 use rmcp::{ServerHandler, tool, tool_handler, tool_router};
@@ -53,7 +53,6 @@ impl Default for McpConfig {
 
 #[derive(Clone)]
 pub struct McpServer {
-    tool_router: ToolRouter<Self>,
     db: Arc<Database>,
     config: McpConfig,
 }
@@ -636,11 +635,7 @@ impl McpServer {
     }
 
     pub fn with_config(db: Arc<Database>, config: McpConfig) -> Self {
-        Self {
-            tool_router: Self::tool_router(),
-            db,
-            config,
-        }
+        Self { db, config }
     }
 
     /// Reject the call if the server is in read-only mode.

--- a/tests/mcp_server.rs
+++ b/tests/mcp_server.rs
@@ -1197,6 +1197,97 @@ fn test_http_transport() {
     let _ = child.wait();
 }
 
+// Regression: rmcp 1.4+ ships a Host-header allowlist defaulting to
+// ["localhost", "127.0.0.1", "::1"] to defend the Streamable HTTP transport
+// against DNS rebinding (CVE-2026-42559 / GHSA-89vp-x53w-74fx). dynoxide binds
+// only to 127.0.0.1, so the default matches the bind surface and we rely on it
+// rather than calling with_allowed_hosts explicitly. This test locks the
+// behaviour in so a future config refactor or rmcp default flip cannot silently
+// regress the protection.
+#[test]
+fn test_http_transport_rejects_foreign_host() {
+    use std::io::Read;
+
+    let binary = env!("CARGO_BIN_EXE_dynoxide");
+
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+
+    let mut child = Command::new(binary)
+        .args(["mcp", "--http", "--port", &port.to_string()])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn dynoxide mcp --http");
+
+    let mut ready = false;
+    for _ in 0..50 {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        if std::net::TcpStream::connect(format!("127.0.0.1:{port}")).is_ok() {
+            ready = true;
+            break;
+        }
+    }
+    assert!(ready, "MCP HTTP server did not start within 5 seconds");
+
+    let init_body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-03-26",
+            "capabilities": {},
+            "clientInfo": {"name": "test", "version": "1.0"}
+        }
+    });
+    let body = serde_json::to_string(&init_body).unwrap();
+
+    let send_with_host = |host: &str| -> String {
+        let mut stream = std::net::TcpStream::connect(format!("127.0.0.1:{port}")).unwrap();
+        stream
+            .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+            .unwrap();
+        let request = format!(
+            "POST /mcp HTTP/1.1\r\n\
+             Host: {host}\r\n\
+             Content-Type: application/json\r\n\
+             Accept: application/json, text/event-stream\r\n\
+             Content-Length: {}\r\n\
+             Connection: close\r\n\
+             \r\n\
+             {body}",
+            body.len()
+        );
+        stream.write_all(request.as_bytes()).unwrap();
+        let mut buf = Vec::new();
+        let _ = stream.read_to_end(&mut buf);
+        String::from_utf8_lossy(&buf).into_owned()
+    };
+
+    let loopback_response = send_with_host(&format!("127.0.0.1:{port}"));
+    assert!(
+        loopback_response.starts_with("HTTP/1.1 2"),
+        "Loopback Host should be accepted with 2xx, got: {loopback_response}"
+    );
+    assert!(
+        loopback_response.contains("dynoxide"),
+        "Loopback response should contain server name, got: {loopback_response}"
+    );
+
+    // Body wording is rmcp-internal and may change across minor releases; assert
+    // only on the status line, which is the security-relevant contract.
+    let foreign_response = send_with_host("evil.example.com");
+    assert!(
+        foreign_response.starts_with("HTTP/1.1 403"),
+        "Foreign Host should be rejected with 403, got: {foreign_response}"
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
 // ---------------------------------------------------------------------------
 // Data model (--data-model) tests
 // ---------------------------------------------------------------------------

--- a/tests/mcp_server.rs
+++ b/tests/mcp_server.rs
@@ -1197,16 +1197,26 @@ fn test_http_transport() {
     let _ = child.wait();
 }
 
-// Regression: rmcp 1.4+ ships a Host-header allowlist defaulting to
-// ["localhost", "127.0.0.1", "::1"] to defend the Streamable HTTP transport
-// against DNS rebinding (CVE-2026-42559 / GHSA-89vp-x53w-74fx). dynoxide binds
-// only to 127.0.0.1, so the default matches the bind surface and we rely on it
-// rather than calling with_allowed_hosts explicitly. This test locks the
-// behaviour in so a future config refactor or rmcp default flip cannot silently
-// regress the protection.
+// Regression for CVE-2026-42559 / GHSA-89vp-x53w-74fx (DNS rebinding against
+// rmcp's Streamable HTTP transport). src/mcp/mod.rs sets allowed_hosts and
+// allowed_origins explicitly; this test locks both in. Asserts on rmcp's
+// rejection-reason body so a future 403 emitted from elsewhere can't masquerade
+// as the Host or Origin check still working.
 #[test]
-fn test_http_transport_rejects_foreign_host() {
+fn test_http_transport_dns_rebinding_defences() {
     use std::io::Read;
+
+    // Kill the child on every exit path, including panic between spawn and the
+    // final assertion. std::process::Child does not kill on drop, so a panicked
+    // test would otherwise leak a dynoxide process holding the loopback port and
+    // flake subsequent runs.
+    struct ChildKiller(std::process::Child);
+    impl Drop for ChildKiller {
+        fn drop(&mut self) {
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+        }
+    }
 
     let binary = env!("CARGO_BIN_EXE_dynoxide");
 
@@ -1214,13 +1224,14 @@ fn test_http_transport_rejects_foreign_host() {
     let port = listener.local_addr().unwrap().port();
     drop(listener);
 
-    let mut child = Command::new(binary)
+    let child = Command::new(binary)
         .args(["mcp", "--http", "--port", &port.to_string()])
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
         .spawn()
         .expect("failed to spawn dynoxide mcp --http");
+    let _kill_on_drop = ChildKiller(child);
 
     let mut ready = false;
     for _ in 0..50 {
@@ -1244,14 +1255,19 @@ fn test_http_transport_rejects_foreign_host() {
     });
     let body = serde_json::to_string(&init_body).unwrap();
 
-    let send_with_host = |host: &str| -> String {
+    let send = |host: &str, origin: Option<&str>| -> String {
         let mut stream = std::net::TcpStream::connect(format!("127.0.0.1:{port}")).unwrap();
         stream
             .set_read_timeout(Some(std::time::Duration::from_secs(5)))
             .unwrap();
+        let origin_line = match origin {
+            Some(o) => format!("Origin: {o}\r\n"),
+            None => String::new(),
+        };
         let request = format!(
             "POST /mcp HTTP/1.1\r\n\
              Host: {host}\r\n\
+             {origin_line}\
              Content-Type: application/json\r\n\
              Accept: application/json, text/event-stream\r\n\
              Content-Length: {}\r\n\
@@ -1266,26 +1282,41 @@ fn test_http_transport_rejects_foreign_host() {
         String::from_utf8_lossy(&buf).into_owned()
     };
 
-    let loopback_response = send_with_host(&format!("127.0.0.1:{port}"));
+    // Ordering is load-bearing: with stateful_mode=false the Host and Origin
+    // checks run before session lookup, so per-request rejection cannot leak
+    // state. If stateful_mode ever flips, revisit this ordering.
+    let loopback = send(&format!("127.0.0.1:{port}"), None);
     assert!(
-        loopback_response.starts_with("HTTP/1.1 2"),
-        "Loopback Host should be accepted with 2xx, got: {loopback_response}"
+        loopback.starts_with("HTTP/1.1 2"),
+        "Loopback Host should be accepted with 2xx, got: {loopback}"
     );
     assert!(
-        loopback_response.contains("dynoxide"),
-        "Loopback response should contain server name, got: {loopback_response}"
-    );
-
-    // Body wording is rmcp-internal and may change across minor releases; assert
-    // only on the status line, which is the security-relevant contract.
-    let foreign_response = send_with_host("evil.example.com");
-    assert!(
-        foreign_response.starts_with("HTTP/1.1 403"),
-        "Foreign Host should be rejected with 403, got: {foreign_response}"
+        loopback.contains("dynoxide"),
+        "Loopback response should contain server name, got: {loopback}"
     );
 
-    let _ = child.kill();
-    let _ = child.wait();
+    let foreign_host = send("evil.example.com", None);
+    assert!(
+        foreign_host.starts_with("HTTP/1.1 403"),
+        "Foreign Host should be rejected with 403, got: {foreign_host}"
+    );
+    assert!(
+        foreign_host.contains("Host header is not allowed"),
+        "Foreign Host rejection should name the Host check, got: {foreign_host}"
+    );
+
+    let foreign_origin = send(
+        &format!("127.0.0.1:{port}"),
+        Some("https://evil.example.com"),
+    );
+    assert!(
+        foreign_origin.starts_with("HTTP/1.1 403"),
+        "Foreign Origin should be rejected with 403, got: {foreign_origin}"
+    );
+    assert!(
+        foreign_origin.contains("Origin header is not allowed"),
+        "Foreign Origin rejection should name the Origin check, got: {foreign_origin}"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this changes

Closes [GHSA-89vp-x53w-74fx](https://github.com/modelcontextprotocol/rust-sdk/security/advisories/GHSA-89vp-x53w-74fx) / [CVE-2026-42559](https://www.cve.org/CVERecord?id=CVE-2026-42559) (DNS rebinding against rmcp's MCP HTTP transport) by upgrading `rmcp` from 1.1.1 to 1.6.0 in both lockfiles. Also sets explicit `allowed_hosts` and `allowed_origins` on `StreamableHttpServerConfig` to close a related cross-origin CSRF gap and harden against a future rmcp default flip. Resolves Dependabot alerts #33 and #34. Ships as 0.9.13.

## Checklist

- [x] Tests added or updated. New `test_http_transport_dns_rebinding_defences` covers loopback Host (2xx), foreign Host (403 with `Host header is not allowed` body), and foreign Origin (403 with `Origin header is not allowed` body)
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` pass locally
- [x] `CHANGELOG.md` updated
- ~~If AI tools drafted or materially shaped this change, disclosed in the description above~~
- [x] Linked issue: Dependabot alerts [#33](https://github.com/nubo-db/dynoxide/security/dependabot/33) and [#34](https://github.com/nubo-db/dynoxide/security/dependabot/34)