### PR TITLE
feat: publish official Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# The build context only needs the prebuilt binaries that the release
+# workflow stages under dist/. Everything else stays out so the context
+# uploaded to buildx is a few MB rather than the whole repo.
+
+*
+!dist/
+!dist/**

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,177 @@
+name: Publish Docker image (recovery)
+
+# Manual recovery workflow. The primary publish path is release.yml's
+# publish-docker job. Use this only to re-run the Docker publish for a
+# specific tag, e.g. when GHCR auth was momentarily wrong or when a
+# Sigstore outage skipped the provenance attestation.
+#
+# Diverges from release.yml's inline job in two ways:
+#   - tags are computed from the workflow_dispatch input rather than
+#     github.ref, so metadata-action receives an explicit value=
+#   - ECR Public is intentionally not mirrored from this workflow. The
+#     OIDC trust policy is scoped to tag refs, not branch refs, so a
+#     dispatch from main cannot assume the ECR Public role. Republish
+#     ECR Public via release.yml on a follow-up patch tag instead.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. v0.9.10)"
+        required: true
+        type: string
+
+jobs:
+  publish-docker:
+    name: Publish Docker image
+    if: github.repository == 'nubo-db/dynoxide'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate and resolve tag
+        id: tag
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$INPUT_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Invalid tag format: $INPUT_TAG (expected vX.Y.Z or vX.Y.Z-pre.N)"
+            exit 1
+          fi
+          echo "tag=$INPUT_TAG" >> "$GITHUB_OUTPUT"
+          echo "version=${INPUT_TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Stage prebuilt linux-musl binaries
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          rm -rf dist staging
+          mkdir -p dist/amd64 dist/arm64 staging
+          gh release download "$TAG" \
+            --repo nubo-db/dynoxide \
+            --pattern '*linux-musl.tar.gz' \
+            --dir staging/
+          tar -xzf staging/dynoxide-x86_64-unknown-linux-musl.tar.gz -C dist/amd64/
+          tar -xzf staging/dynoxide-aarch64-unknown-linux-musl.tar.gz -C dist/arm64/
+          chmod +x dist/amd64/dynoxide dist/arm64/dynoxide
+          file dist/amd64/dynoxide
+          file dist/arm64/dynoxide
+          file dist/amd64/dynoxide | grep -q 'x86-64'
+          file dist/arm64/dynoxide | grep -q 'aarch64'
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        id: ghcr-login
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        id: dockerhub-login
+        continue-on-error: true
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Compute image tags and labels
+        id: meta
+        uses: docker/metadata-action@v5
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        with:
+          images: ghcr.io/${{ github.repository }}
+          flavor: |
+            latest=auto
+          tags: |
+            type=semver,pattern={{version}},value=${{ inputs.tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.tag }}
+            type=semver,pattern={{major}},value=${{ inputs.tag }},enable=${{ !startsWith(inputs.tag, 'v0.') }}
+
+      - name: Build and push to GHCR
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: mode=max
+          sbom: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Verify published image runs on both architectures
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}:${{ steps.tag.outputs.version }}
+          EXPECTED: ${{ steps.tag.outputs.version }}
+        run: |
+          set -euo pipefail
+          for arch in linux/amd64 linux/arm64; do
+            actual=$(docker run --rm --pull=always --platform "$arch" "$IMAGE" --version | awk '{print $NF}')
+            if [ "$actual" != "$EXPECTED" ]; then
+              echo "::error::$arch reported version $actual, expected $EXPECTED"
+              exit 1
+            fi
+          done
+
+      - name: Attest build provenance
+        id: attest
+        continue-on-error: true
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Mirror to Docker Hub
+        id: mirror-dockerhub
+        if: ${{ !cancelled() && steps.dockerhub-login.outcome == 'success' }}
+        continue-on-error: true
+        env:
+          META_JSON: ${{ steps.meta.outputs.json }}
+        run: |
+          set -euo pipefail
+          echo "$META_JSON" | jq -r '.tags[]' | while read -r src_tag; do
+            tag="${src_tag##*:}"
+            docker buildx imagetools create \
+              -t "docker.io/nubodb/dynoxide:${tag}" \
+              "$src_tag"
+          done
+
+      - name: Publish summary
+        if: ${{ !cancelled() }}
+        env:
+          META_JSON: ${{ steps.meta.outputs.json }}
+          GHCR_OUTCOME: ${{ steps.build.outcome }}
+          ATTEST_OUTCOME: ${{ steps.attest.outcome }}
+          DOCKERHUB_OUTCOME: ${{ steps.mirror-dockerhub.outcome }}
+        run: |
+          {
+            echo "## Docker recovery publish summary"
+            echo
+            echo "| Surface | Outcome |"
+            echo "| --- | --- |"
+            echo "| GHCR push | ${GHCR_OUTCOME} |"
+            echo "| Provenance attestation | ${ATTEST_OUTCOME} |"
+            echo "| Docker Hub mirror | ${DOCKERHUB_OUTCOME:-skipped} |"
+            echo "| ECR Public mirror | not run from docker.yml |"
+            echo
+            echo "### Pushed tags"
+            echo
+            echo "$META_JSON" | jq -r '.tags[] | "- `\(.)`"'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -9,7 +9,8 @@ on:
 
 permissions:
   contents: read
-  id-token: write  # required for npm OIDC provenance dry-run
+  id-token: write  # required for npm OIDC provenance dry-run and ECR Public OIDC
+  packages: read   # required for GHCR auth probe
 
 jobs:
   preflight:
@@ -73,6 +74,42 @@ jobs:
           fi
           echo "Homebrew tap access confirmed"
 
+      # --- GHCR ---------------------------------------------------------
+      - name: GHCR auth probe
+        id: ghcr-check
+        continue-on-error: true
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # --- Docker Hub ---------------------------------------------------
+      - name: Docker Hub auth probe
+        id: dockerhub-check
+        continue-on-error: true
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # --- ECR Public ---------------------------------------------------
+      - name: ECR Public AWS credentials probe
+        id: ecr-public-creds
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.ECR_PUBLIC_PUBLISH_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: ECR Public auth token probe
+        id: ecr-public-check
+        if: steps.ecr-public-creds.outcome == 'success'
+        continue-on-error: true
+        # Discard the token output so GitHub's secret masking does not have to
+        # race the runner log buffer.
+        run: aws ecr-public get-authorization-token --region us-east-1 --query 'authorizationData.authorizationToken' --output text > /dev/null
+
       # --- Summary and final gate ---------------------------------------
       - name: Preflight summary
         if: always()
@@ -80,6 +117,9 @@ jobs:
           CARGO_OUTCOME: ${{ steps.cargo-check.outcome }}
           NPM_OUTCOME: ${{ steps.npm-check.outcome }}
           HOMEBREW_OUTCOME: ${{ steps.homebrew-check.outcome }}
+          GHCR_OUTCOME: ${{ steps.ghcr-check.outcome }}
+          DOCKERHUB_OUTCOME: ${{ steps.dockerhub-check.outcome }}
+          ECR_OUTCOME: ${{ steps.ecr-public-check.outcome }}
         run: |
           {
             echo "## Release Preflight"
@@ -89,6 +129,9 @@ jobs:
             echo "| cargo publish --dry-run | $CARGO_OUTCOME |"
             echo "| npm publish --dry-run --provenance (meta) | $NPM_OUTCOME |"
             echo "| Homebrew tap write-access probe | $HOMEBREW_OUTCOME |"
+            echo "| GHCR auth probe | $GHCR_OUTCOME |"
+            echo "| Docker Hub auth probe | $DOCKERHUB_OUTCOME |"
+            echo "| ECR Public auth probe | ${ECR_OUTCOME:-skipped} |"
             echo ""
             echo "Run: ${{ github.run_id }}"
             echo "Triggered by: ${{ github.actor }}"
@@ -96,7 +139,10 @@ jobs:
 
           if [ "$CARGO_OUTCOME" != "success" ] || \
              [ "$NPM_OUTCOME" != "success" ] || \
-             [ "$HOMEBREW_OUTCOME" != "success" ]; then
+             [ "$HOMEBREW_OUTCOME" != "success" ] || \
+             [ "$GHCR_OUTCOME" != "success" ] || \
+             [ "$DOCKERHUB_OUTCOME" != "success" ] || \
+             [ "$ECR_OUTCOME" != "success" ]; then
             echo "::error::One or more preflight checks failed. See summary for details."
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ name: Release
 # then let this workflow do the rest.
 #
 # Flow: validate -> build (5 targets) -> github-release -> publish-crate
-# (review gate) -> publish-homebrew + publish-npm in parallel.
+# (review gate) -> publish-homebrew + publish-npm + publish-docker in parallel.
 
 on:
   push:
@@ -324,3 +324,185 @@ jobs:
             -f ref=main \
             -f "inputs[tag]=$TAG"
           echo "Dispatched npm.yml with tag $TAG"
+
+  # -------------------------------------------------------------------
+  # Build and push multi-arch Docker images. GHCR is canonical and
+  # gating; Docker Hub and ECR Public are best-effort mirrors.
+  # -------------------------------------------------------------------
+  publish-docker:
+    name: Publish Docker image
+    needs: [validate, publish-crate]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Stage prebuilt linux-musl binaries
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          set -euo pipefail
+          rm -rf dist staging
+          mkdir -p dist/amd64 dist/arm64 staging
+          gh release download "$TAG" \
+            --repo nubo-db/dynoxide \
+            --pattern '*linux-musl.tar.gz' \
+            --dir staging/
+          tar -xzf staging/dynoxide-x86_64-unknown-linux-musl.tar.gz -C dist/amd64/
+          tar -xzf staging/dynoxide-aarch64-unknown-linux-musl.tar.gz -C dist/arm64/
+          chmod +x dist/amd64/dynoxide dist/arm64/dynoxide
+          # Fail loud if either slot holds the wrong arch.
+          file dist/amd64/dynoxide
+          file dist/arm64/dynoxide
+          file dist/amd64/dynoxide | grep -q 'x86-64'
+          file dist/arm64/dynoxide | grep -q 'aarch64'
+
+      # QEMU is for the post-push verification step that runs the arm64
+      # image on the amd64 runner. The build itself is pure COPY.
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        id: ghcr-login
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        id: dockerhub-login
+        continue-on-error: true
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Configure AWS credentials for ECR Public
+        id: aws-creds
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.ECR_PUBLIC_PUBLISH_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Login to ECR Public
+        id: ecr-public-login
+        continue-on-error: true
+        if: steps.aws-creds.outcome == 'success'
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
+      - name: Compute image tags and labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          flavor: |
+            latest=auto
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+
+      - name: Build and push to GHCR
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: mode=max
+          sbom: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Verify published image runs on both architectures
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}:${{ needs.validate.outputs.version }}
+          EXPECTED: ${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          for arch in linux/amd64 linux/arm64; do
+            echo "Probing $IMAGE on $arch"
+            actual=$(docker run --rm --pull=always --platform "$arch" "$IMAGE" --version | awk '{print $NF}')
+            echo "  reported: $actual"
+            if [ "$actual" != "$EXPECTED" ]; then
+              echo "::error::$arch reported version $actual, expected $EXPECTED"
+              exit 1
+            fi
+          done
+
+      - name: Attest build provenance
+        id: attest
+        continue-on-error: true
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Mirror to Docker Hub
+        id: mirror-dockerhub
+        if: ${{ !cancelled() && steps.dockerhub-login.outcome == 'success' }}
+        continue-on-error: true
+        env:
+          META_JSON: ${{ steps.meta.outputs.json }}
+        run: |
+          set -euo pipefail
+          echo "$META_JSON" | jq -r '.tags[]' | while read -r src_tag; do
+            tag="${src_tag##*:}"
+            echo "Mirroring $src_tag -> docker.io/nubodb/dynoxide:${tag}"
+            docker buildx imagetools create \
+              -t "docker.io/nubodb/dynoxide:${tag}" \
+              "$src_tag"
+          done
+
+      - name: Mirror to ECR Public
+        id: mirror-ecr
+        if: ${{ !cancelled() && steps.ecr-public-login.outcome == 'success' }}
+        continue-on-error: true
+        env:
+          META_JSON: ${{ steps.meta.outputs.json }}
+        run: |
+          set -euo pipefail
+          echo "$META_JSON" | jq -r '.tags[]' | while read -r src_tag; do
+            tag="${src_tag##*:}"
+            echo "Mirroring $src_tag -> public.ecr.aws/nubodb/dynoxide:${tag}"
+            docker buildx imagetools create \
+              -t "public.ecr.aws/nubodb/dynoxide:${tag}" \
+              "$src_tag"
+          done
+
+      - name: Publish summary
+        if: ${{ !cancelled() }}
+        env:
+          META_JSON: ${{ steps.meta.outputs.json }}
+          GHCR_OUTCOME: ${{ steps.build.outcome }}
+          ATTEST_OUTCOME: ${{ steps.attest.outcome }}
+          DOCKERHUB_OUTCOME: ${{ steps.mirror-dockerhub.outcome }}
+          ECR_OUTCOME: ${{ steps.mirror-ecr.outcome }}
+        run: |
+          {
+            echo "## Docker publish summary"
+            echo
+            echo "| Surface | Outcome |"
+            echo "| --- | --- |"
+            echo "| GHCR push | ${GHCR_OUTCOME} |"
+            echo "| Provenance attestation | ${ATTEST_OUTCOME} |"
+            echo "| Docker Hub mirror | ${DOCKERHUB_OUTCOME:-skipped} |"
+            echo "| ECR Public mirror | ${ECR_OUTCOME:-skipped} |"
+            echo
+            echo "### Pushed tags"
+            echo
+            echo "$META_JSON" | jq -r '.tags[] | "- `\(.)`"'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -477,9 +477,9 @@ jobs:
           set -euo pipefail
           echo "$META_JSON" | jq -r '.tags[]' | while read -r src_tag; do
             tag="${src_tag##*:}"
-            echo "Mirroring $src_tag -> public.ecr.aws/nubodb/dynoxide:${tag}"
+            echo "Mirroring $src_tag -> public.ecr.aws/nubo-db/dynoxide:${tag}"
             docker buildx imagetools create \
-              -t "public.ecr.aws/nubodb/dynoxide:${tag}" \
+              -t "public.ecr.aws/nubo-db/dynoxide:${tag}" \
               "$src_tag"
           done
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Official Docker image. `docker run -p 8000:8000 ghcr.io/nubo-db/dynoxide` is a ~5 MB drop-in for `amazon/dynamodb-local` in containerised test suites: multi-arch (`linux/amd64` and `linux/arm64`), `FROM scratch`, published to GHCR on each release with Docker Hub and ECR Public mirrors pushed best-effort. The image ships a `HEALTHCHECK` backed by a new `dynoxide healthcheck` subcommand, so `docker ps` and Compose health gates report status without extra tooling ([#3](https://github.com/nubo-db/dynoxide/issues/3)).
+- `SECURITY.md`, setting out the MCP HTTP transport's loopback-only threat model: what the Host and Origin allowlists cover, what they don't, and where it's safe to run until authentication ([#27](https://github.com/nubo-db/dynoxide/issues/27)) lands.
+
 ## [0.9.13] - 2026-05-11
 
 ### Security

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ zeroize = { version = "1", optional = true }
 axum = { version = "0.8", optional = true }
 tokio = { version = "1", features = ["full"], optional = true }
 tower-http = { version = "0.6", features = ["cors", "set-header", "trace"], optional = true }
-clap = { version = "4", features = ["derive"], optional = true }
+clap = { version = "4", features = ["derive", "env"], optional = true }
 tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 socket2 = { version = "0.6", optional = true }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Dynoxide container image. FROM scratch: just the static binary, no shell,
+# no CA certs (the binary has no TLS surface today). Multi-arch built with
+# `docker buildx build --platform linux/amd64,linux/arm64`; the build context
+# must contain both arches under dist/amd64/ and dist/arm64/.
+
+FROM scratch
+
+ARG TARGETARCH
+
+COPY dist/${TARGETARCH}/dynoxide /usr/local/bin/dynoxide
+
+WORKDIR /data
+
+EXPOSE 8000
+
+# Read by the healthcheck subcommand. Override with `docker run -e ...` when
+# CMD is overridden to bind to a non-default port.
+ENV DYNOXIDE_HEALTHCHECK_HOST=127.0.0.1 \
+    DYNOXIDE_HEALTHCHECK_PORT=8000
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD ["/usr/local/bin/dynoxide", "healthcheck"]
+
+ENTRYPOINT ["/usr/local/bin/dynoxide"]
+CMD ["serve", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -131,6 +131,53 @@ dynoxide-rs = { version = "0.9", default-features = false, features = ["native-s
 
 See [action/action.yml](action/action.yml) for all inputs and outputs.
 
+### Docker
+
+A 5 MB drop-in for `amazon/dynamodb-local` in containerised test suites. Same DynamoDB-compatible API, faster startup, smaller image. Note that this is a packaging convenience for test fixtures, not a containerised database product; production-database-on-Kubernetes patterns are out of scope.
+
+```sh
+docker run --rm -p 8000:8000 ghcr.io/nubo-db/dynoxide
+```
+
+With persistent storage:
+
+```sh
+docker run --rm -p 8000:8000 \
+  -v "$(pwd)/data:/data" \
+  ghcr.io/nubo-db/dynoxide \
+  serve --host 0.0.0.0 --port 8000 --db-path /data/dynoxide.sqlite
+```
+
+The image runs as root by default, matching `amazon/dynamodb-local`, so bind mounts on Linux Just Work without `--user`. The canonical image lives at `ghcr.io/nubo-db/dynoxide`. Mirrors are pushed to `docker.io/nubodb/dynoxide` and `public.ecr.aws/nubodb/dynoxide` on a best-effort basis. SLSA provenance and SBOM attestations are published to GHCR only; if you want to verify provenance, pull from the GHCR canonical.
+
+If you override `CMD` to bind to a different port, set the healthcheck target with environment variables so the container's `HEALTHCHECK` follows:
+
+```sh
+docker run -e DYNOXIDE_HEALTHCHECK_PORT=9000 ghcr.io/nubo-db/dynoxide serve --port 9000
+```
+
+`DYNOXIDE_HEALTHCHECK_HOST` and `DYNOXIDE_HEALTHCHECK_PORT` are documented public surface and will not be renamed in a patch or minor release.
+
+#### Running as nonroot
+
+For security-conscious operators, opt into a nonroot uid:
+
+```sh
+docker run --rm -p 8000:8000 --user 65532:65532 ghcr.io/nubo-db/dynoxide
+```
+
+Persistent mode under nonroot needs a host-owned bind mount, since the in-image `/data` is owned by root:
+
+```sh
+docker run --rm -p 8000:8000 \
+  --user "$(id -u):$(id -g)" \
+  -v "$(pwd)/data:/data" \
+  ghcr.io/nubo-db/dynoxide \
+  serve --host 0.0.0.0 --port 8000 --db-path /data/dynoxide.sqlite
+```
+
+The default in-memory mode needs no flags whether root or nonroot. The uid 65532 is the well-known nonroot uid used by Google's distroless images; pick any uid you prefer with `--user <uid>:<gid>`.
+
 ## HTTP Server
 
 Start the server:

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ docker run --rm -p 8000:8000 \
   serve --host 0.0.0.0 --port 8000 --db-path /data/dynoxide.sqlite
 ```
 
-The image runs as root by default, matching `amazon/dynamodb-local`, so bind mounts on Linux Just Work without `--user`. The canonical image lives at `ghcr.io/nubo-db/dynoxide`. Mirrors are pushed to `docker.io/nubodb/dynoxide` and `public.ecr.aws/nubodb/dynoxide` on a best-effort basis. SLSA provenance and SBOM attestations are published to GHCR only; if you want to verify provenance, pull from the GHCR canonical.
+The image runs as root by default, matching `amazon/dynamodb-local`, so bind mounts on Linux Just Work without `--user`. The canonical image lives at `ghcr.io/nubo-db/dynoxide`. Mirrors are pushed to `docker.io/nubodb/dynoxide` and `public.ecr.aws/nubo-db/dynoxide` on a best-effort basis. SLSA provenance and SBOM attestations are published to GHCR only; if you want to verify provenance, pull from the GHCR canonical.
 
 If you override `CMD` to bind to a different port, set the healthcheck target with environment variables so the container's `HEALTHCHECK` follows:
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -21,11 +21,11 @@ schedule. Versioning follows [SemVer](https://semver.org).
    `Cargo.toml` and `CHANGELOG.md`, build binaries for five targets in
    parallel, create a GitHub Release with artefacts and checksums, pause for
    one-click maintainer approval, then publish to crates.io, update the
-   Homebrew tap, and publish the npm packages.
+   Homebrew tap, publish the npm packages, and push the Docker image.
 
 The approval gate between the GitHub Release and any external publish means
 a release can still be aborted after the artefacts are built but before
-anything reaches crates.io, Homebrew, or npm.
+anything reaches crates.io, Homebrew, npm, or any container registry.
 
 ## Verifying a release
 
@@ -37,6 +37,12 @@ anything reaches crates.io, Homebrew, or npm.
 - **crates.io** is published by the same pipeline under the same tag, so
   `docs.rs`, the GitHub Release binaries, and the npm packages all
   correspond to a single commit.
+- **Docker images** carry SLSA provenance and SBOM attestations on the
+  GHCR canonical (`ghcr.io/nubo-db/dynoxide`). Verify with
+  `gh attestation verify oci://ghcr.io/nubo-db/dynoxide:<version> --owner nubo-db`.
+  Docker Hub and ECR Public mirrors hold the same image manifest and blobs
+  but not the OCI referrers, so attestation verification needs the GHCR
+  canonical.
 
 ## Release history
 
@@ -63,8 +69,9 @@ Public workflows a contributor may see when opening a PR:
 
 Additional workflows in `.github/workflows/` (`benchmark-refresh.yml`,
 `release-preflight.yml`, `test-build.yml`, `publish-crate.yml`,
-`homebrew.yml`, `npm.yml`) support release operations and recovery. They
-are maintainer workflows and are not exercised by PR traffic.
+`homebrew.yml`, `npm.yml`, `docker.yml`) support release operations and
+recovery. They are maintainer workflows and are not exercised by PR
+traffic.
 
 ## Maintainer runbook
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -603,7 +603,10 @@ fn do_healthcheck(args: HealthcheckArgs) -> Result<(), String> {
             "127.0.0.1".to_string()
         }
         "::" | "[::]" => {
-            eprintln!("healthcheck: rewriting wildcard host {} to ::1 for probe", args.host);
+            eprintln!(
+                "healthcheck: rewriting wildcard host {} to ::1 for probe",
+                args.host
+            );
             "::1".to_string()
         }
         h => h.to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 //! - `dynoxide` or `dynoxide serve` — start the DynamoDB-compatible HTTP server
 //! - `dynoxide mcp` — start the MCP server (enabled by default)
 //! - `dynoxide import` — import DynamoDB Export data (enabled by default)
+//! - `dynoxide healthcheck` — probe a running server for liveness (used by Docker HEALTHCHECK)
 
 #[cfg(any(feature = "http-server", feature = "mcp-server"))]
 use dynoxide::Database;
@@ -63,6 +64,10 @@ enum Commands {
     /// Import DynamoDB Export data into a Dynoxide database
     #[cfg(feature = "import")]
     Import(ImportArgs),
+
+    /// Probe a running Dynoxide server for liveness (used by Docker HEALTHCHECK and Kubernetes probes)
+    #[cfg(feature = "http-server")]
+    Healthcheck(HealthcheckArgs),
 }
 
 /// Arguments for the `serve` subcommand.
@@ -104,6 +109,28 @@ struct ServeArgs {
     #[cfg(feature = "mcp-server")]
     #[arg(long, value_name = "PATH", requires = "mcp")]
     mcp_data_model: Option<PathBuf>,
+}
+
+/// Arguments for the `healthcheck` subcommand.
+///
+/// Defaults match what the `serve` subcommand listens on. The Docker image's
+/// HEALTHCHECK directive sets `DYNOXIDE_HEALTHCHECK_HOST` and
+/// `DYNOXIDE_HEALTHCHECK_PORT` so users who override `CMD` can also override
+/// the probe target with `-e DYNOXIDE_HEALTHCHECK_PORT=...`.
+#[cfg(feature = "http-server")]
+#[derive(clap::Args)]
+struct HealthcheckArgs {
+    /// Host to probe. Wildcard hosts (0.0.0.0, ::) are silently rewritten to loopback.
+    #[arg(long, env = "DYNOXIDE_HEALTHCHECK_HOST", default_value = "127.0.0.1")]
+    host: String,
+
+    /// Port to probe.
+    #[arg(long, env = "DYNOXIDE_HEALTHCHECK_PORT", default_value_t = 8000)]
+    port: u16,
+
+    /// Total deadline in seconds for the entire probe (resolve + connect + write + read).
+    #[arg(long, default_value_t = 3)]
+    timeout: u64,
 }
 
 /// Arguments for the `mcp` subcommand.
@@ -289,6 +316,9 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
 
         #[cfg(feature = "import")]
         Some(Commands::Import(args)) => run_import(args).await,
+
+        #[cfg(feature = "http-server")]
+        Some(Commands::Healthcheck(args)) => run_healthcheck(args),
 
         #[cfg(feature = "http-server")]
         None => {
@@ -528,6 +558,134 @@ fn wrap_encrypted_open_error(
         .into()
     } else {
         Box::new(err)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Healthcheck subcommand (http-server feature)
+// ---------------------------------------------------------------------------
+
+/// Entry point for the `healthcheck` subcommand.
+///
+/// Runs `do_healthcheck`, prints any error to stderr, and exits with the
+/// status code that the Docker `HEALTHCHECK` directive contracts on:
+/// 0 on success, non-zero on any failure. Never returns.
+#[cfg(feature = "http-server")]
+fn run_healthcheck(args: HealthcheckArgs) -> ! {
+    match do_healthcheck(args) {
+        Ok(()) => std::process::exit(0),
+        Err(e) => {
+            eprintln!("healthcheck: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Probe an HTTP endpoint for a 200 response.
+///
+/// Implementation is std-only (no tokio, no reqwest) so the binary's
+/// healthcheck path stays light and the scratch container has nothing extra
+/// to load. The single `--timeout` argument is a total wall-clock deadline,
+/// not a per-operation timeout: each of resolve, connect, write, and read
+/// shares the same budget so the worst case is one timeout, not three.
+#[cfg(feature = "http-server")]
+fn do_healthcheck(args: HealthcheckArgs) -> Result<(), String> {
+    use std::io::{Read, Write};
+    use std::net::{TcpStream, ToSocketAddrs};
+    use std::time::{Duration, Instant};
+
+    // Wildcard hosts cannot be probed; rewrite to loopback. This makes the
+    // env-var path safe when an operator copies their `serve --host 0.0.0.0`
+    // value into `DYNOXIDE_HEALTHCHECK_HOST`.
+    let probe_host = match args.host.as_str() {
+        "0.0.0.0" => {
+            eprintln!("healthcheck: rewriting wildcard host 0.0.0.0 to 127.0.0.1 for probe");
+            "127.0.0.1".to_string()
+        }
+        "::" | "[::]" => {
+            eprintln!("healthcheck: rewriting wildcard host {} to ::1 for probe", args.host);
+            "::1".to_string()
+        }
+        h => h.to_string(),
+    };
+
+    let total = Duration::from_secs(args.timeout);
+    let started = Instant::now();
+    let remaining = || total.saturating_sub(started.elapsed());
+
+    // IPv6 literal addresses must be bracketed for the SocketAddr parser.
+    let addr_str = if probe_host.contains(':') && !probe_host.starts_with('[') {
+        format!("[{probe_host}]:{}", args.port)
+    } else {
+        format!("{probe_host}:{}", args.port)
+    };
+    let sock_addr = addr_str
+        .to_socket_addrs()
+        .map_err(|e| format!("resolve {addr_str}: {e}"))?
+        .next()
+        .ok_or_else(|| format!("no addresses for {addr_str}"))?;
+
+    let connect_budget = remaining();
+    if connect_budget.is_zero() {
+        return Err("timeout exceeded before connect".into());
+    }
+    let mut stream = TcpStream::connect_timeout(&sock_addr, connect_budget)
+        .map_err(|e| format!("connect {sock_addr}: {e}"))?;
+
+    let write_budget = remaining();
+    if write_budget.is_zero() {
+        return Err("timeout exceeded before write".into());
+    }
+    stream
+        .set_write_timeout(Some(write_budget))
+        .map_err(|e| format!("set_write_timeout: {e}"))?;
+
+    let request = format!(
+        "GET / HTTP/1.1\r\nHost: {host}:{port}\r\nConnection: close\r\n\r\n",
+        host = probe_host,
+        port = args.port,
+    );
+    stream
+        .write_all(request.as_bytes())
+        .map_err(|e| format!("write request: {e}"))?;
+
+    let read_budget = remaining();
+    if read_budget.is_zero() {
+        return Err("timeout exceeded before read".into());
+    }
+    stream
+        .set_read_timeout(Some(read_budget))
+        .map_err(|e| format!("set_read_timeout: {e}"))?;
+
+    // Read until first \r\n. TcpStream::read may return only a partial status
+    // line on a single call (especially over loopback under load), so loop
+    // until the terminator appears or the cap is reached. 512 bytes is more
+    // than any well-formed status line and guards against a malformed peer.
+    let mut buf = Vec::with_capacity(64);
+    let mut byte = [0u8; 1];
+    loop {
+        if buf.len() >= 512 {
+            return Err("status line exceeded 512 bytes".into());
+        }
+        let n = stream
+            .read(&mut byte)
+            .map_err(|e| format!("read status: {e}"))?;
+        if n == 0 {
+            return Err("connection closed before status line".into());
+        }
+        buf.push(byte[0]);
+        if buf.ends_with(b"\r\n") {
+            break;
+        }
+    }
+    let status_line = std::str::from_utf8(&buf)
+        .map_err(|e| format!("status line not utf-8: {e}"))?
+        .trim_end_matches("\r\n");
+
+    if status_line.starts_with("HTTP/1.1 200") || status_line.starts_with("HTTP/1.0 200") {
+        Ok(())
+    } else {
+        Err(format!("unexpected status: {status_line}"))
     }
 }
 

--- a/tests/healthcheck.rs
+++ b/tests/healthcheck.rs
@@ -46,13 +46,7 @@ fn fails_fast_on_unused_port() {
     };
     let started = Instant::now();
     let status = Command::new(dynoxide_bin())
-        .args([
-            "healthcheck",
-            "--port",
-            &port.to_string(),
-            "--timeout",
-            "2",
-        ])
+        .args(["healthcheck", "--port", &port.to_string(), "--timeout", "2"])
         .status()
         .expect("spawn dynoxide");
     let elapsed = started.elapsed();
@@ -87,22 +81,13 @@ fn times_out_on_listener_that_never_writes() {
     // on its read budget rather than hang forever.
     std::thread::spawn(move || {
         let mut held = Vec::new();
-        loop {
-            match listener.accept() {
-                Ok((s, _)) => held.push(s),
-                Err(_) => break,
-            }
+        while let Ok((s, _)) = listener.accept() {
+            held.push(s);
         }
     });
     let started = Instant::now();
     let status = Command::new(dynoxide_bin())
-        .args([
-            "healthcheck",
-            "--port",
-            &port.to_string(),
-            "--timeout",
-            "1",
-        ])
+        .args(["healthcheck", "--port", &port.to_string(), "--timeout", "1"])
         .status()
         .expect("spawn dynoxide");
     let elapsed = started.elapsed();
@@ -135,10 +120,7 @@ async fn rewrites_ipv4_wildcard_host() {
         .await
         .expect("spawn dynoxide");
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        output.status.success(),
-        "expected exit 0; stderr: {stderr}"
-    );
+    assert!(output.status.success(), "expected exit 0; stderr: {stderr}");
     assert!(
         stderr.contains("rewriting wildcard host 0.0.0.0"),
         "stderr did not mention wildcard rewrite: {stderr}"

--- a/tests/healthcheck.rs
+++ b/tests/healthcheck.rs
@@ -1,0 +1,159 @@
+//! Integration tests for the `dynoxide healthcheck` subcommand.
+//!
+//! These tests spawn the compiled binary as a subprocess so the exit-code
+//! contract that `HEALTHCHECK` and Kubernetes probes rely on is exercised
+//! end to end.
+
+#![cfg(feature = "http-server")]
+
+use std::io::Write;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+fn dynoxide_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_dynoxide")
+}
+
+/// Spawn a real dynoxide HTTP server in-process on a random loopback port.
+async fn start_loopback_server() -> (u16, tokio::task::JoinHandle<()>) {
+    let db = dynoxide::Database::memory().unwrap();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let handle = tokio::spawn(async move {
+        dynoxide::server::serve_on(listener, db).await;
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    (port, handle)
+}
+
+#[tokio::test]
+async fn happy_path_succeeds_against_running_server() {
+    let (port, _handle) = start_loopback_server().await;
+    let status = tokio::process::Command::new(dynoxide_bin())
+        .args(["healthcheck", "--port", &port.to_string()])
+        .status()
+        .await
+        .expect("spawn dynoxide");
+    assert!(status.success(), "expected exit 0, got {status:?}");
+}
+
+#[test]
+fn fails_fast_on_unused_port() {
+    // Bind and immediately drop a listener to grab a port the OS just freed.
+    let port = {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.local_addr().unwrap().port()
+    };
+    let started = Instant::now();
+    let status = Command::new(dynoxide_bin())
+        .args([
+            "healthcheck",
+            "--port",
+            &port.to_string(),
+            "--timeout",
+            "2",
+        ])
+        .status()
+        .expect("spawn dynoxide");
+    let elapsed = started.elapsed();
+    assert!(!status.success(), "expected non-zero exit on unused port");
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "healthcheck took {elapsed:?}; expected sub-5s"
+    );
+}
+
+#[test]
+fn fails_on_non_200_status() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    std::thread::spawn(move || {
+        if let Ok((mut s, _)) = listener.accept() {
+            let _ = s.write_all(b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\n\r\n");
+        }
+    });
+    let status = Command::new(dynoxide_bin())
+        .args(["healthcheck", "--port", &port.to_string()])
+        .status()
+        .expect("spawn dynoxide");
+    assert!(!status.success(), "expected non-zero exit on 500 response");
+}
+
+#[test]
+fn times_out_on_listener_that_never_writes() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    // Accept connections but never write a byte; healthcheck must time out
+    // on its read budget rather than hang forever.
+    std::thread::spawn(move || {
+        let mut held = Vec::new();
+        loop {
+            match listener.accept() {
+                Ok((s, _)) => held.push(s),
+                Err(_) => break,
+            }
+        }
+    });
+    let started = Instant::now();
+    let status = Command::new(dynoxide_bin())
+        .args([
+            "healthcheck",
+            "--port",
+            &port.to_string(),
+            "--timeout",
+            "1",
+        ])
+        .status()
+        .expect("spawn dynoxide");
+    let elapsed = started.elapsed();
+    assert!(!status.success(), "expected non-zero exit on timeout");
+    assert!(
+        elapsed < Duration::from_secs(3),
+        "healthcheck took {elapsed:?}; expected sub-3s with --timeout 1"
+    );
+}
+
+#[tokio::test]
+async fn rewrites_ipv4_wildcard_host() {
+    let db = dynoxide::Database::memory().unwrap();
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let _handle = tokio::spawn(async move {
+        dynoxide::server::serve_on(listener, db).await;
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let output = tokio::process::Command::new(dynoxide_bin())
+        .args([
+            "healthcheck",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            &port.to_string(),
+        ])
+        .output()
+        .await
+        .expect("spawn dynoxide");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "expected exit 0; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("rewriting wildcard host 0.0.0.0"),
+        "stderr did not mention wildcard rewrite: {stderr}"
+    );
+}
+
+#[test]
+fn help_text_lists_all_flags() {
+    let output = Command::new(dynoxide_bin())
+        .args(["healthcheck", "--help"])
+        .output()
+        .expect("spawn dynoxide");
+    assert!(output.status.success(), "--help should exit 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for flag in ["--host", "--port", "--timeout"] {
+        assert!(stdout.contains(flag), "help missing {flag}: {stdout}");
+    }
+}


### PR DESCRIPTION
## What this changes

An official Docker image: `ghcr.io/nubo-db/dynoxide`, a ~5 MB `FROM scratch` drop-in for `amazon/dynamodb-local`, multi-arch, built from the release musl binaries. It also adds a `dynoxide healthcheck` subcommand (for the image `HEALTHCHECK`), a `docker.yml` recovery workflow, and preflight auth probes. Implements #3.

Publishing only runs on a version tag, so merging publishes nothing until the next release (or a manual `docker.yml` run against an existing tag). GHCR is canonical and needs no new secrets. Docker Hub and ECR Public are best-effort mirrors that skip if their creds are missing: Docker Hub needs `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN`, ECR Public needs `ECR_PUBLIC_PUBLISH_ROLE_ARN` and the `nubo-db` alias (still in AWS review).

## Checklist

- [x] Tests added or updated (`tests/healthcheck.rs`)
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` pass locally
- [x] `CHANGELOG.md` updated (`[Unreleased]`)
- ~~If AI tools drafted or materially shaped this change, disclosed in the description above~~ - n/a
- [x] Linked issue: #3

## DynamoDB compatibility note

None. Packaging plus a `healthcheck` subcommand, no behaviour change.
