### PR TITLE
Close negative-path validation gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Official Docker image. `docker run -p 8000:8000 ghcr.io/nubo-db/dynoxide` is a ~5 MB drop-in for `amazon/dynamodb-local` in containerised test suites: multi-arch (`linux/amd64` and `linux/arm64`), `FROM scratch`, published to GHCR on each release with Docker Hub and ECR Public mirrors pushed best-effort. The image ships a `HEALTHCHECK` backed by a new `dynoxide healthcheck` subcommand, so `docker ps` and Compose health gates report status without extra tooling ([#3](https://github.com/nubo-db/dynoxide/issues/3)).
 - `SECURITY.md`, setting out the MCP HTTP transport's loopback-only threat model: what the Host and Origin allowlists cover, what they don't, and where it's safe to run until authentication ([#27](https://github.com/nubo-db/dynoxide/issues/27)) lands.
 
+### Fixed
+
+- Tighter expression and scan validation, to match what real DynamoDB rejects
+  (surfaced by the conformance suite). Dynoxide now turns away redundant
+  parentheses like `((a = :b))` in condition, filter, and key-condition
+  expressions; `contains(x, x)` with the same operand on both sides; and
+  `begins_with` handed a number instead of a string or binary. These are
+  rejected up front, before any items are scanned
+  ([#31](https://github.com/nubo-db/dynoxide/issues/31)).
+- `size()` now measures strings in UTF-16 code units rather than bytes, so
+  values with emoji or accented characters report the length DynamoDB returns.
+- A negative `Segment` on a parallel scan is now rejected rather than accepted.
+
 ## [0.9.13] - 2026-05-11
 
 ### Security

--- a/src/actions/delete_item.rs
+++ b/src/actions/delete_item.rs
@@ -194,6 +194,14 @@ pub fn execute(storage: &Storage, mut request: DeleteItemRequest) -> Result<Dele
             &request.expression_attribute_values,
         )
         .map_err(DynoxideError::ValidationException)?;
+        crate::expressions::condition::validate_operand_semantics(
+            &parsed,
+            &request.expression_attribute_names,
+            &request.expression_attribute_values,
+        )
+        .map_err(|e| {
+            DynoxideError::ValidationException(format!("Invalid ConditionExpression: {e}"))
+        })?;
     }
 
     // Validate legacy Expected parameter BEFORE checking table existence

--- a/src/actions/put_item.rs
+++ b/src/actions/put_item.rs
@@ -192,6 +192,14 @@ pub fn execute(storage: &Storage, mut request: PutItemRequest) -> Result<PutItem
             &request.expression_attribute_values,
         )
         .map_err(DynoxideError::ValidationException)?;
+        crate::expressions::condition::validate_operand_semantics(
+            &parsed,
+            &request.expression_attribute_names,
+            &request.expression_attribute_values,
+        )
+        .map_err(|e| {
+            DynoxideError::ValidationException(format!("Invalid ConditionExpression: {e}"))
+        })?;
     }
 
     // Validate ReturnValues parameter (PutItem only supports NONE and ALL_OLD)

--- a/src/actions/query.rs
+++ b/src/actions/query.rs
@@ -278,6 +278,15 @@ pub fn execute(storage: &Storage, mut request: QueryRequest) -> Result<QueryResp
                     "Invalid FilterExpression: {e}"
                 )));
             }
