### PR TITLE
ci: lock GITHUB_TOKEN to contents:read on remaining workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test (${{ matrix.name }})

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -11,6 +11,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   update-formula:
     name: Update Homebrew tap

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -15,6 +15,9 @@ concurrency:
   group: publish-crate
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: Publish to crates.io

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -3,6 +3,9 @@ name: Test Build
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
## What this changes

Adds a top-level `permissions: contents: read` block to `ci.yml`, `test-build.yml`, `publish-crate.yml`, and `homebrew.yml`. Matches the existing pattern in `release.yml`, `npm.yml`, and the benchmark workflows, and closes the six CodeQL `actions/missing-workflow-permissions` alerts.

Crate publishing uses `CARGO_REGISTRY_TOKEN` and the Homebrew tap update uses `HOMEBREW_TAP_TOKEN`, so neither workflow needs write on the workflow token.

## Checklist

- ~~Tests added or updated~~
- ~~`cargo fmt --check` and `cargo clippy -- -D warnings` pass locally~~ (no Rust changes)
- ~~`CHANGELOG.md` updated if this is a user-visible change~~ (CI-only)
- ~~If AI tools drafted or materially shaped this change, disclosed in the description above~~
- [x] Linked issue, discussion, or a short note explaining the motivation -- CodeQL alerts on the repo's Security tab

- ~~DynamoDB compatibility note~~ (n/a)