### PR TITLE
feat(docker): reach the MCP HTTP transport from the image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,143 @@ jobs:
             echo "ERROR: no SQLite backend should cause compile_error!"
             exit 1
           fi
+
+  # Gate the Docker smoke test on the paths that can actually break the
+  # documented MCP-in-Docker recipe. src/main.rs carries the ServeArgs/McpArgs
+  # flag plumbing and Cargo.{toml,lock} the feature set / rmcp version — both can
+  # break the recipe without touching src/mcp/, so a src/mcp-only gate is too
+  # narrow. Implemented with git diff (no third-party action).
+  changes:
+    name: Detect recipe-affecting changes
+    runs-on: ubuntu-latest
+    outputs:
+      docker: ${{ steps.filter.outputs.docker }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect changes
+        id: filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          # workflow_dispatch has no PR base, and a missing/unreachable base ref
+          # should fail open — run the smoke job rather than skip it silently.
+          if [ -z "${BASE_SHA:-}" ] || ! changed=$(git diff --name-only "$BASE_SHA" HEAD 2>/dev/null); then
+            echo "docker=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Changed files:"; echo "$changed"
+          if echo "$changed" | grep -qE '^(Dockerfile|Cargo\.(toml|lock)|src/main\.rs|src/mcp/|README\.md|\.github/workflows/ci\.yml)'; then
+            echo "docker=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docker=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  docker-smoke:
+    name: Docker MCP smoke test
+    needs: changes
+    if: needs.changes.outputs.docker == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-musl
+      - uses: Swatinem/rust-cache@v2
+
+      # FROM scratch needs a fully static binary; native-sqlite bundles SQLite
+      # via a C compiler, so the musl C toolchain (musl-gcc) is required. This
+      # mirrors the release-amd64 build (.github/workflows/release.yml).
+      - name: Install musl tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
+      - name: Build static musl binary
+        run: cargo build --release --target x86_64-unknown-linux-musl --features full
+
+      - name: Stage binary into the Docker build context
+        run: |
+          set -euo pipefail
+          mkdir -p dist/amd64
+          cp target/x86_64-unknown-linux-musl/release/dynoxide dist/amd64/dynoxide
+          chmod +x dist/amd64/dynoxide
+          file dist/amd64/dynoxide
+          file dist/amd64/dynoxide | grep -q 'statically linked'
+
+      - uses: docker/setup-buildx-action@v3
+
+      # Two flags are load-bearing for `--load`:
+      #   --platform linux/amd64  — without it buildx builds a multi-platform
+      #     manifest that --load cannot export.
+      #   --provenance=false      — without it buildx attaches an attestation
+      #     manifest, which is also a manifest list and is rejected by --load on
+      #     the runner's classic (non-containerd) image store.
+      # Single-arch amd64 is enough for a smoke test; release.yml does multi-arch.
+      - name: Build image (linux/amd64)
+        run: docker buildx build --provenance=false --platform linux/amd64 --load -t dynoxide:smoke .
+
+      - name: Image declares the MCP port (R1)
+        run: |
+          docker image inspect dynoxide:smoke \
+            --format '{{json .Config.ExposedPorts}}' | tee /dev/stderr | grep -q '19280/tcp'
+
+      # The documented recipe. The token is a hardcoded throwaway, intentionally
+      # inline (not a repository secret): it has no value outside this job. The
+      # host-side bind is pinned to 127.0.0.1 so the ports are not reachable on
+      # the Actions Docker bridge.
+      - name: Start the documented DynamoDB + MCP recipe
+        env:
+          DYNOXIDE_MCP_AUTH_TOKEN: ci-smoke-test-token
+        run: |
+          set -euo pipefail
+          docker run -d --name dynoxide-smoke \
+            -p 127.0.0.1:8000:8000 -p 127.0.0.1:19280:19280 \
+            -e DYNOXIDE_MCP_AUTH_TOKEN \
+            dynoxide:smoke \
+            serve --host 0.0.0.0 --port 8000 \
+                  --mcp --mcp-host 0.0.0.0 --mcp-port 19280
+
+      # Poll the port directly; the container HEALTHCHECK's 30s interval lags a
+      # fast smoke run. GET / is the same liveness probe `dynoxide healthcheck`
+      # uses (an unsigned DynamoDB op would 400 on SigV4 auth).
+      - name: DynamoDB reachable on :8000 (R3)
+        run: |
+          set -euo pipefail
+          ok=
+          for _ in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:8000/ | grep -q 'healthy'; then
+              echo "DynamoDB up"; ok=1; break
+            fi
+            sleep 1
+          done
+          [ "${ok:-}" = 1 ] || { echo "::error::DynamoDB never came up"; docker logs dynoxide-smoke; exit 1; }
+
+      - name: MCP authenticated-reachable on :19280 (R2, R4)
+        run: |
+          set -euo pipefail
+          body='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"ci","version":"1.0"}}}'
+          resp=$(curl -fsS -X POST http://127.0.0.1:19280/mcp \
+            -H 'Authorization: Bearer ci-smoke-test-token' \
+            -H 'Content-Type: application/json' \
+            -H 'Accept: application/json, text/event-stream' \
+            -d "$body")
+          echo "$resp"
+          echo "$resp" | grep -q 'dynoxide'
+
+      - name: MCP rejects a missing token with 401 (R4)
+        run: |
+          set -euo pipefail
+          code=$(curl -s -o /dev/null -w '%{http_code}' -X POST http://127.0.0.1:19280/mcp \
+            -H 'Content-Type: application/json' \
+            -H 'Accept: application/json, text/event-stream' \
+            -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}')
+          echo "status=$code"
+          [ "$code" = 401 ] || { echo "::error::expected 401 without token, got $code"; docker logs dynoxide-smoke; exit 1; }
+
+      - name: Teardown
+        if: always()
+        run: docker rm -f dynoxide-smoke || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,9 @@ jobs:
           cp target/x86_64-unknown-linux-musl/release/dynoxide dist/amd64/dynoxide
           chmod +x dist/amd64/dynoxide
           file dist/amd64/dynoxide
-          file dist/amd64/dynoxide | grep -q 'statically linked'
+          # musl builds report "static-pie linked"; zig cross-builds report
+          # "statically linked". Both are self-contained and run on FROM scratch.
+          file dist/amd64/dynoxide | grep -qE 'static-pie linked|statically linked'
 
       - uses: docker/setup-buildx-action@v3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,13 @@ COPY dist/${TARGETARCH}/dynoxide /usr/local/bin/dynoxide
 
 WORKDIR /data
 
-EXPOSE 8000
+# 8000: DynamoDB HTTP API (started by the default CMD).
+# 19280: MCP Streamable-HTTP transport. Opt-in, not started by default — override
+# CMD with `serve --mcp --mcp-host 0.0.0.0` and supply a bearer token via
+# DYNOXIDE_MCP_AUTH_TOKEN (a non-loopback MCP bind refuses to boot without one).
+# See the README "MCP over HTTP in Docker" section. EXPOSE is metadata only; it
+# documents intent and lets `docker run -P` map the port.
+EXPOSE 8000 19280
 
 # Read by the healthcheck subcommand. Override with `docker run -e ...` when
 # CMD is overridden to bind to a non-default port.

--- a/README.md
+++ b/README.md
@@ -177,6 +177,28 @@ docker run --rm -p 8000:8000 \
 
 The default in-memory mode needs no flags whether root or nonroot. The uid 65532 is the well-known nonroot uid used by Google's distroless images; pick any uid you prefer with `--user <uid>:<gid>`.
 
+#### MCP over HTTP in Docker
+
+The default image serves DynamoDB only. To also expose the [MCP](#mcp-server) Streamable HTTP transport, override the command to start it on `0.0.0.0` and supply a bearer token. The token is **mandatory** for any non-loopback bind — pass it via the `DYNOXIDE_MCP_AUTH_TOKEN` environment variable (which keeps it out of shell history and `ps`), not a `--mcp-token` flag:
+
+```sh
+TOKEN=$(openssl rand -base64 24)
+
+docker run --rm -p 8000:8000 -p 19280:19280 \
+  -e DYNOXIDE_MCP_AUTH_TOKEN="$TOKEN" \
+  ghcr.io/nubo-db/dynoxide \
+  serve --host 0.0.0.0 --port 8000 \
+        --mcp --mcp-host 0.0.0.0 --mcp-port 19280
+```
+
+DynamoDB is then reachable on `http://localhost:8000` and MCP on `http://localhost:19280/mcp`. Point an HTTP-transport MCP client at the latter with an `Authorization: Bearer <token>` header — see [MCP Server](#mcp-server) for the client config shape.
+
+A few things to know:
+
+- **The token is not optional.** Omit it and the container exits immediately with `a non-loopback MCP bind requires an explicit token`. The default `docker run ghcr.io/nubo-db/dynoxide` stays DynamoDB-only precisely because a token-less `0.0.0.0` MCP bind cannot boot.
+- **Reaching MCP from another container** by service name (rather than `localhost`) needs that name added to the Host allowlist: `--mcp-allowed-host <name>` (e.g. `--mcp-allowed-host dynoxide`). The `-p`-mapped `localhost` access above needs nothing extra.
+- **`--network host`** (Linux only) is an alternative to `-p`, but it bypasses Docker network isolation and binds MCP directly on the host's network interface — reachable from the LAN, not just the host. Prefer `-p` unless you specifically need host networking.
+
 ## HTTP Server
 
 Start the server:
@@ -264,6 +286,9 @@ design.
 On the `serve` subcommand the equivalent flags are prefixed —
 `--mcp-host`, `--mcp-token`, `--mcp-no-auth`, `--mcp-allowed-host` — because
 `serve` already owns `--host`/`--port` for the DynamoDB server.
+
+To run the HTTP transport from the container image, see
+[MCP over HTTP in Docker](#mcp-over-http-in-docker).
 
 #### HTTP client configuration
 

--- a/tests/mcp_server.rs
+++ b/tests/mcp_server.rs
@@ -1637,9 +1637,26 @@ fn wait_ready(addr: &str) {
 /// until it accepts connections. The explicit token means no token file is
 /// written, so tests never touch the real per-user config dir.
 fn spawn_authed_mcp(port: u16, token: &str) -> AuthChild {
+    spawn_authed_mcp_host(port, token, "127.0.0.1", &[])
+}
+
+/// Like [`spawn_authed_mcp`] but binds an explicit `--host` (e.g. `0.0.0.0`)
+/// with optional extra args (e.g. `--allowed-host`). Connections are still made
+/// over loopback: a `0.0.0.0` bind includes `127.0.0.1`, so tests reach it the
+/// same way regardless of the bind host (the #24 reachability shape).
+fn spawn_authed_mcp_host(port: u16, token: &str, host: &str, extra_args: &[&str]) -> AuthChild {
     let binary = env!("CARGO_BIN_EXE_dynoxide");
+    let mut args: Vec<String> = vec![
+        "mcp".into(),
+        "--http".into(),
+        "--host".into(),
+        host.into(),
+        "--port".into(),
+        port.to_string(),
+    ];
+    args.extend(extra_args.iter().map(|s| s.to_string()));
     let child = Command::new(binary)
-        .args(["mcp", "--http", "--port", &port.to_string()])
+        .args(&args)
         .env("DYNOXIDE_MCP_AUTH_TOKEN", token)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -2042,5 +2059,44 @@ fn allowed_host_extends_acceptance() {
     assert!(
         foreign.starts_with("HTTP/1.1 403"),
         "non-allowlisted host should still be 403, got: {foreign}"
+    );
+}
+
+#[test]
+fn off_loopback_bind_is_reachable_with_token() {
+    // #24: a 0.0.0.0 bind with a token is reachable over loopback and
+    // authenticates — the core Docker reachability shape. Existing auth tests
+    // all bind the 127.0.0.1 default; this is the only widened-bind happy path.
+    let port = free_port();
+    let _srv = spawn_authed_mcp_host(port, "the-secret-token", "0.0.0.0", &[]);
+    let resp = mcp_request(port, &format!("127.0.0.1:{port}"), Some("the-secret-token"));
+    assert!(
+        resp.starts_with("HTTP/1.1 2"),
+        "0.0.0.0 bind with a token should accept a loopback-Host request, got: {resp}"
+    );
+    assert!(resp.contains("dynoxide"), "got: {resp}");
+}
+
+#[test]
+fn off_loopback_bind_accepts_allowlisted_name() {
+    // #24 container-to-container shape: a 0.0.0.0 bind reached by service name
+    // needs that name on the Host allowlist via --allowed-host. (Foreign-Host
+    // 403 and loopback acceptance are covered by auth_does_not_mask_host_check
+    // and allowed_host_extends_acceptance.)
+    let port = free_port();
+    let _srv = spawn_authed_mcp_host(
+        port,
+        "the-secret-token",
+        "0.0.0.0",
+        &["--allowed-host", "dynoxide.test"],
+    );
+    let resp = mcp_request(
+        port,
+        &format!("dynoxide.test:{port}"),
+        Some("the-secret-token"),
+    );
+    assert!(
+        resp.starts_with("HTTP/1.1 2"),
+        "allowlisted by-name Host on a 0.0.0.0 bind should be accepted, got: {resp}"
     );
 }


### PR DESCRIPTION
## What

Surfaces the MCP HTTP transport through the published Docker image. The image
served DynamoDB only and never started MCP, and the README Docker section said
nothing about it — so the image was a drop-in for `amazon/dynamodb-local` but
not for dynoxide's full surface.

The MCP engine work this needed already shipped in #41 (the `--mcp-host` /
`--mcp-allowed-host` flags and the token-gated non-loopback bind), so this is
image metadata, documentation, and verification — no Rust logic change.

Closes #24.

## Changes

- **`Dockerfile`** — declare `EXPOSE 8000 19280` so the MCP port is discoverable
  and `docker run -P` maps it. The default `CMD` stays DynamoDB-only.
- **`README.md`** — an "MCP over HTTP in Docker" recipe: `serve --mcp
  --mcp-host 0.0.0.0` with a mandatory bearer token via `DYNOXIDE_MCP_AUTH_TOKEN`,
  plus notes on by-name access (`--mcp-allowed-host`) and the `--network host`
  blast radius.
- **`tests/mcp_server.rs`** — two integration tests for a `0.0.0.0` bind: a
  token-gated reachable happy path and by-name access via `--allowed-host`. The
  missing-token and foreign-Host-403 cases were already covered.
- **`.github/workflows/ci.yml`** — a path-gated `docker-smoke` job that builds a
  static musl image and runs the documented recipe in a container, asserting
  DynamoDB on `:8000`, authenticated MCP on `:19280`, and a 401 without a token.

## Verification

Built the static musl image locally and ran the documented recipe end-to-end —
DynamoDB reachable, MCP `initialize` returns `serverInfo.name: dynoxide`, a
token-less request gets 401, and the image exposes 19280. `cargo test --test
mcp_server` is green (43 tests).

Validating locally surfaced a portability fix now in the job: `docker buildx
--load` needs `--provenance=false` (alongside the single `--platform`) or buildx
emits an attestation manifest list that `--load` rejects on the runner's classic
image store.

The default `docker run ghcr.io/nubo-db/dynoxide` is unchanged: DynamoDB-only,
no token required.