+            if let Err(e) = expressions::condition::validate_operand_semantics(
+                &parsed_fe,
+                &request.expression_attribute_names,
+                &request.expression_attribute_values,
+            ) {
+                return Err(DynoxideError::ValidationException(format!(
+                    "Invalid FilterExpression: {e}"
+                )));
+            }
         }
     }
     if let Some(ref pe) = request.projection_expression {

--- a/src/actions/scan.rs
+++ b/src/actions/scan.rs
@@ -32,8 +32,11 @@ struct ScanRequestRaw {
     consistent_read: Option<bool>,
     #[serde(rename = "IndexName", default)]
     index_name: Option<String>,
+    // Signed so a negative Segment deserialises and can be rejected with the
+    // DynamoDB ValidationException rather than a serde error. Cast to u32 after
+    // the >= 0 check below.
     #[serde(rename = "Segment", default)]
-    segment: Option<u32>,
+    segment: Option<i64>,
     #[serde(rename = "TotalSegments", default)]
     total_segments: Option<u32>,
     #[serde(rename = "ReturnConsumedCapacity", default)]
@@ -128,6 +131,18 @@ impl<'de> serde::Deserialize<'de> for ScanRequest {
             }
         }
 
+        // Segment must be >= 0. (Segment vs TotalSegments and the TotalSegments
+        // range are checked in execute().)
+        if let Some(segment) = raw.segment {
+            if segment < 0 {
+                errors.push(format!(
+                    "Value '{}' at 'segment' failed to satisfy constraint: \
+                     Member must have value greater than or equal to 0",
+                    segment
+                ));
+            }
+        }
+
         if let Some(msg) = format_validation_errors(&errors) {
             return Err(serde::de::Error::custom(format!("VALIDATION:{}", msg)));
         }
@@ -143,7 +158,7 @@ impl<'de> serde::Deserialize<'de> for ScanRequest {
             select: raw.select,
             consistent_read: raw.consistent_read,
             index_name: raw.index_name,
-            segment: raw.segment,
+            segment: raw.segment.map(|s| s as u32),
             total_segments: raw.total_segments,
             return_consumed_capacity: raw.return_consumed_capacity,
             attributes_to_get: raw.attributes_to_get,
@@ -299,6 +314,15 @@ pub fn execute(storage: &Storage, mut request: ScanRequest) -> Result<ScanRespon
             if let Err(e) = expressions::condition::validate_name_refs(
                 &parsed_fe,
                 &request.expression_attribute_names,
+            ) {
+                return Err(DynoxideError::ValidationException(format!(
+                    "Invalid FilterExpression: {e}"
+                )));
+            }
+            if let Err(e) = expressions::condition::validate_operand_semantics(
+                &parsed_fe,
+                &request.expression_attribute_names,
+                &request.expression_attribute_values,
             ) {
                 return Err(DynoxideError::ValidationException(format!(
                     "Invalid FilterExpression: {e}"

--- a/src/actions/update_item.rs
+++ b/src/actions/update_item.rs
@@ -341,6 +341,14 @@ pub fn execute(storage: &Storage, mut request: UpdateItemRequest) -> Result<Upda
             &request.expression_attribute_values,
         )
         .map_err(DynoxideError::ValidationException)?;
+        crate::expressions::condition::validate_operand_semantics(
+            &parsed,
+            &request.expression_attribute_names,
+            &request.expression_attribute_values,
+        )
+        .map_err(|e| {
+            DynoxideError::ValidationException(format!("Invalid ConditionExpression: {e}"))
+        })?;
     }
 
     // Convert legacy Expected parameter to ConditionExpression if no expression is set

--- a/src/expressions/condition.rs
+++ b/src/expressions/condition.rs
@@ -2,7 +2,7 @@
 //!
 //! Both use identical syntax: comparisons, functions, BETWEEN, IN, AND/OR/NOT.
 
-use crate::expressions::tokenizer::{Token, TokenStream, tokenize};
+use crate::expressions::tokenizer::{Token, TokenStream, check_redundant_parens, tokenize};
 use crate::expressions::{
     PathElement, TrackedExpressionAttributes, resolve_path, resolve_path_elements,
 };
@@ -62,7 +62,7 @@ pub enum CompOp {
 }
 
 /// An operand in an expression.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Operand {
     /// A document path (e.g., `attr`, `a.b[0].c`, `#name.sub`)
     Path(Vec<PathElement>),
@@ -78,6 +78,7 @@ pub enum Operand {
 /// prefix — callers must add the appropriate prefix for their expression type.
 pub fn parse(expr: &str) -> Result<ConditionExpr, String> {
     let tokens = tokenize(expr).map_err(|e| e.to_string())?;
+    check_redundant_parens(&tokens)?;
     let mut stream = TokenStream::new(tokens);
     let result = parse_or(&mut stream)?;
     if !stream.at_end() {
@@ -529,7 +530,9 @@ fn resolve_operand(
             match resolve_path(item, &resolved) {
                 Some(val) => {
                     let size = match &val {
-                        AttributeValue::S(s) => s.len(),
+                        // DynamoDB measures string size in UTF-16 code units,
+                        // not UTF-8 bytes (so a surrogate pair counts as 2).
+                        AttributeValue::S(s) => s.encode_utf16().count(),
                         AttributeValue::B(b) => b.len(),
                         AttributeValue::SS(set) => set.len(),
                         AttributeValue::NS(set) => set.len(),
@@ -735,6 +738,69 @@ fn track_cond_path_refs(
 /// - Correct ordering (lower bound must not be greater than upper bound)
 ///
 /// This validation happens before table lookup, matching DynamoDB behaviour.
+/// Semantic validation that needs resolved names and/or values: rejects
+/// `contains(x, x)` (operands must be distinct) and `begins_with(_, :v)` where
+/// the value operand is not a string or binary. Returns the raw reason; callers
+/// add the `Invalid <X>Expression:` prefix. Runs before execution, so it
+/// rejects on empty tables the way real DynamoDB does.
+pub fn validate_operand_semantics(
+    expr: &ConditionExpr,
+    names: &Option<HashMap<String, String>>,
+    values: &Option<HashMap<String, AttributeValue>>,
+) -> Result<(), String> {
+    match expr {
+        ConditionExpr::Contains(first, rest) => {
+            if first == rest {
+                return Err(format!(
+                    "The first operand must be distinct from the remaining operands for this operator or function; operator: contains, first operand: [{}]",
+                    render_operand_name(first, names)
+                ));
+            }
+            Ok(())
+        }
+        ConditionExpr::BeginsWith(_, prefix) => {
+            if let Operand::ValueRef(vname) = prefix {
+                if let Some(v) = values.as_ref().and_then(|m| m.get(vname.as_str())) {
+                    if !matches!(v, AttributeValue::S(_) | AttributeValue::B(_)) {
+                        return Err(format!(
+                            "Incorrect operand type for operator or function; operator or function: begins_with, operand type: {}",
+                            v.type_name()
+                        ));
+                    }
+                }
+            }
+            Ok(())
+        }
+        ConditionExpr::And(a, b) | ConditionExpr::Or(a, b) => {
+            validate_operand_semantics(a, names, values)?;
+            validate_operand_semantics(b, names, values)
+        }
+        ConditionExpr::Not(inner) => validate_operand_semantics(inner, names, values),
+        _ => Ok(()),
+    }
+}
+
+/// Render an operand's path for error messages, resolving `#name` aliases.
+fn render_operand_name(op: &Operand, names: &Option<HashMap<String, String>>) -> String {
+    let elems = match op {
+        Operand::Path(elems) | Operand::Size(elems) => elems,
+        Operand::ValueRef(name) => return name.clone(),
+    };
+    elems
+        .iter()
+        .map(|e| match e {
+            PathElement::Attribute(a) if a.starts_with('#') => names
+                .as_ref()
+                .and_then(|m| m.get(a))
+                .cloned()
+                .unwrap_or_else(|| a.clone()),
+            PathElement::Attribute(a) => a.clone(),
+            PathElement::Index(i) => format!("[{i}]"),
+        })
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
 pub fn validate_static(
     expr: &ConditionExpr,
     values: &Option<HashMap<String, AttributeValue>>,

--- a/src/expressions/key_condition.rs
+++ b/src/expressions/key_condition.rs
@@ -4,7 +4,9 @@
 //! Sort key conditions: `=`, `<`, `<=`, `>`, `>=`, `BETWEEN ... AND ...`, `begins_with(sk, :prefix)`
 
 use crate::expressions::condition::parse_raw_path;
-use crate::expressions::tokenizer::{Token, TokenSpan, TokenStream, tokenize};
+use crate::expressions::tokenizer::{
+    Token, TokenSpan, TokenStream, check_redundant_parens, tokenize,
+};
 use crate::expressions::{PathElement, TrackedExpressionAttributes};
 use crate::types::AttributeValue;
 
@@ -37,6 +39,9 @@ pub enum SortKeyCondition {
 /// the entire expression, matching DynamoDB behavior.
 pub fn parse(expr: &str, tracker: &TrackedExpressionAttributes) -> Result<KeyCondition, String> {
     let tokens = tokenize(expr).map_err(|e| format!("Invalid KeyConditionExpression: {e}"))?;
+    // Reject redundant parens before stripping outer ones (strip_outer_parens
+    // would otherwise silently accept `((pk = :pk))`).
+    check_redundant_parens(&tokens).map_err(|e| format!("Invalid KeyConditionExpression: {e}"))?;
     let tokens = strip_outer_parens(tokens);
     let mut stream = TokenStream::new(tokens);
 
@@ -546,20 +551,20 @@ mod tests {
         assert_eq!(kc.pk_name, "pk");
         assert!(matches!(kc.sk_condition, Some(SortKeyCondition::Eq(_, _))));
 
-        // Nested parens
+        // Genuinely nested (non-redundant) parens are accepted.
         let tracker = make_tracker(&no_names, &no_values);
-        let kc = parse("((pk = :pk)) AND ((sk > :sk))", &tracker).unwrap();
+        let kc = parse("(pk = :pk AND (sk > :sk))", &tracker).unwrap();
         assert_eq!(kc.pk_name, "pk");
         assert!(matches!(kc.sk_condition, Some(SortKeyCondition::Gt(_, _))));
 
-        // Multiple pairs: outer parens wrapping conditions with their own nested parens
+        // Redundant parentheses are rejected, matching real DynamoDB. Dynoxide
+        // previously stripped them and silently accepted.
         let tracker = make_tracker(&no_names, &no_values);
-        let kc = parse("(((pk = :pk)) AND ((begins_with(sk, :prefix))))", &tracker).unwrap();
-        assert_eq!(kc.pk_name, "pk");
-        assert!(matches!(
-            kc.sk_condition,
-            Some(SortKeyCondition::BeginsWith(_, _))
-        ));
+        let err = parse("((pk = :pk)) AND ((sk > :sk))", &tracker).unwrap_err();
+        assert!(
+            err.contains("redundant parentheses"),
+            "expected redundant-parentheses rejection, got: {err}"
+        );
 
         // Parens around begins_with
         let tracker = make_tracker(&no_names, &no_values);

--- a/src/expressions/tokenizer.rs
+++ b/src/expressions/tokenizer.rs
@@ -383,6 +383,51 @@ pub fn near_window_tokenizer(source: &str, position: usize) -> &str {
     &source[position..end]
 }
 
+/// Detect redundant parentheses, matching DynamoDB's rule: a parenthesised
+/// group whose entire content is itself a single parenthesised group, e.g.
+/// `((expr))` or `((a)) AND (b)`. A single wrap like `(expr)` is fine, and a
+/// wrap around a real combination like `((a) AND (b))` is fine. Shared by
+/// condition/filter and key-condition parsing. Returns the raw reason; callers
+/// add the `Invalid <X>Expression:` prefix.
+pub fn check_redundant_parens(tokens: &[(Token, TokenSpan)]) -> Result<(), String> {
+    let toks: Vec<&Token> = tokens.iter().map(|(t, _)| t).collect();
+    let match_close = |open: usize| -> Option<usize> {
+        let mut depth = 0;
+        for (j, tok) in toks.iter().enumerate().skip(open) {
+            match tok {
+                Token::LParen => depth += 1,
+                Token::RParen => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(j);
+                    }
+                }
+                _ => {}
+            }
+        }
+        None
+    };
+    for i in 0..toks.len() {
+        if !matches!(toks[i], Token::LParen) {
+            continue;
+        }
+        let Some(outer_close) = match_close(i) else {
+            continue;
+        };
+        // Redundant when the outer group's entire content is a single
+        // parenthesised group: the token after the outer `(` is itself `(`
+        // and its match sits immediately before the outer `)`.
+        if matches!(toks.get(i + 1), Some(Token::LParen)) {
+            if let Some(inner_close) = match_close(i + 1) {
+                if inner_close == outer_close - 1 {
+                    return Err("The expression has redundant parentheses;".to_string());
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## What this changes

The conformance suite expansion (nubo-db/dynamodb-conformance#17) found five spots where Dynoxide accepted input real DynamoDB turns away, or sized strings differently. This brings them into line:

- redundant parentheses like `((a = :b))` in condition, filter, and key-condition expressions were waved through; now rejected
- `contains(x, x)` with the same operand on both sides was accepted; now rejected
- `begins_with` took a number instead of a string or binary; now rejected
- `size()` counted bytes, so emoji and accented characters came out the wrong length; it now counts UTF-16 code units like DynamoDB
- a negative `Segment` on a parallel scan slipped past validation; now rejected

The expression rejections fire up front, before any items are scanned, so an empty table behaves the same as a populated one, matching DynamoDB.

Reviewed with AI assistance (Claude Opus 4.7), validated against real AWS DynamoDB via the conformance suite.

Closes #31.

## Checklist

- [x] Tests added or updated
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` pass locally
- [x] `CHANGELOG.md` updated if this is a user-visible change
- [x] If AI tools drafted or materially shaped this change, disclosed in the description above
- [x] Linked issue, discussion, or a short note explaining the motivation

## DynamoDB compatibility note

This makes Dynoxide more compatible, not less: each case now matches real DynamoDB (the conformance suite passes 100% against this build, including the new negative-path tests). The only change for existing users is that previously-accepted malformed input is now rejected.
