### PR TITLE
feat: async engine consuming the StorageBackend trait

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,15 @@ jobs:
             echo "ERROR: no SQLite backend should cause compile_error!"
             exit 1
           fi
+
+  wasm-stub-check:
+    name: wasm-stub trait-shape check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: cargo check --features wasm-stub
+        run: cargo check --features wasm-stub --lib

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,17 +100,17 @@ helps a reviewer but are not required.
 
 ## Storage layer boundary
 
-The storage layer is mid-refactor. A `StorageBackend` trait now lives in
-`src/storage_backend/` and the native rusqlite-backed `Storage` implements
-it; nothing dynamic dispatches the trait yet, and `Database` plus the
-action handlers continue to operate against `Storage` directly. Folding
-the `Storage::conn()` and `Storage::conn_mut()` escape hatches into the
-trait (or migrating their callers off them) is the next move and is
-sequenced with the upcoming non-native (browser / WASM) backend. Please
-open an issue before submitting changes to `src/storage.rs`,
-`src/storage_backend/`, or call sites that use `conn()` directly; we can
-advise whether your change fits the current shape or is better held until
-the next pass.
+The data layer goes through the `StorageBackend` trait in
+`src/storage_backend/`; the native rusqlite-backed `Storage` implements it.
+The action handlers are async and generic over the trait
+(`execute<S: StorageBackend>`), and `Database` is `Database<S = RusqliteBackend>`
+with a `NativeDatabase` alias that preserves the historical synchronous public
+API through a `block_on` facade. The trait is consumed monomorphically (no
+`dyn`); a non-native (browser / WASM) backend is the next consumer. The raw
+`Storage::conn()` / `conn_mut()` escape hatches are no longer used by action
+handlers. Please open an issue before submitting changes to `src/storage.rs`
+or `src/storage_backend/`; we can advise whether your change fits the current
+shape or is better held until the next pass.
 
 ## Where to discuss
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,11 +100,17 @@ helps a reviewer but are not required.
 
 ## Storage layer boundary
 
-The storage layer (`src/storage.rs` and related) is scheduled for a
-significant refactor before 1.0: the `Database` type will become
-generic over a `StorageBackend` trait. Please open an issue before
-submitting changes in this area; we can advise whether your change
-fits the current architecture, the planned one, or is best deferred.
+The storage layer is mid-refactor. A `StorageBackend` trait now lives in
+`src/storage_backend/` and the native rusqlite-backed `Storage` implements
+it; nothing dynamic dispatches the trait yet, and `Database` plus the
+action handlers continue to operate against `Storage` directly. Folding
+the `Storage::conn()` and `Storage::conn_mut()` escape hatches into the
+trait (or migrating their callers off them) is the next move and is
+sequenced with the upcoming non-native (browser / WASM) backend. Please
+open an issue before submitting changes to `src/storage.rs`,
+`src/storage_backend/`, or call sites that use `conn()` directly; we can
+advise whether your change fits the current shape or is better held until
+the next pass.
 
 ## Where to discuss
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-04-30
+
+### Added
+
+- A `StorageBackend` trait in the new `dynoxide::storage_backend` module, decoupling the data layer from a specific SQLite binding. The native rusqlite-backed `Storage` implements the trait. Today the trait is consumed monomorphically only -- `Database`, action handlers, and `DynoxideError` continue to operate against `Storage` directly.
+- A `BackendError` enum returned by the trait surface, with an explicit `rusqlite::Error -> BackendError` mapping for the common failure modes (`NotADatabase`, locked / busy, constraint violations, I/O failures).
+- A `Clock` capability on `Storage` so the trait surface does not assume `std::time`. Stream and TTL paths route their `created_at` and sweep timestamps through the clock; `SystemClock` is the default and `ManualClock` ships as a deterministic test helper. Other `std::time` call sites (idempotency cache, action-handler timestamps, snapshots) remain native-only and are unchanged.
+- A `wasm-stub` cargo feature that builds a placeholder `WaSqliteBackend` whose method bodies are `unimplemented!()`. The stub exists to catch trait-shape drift at type-check time before a real wa-sqlite backend has to absorb it. CI gains a `wasm-stub-check` job that runs `cargo check --features wasm-stub --lib` on every PR.
+
+### Notes
+
+- This release is behaviour-preserving: existing public APIs (`Database`, `Storage`, action handlers, error types) are unchanged. Tests, conformance suites, and benchmarks continue to pass against the same surface as 0.9.10.
+- Building dynoxide for `wasm32-unknown-unknown` is not yet supported. The trait surface is in place; making the rest of the codebase target-agnostic is the next pass and lands when a working WASM backend does.
+
 ## [0.9.10] - 2026-04-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A `Clock` capability on `Storage` so the trait surface does not assume `std::time`. Stream and TTL paths route their `created_at` and sweep timestamps through the clock; `SystemClock` is the default and `ManualClock` ships as a deterministic test helper. Other `std::time` call sites (idempotency cache, action-handler timestamps, snapshots) remain native-only and are unchanged.
 - A `wasm-stub` cargo feature that builds a placeholder `WaSqliteBackend` whose method bodies are `unimplemented!()`. The stub exists to catch trait-shape drift at type-check time before a real wa-sqlite backend has to absorb it. CI gains a `wasm-stub-check` job that runs `cargo check --features wasm-stub --lib` on every PR.
 
+### Changed
+
+- `Database` is now generic over its storage backend -- `Database<S>`, monomorphised, no `dyn`. The parameter defaults to the native rusqlite backend, so existing code that names `Database` is unaffected, and a new `NativeDatabase` alias names that default explicitly. The action handlers are now `async` and route through the `StorageBackend` trait. `NativeDatabase` keeps the historical synchronous public API: each method drives the handler future to completion with `block_on` (via `pollster`), and because the native backend's futures never suspend, that `block_on` never parks the thread, so it stays safe inside the tokio-based HTTP and MCP servers.
+
+### Fixed
+
+- A single-item write (`PutItem`, `DeleteItem`, `UpdateItem`) and its GSI/LSI index fan-out now run in a single transaction. A failure partway through the fan-out rolls the whole write back rather than leaving a base row with a half-applied (torn) index. This matches DynamoDB, where a single-item write does not half-apply to its indexes.
+
 ### Notes
 
-- This release is behaviour-preserving: existing public APIs (`Database`, `Storage`, action handlers, error types) are unchanged. Tests, conformance suites, and benchmarks continue to pass against the same surface as 0.9.10.
+- Existing native code that names `Database` keeps working unchanged: the new generic parameter defaults to the rusqlite backend and the synchronous method signatures are identical. The one deliberate behaviour change is index fan-out atomicity (see Fixed); it is more DynamoDB-correct, and the conformance suite still passes. Tests, conformance, and benchmarks pass against the same observable surface as before.
 - Building dynoxide for `wasm32-unknown-unknown` is not yet supported. The trait surface is in place; making the rest of the codebase target-agnostic is the next pass and lands when a working WASM backend does.
 
 ## [0.9.13] - 2026-05-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- A `StorageBackend` trait in the new `dynoxide::storage_backend` module, decoupling the data layer from a specific SQLite binding. The native rusqlite-backed `Storage` implements the trait. Today the trait is consumed monomorphically only -- `Database`, action handlers, and `DynoxideError` continue to operate against `Storage` directly.
+- A `StorageBackend` trait in the new `dynoxide::storage_backend` module, decoupling the data layer from a specific SQLite binding. The native rusqlite-backed `Storage` implements the trait, and the action handlers and `Database` now consume it (see Changed). The trait surface also carries a `clock()` accessor for the stream and TTL paths and batch-shaped `put_base_items` / `insert_gsi_items` methods that replaced the last two raw `Storage::conn()` escape hatches in the handlers.
 - A `BackendError` enum returned by the trait surface, with an explicit `rusqlite::Error -> BackendError` mapping for the common failure modes (`NotADatabase`, locked / busy, constraint violations, I/O failures).
 - A `Clock` capability on `Storage` so the trait surface does not assume `std::time`. Stream and TTL paths route their `created_at` and sweep timestamps through the clock; `SystemClock` is the default and `ManualClock` ships as a deterministic test helper. Other `std::time` call sites (idempotency cache, action-handler timestamps, snapshots) remain native-only and are unchanged.
 - A `wasm-stub` cargo feature that builds a placeholder `WaSqliteBackend` whose method bodies are `unimplemented!()`. The stub exists to catch trait-shape drift at type-check time before a real wa-sqlite backend has to absorb it. CI gains a `wasm-stub-check` job that runs `cargo check --features wasm-stub --lib` on every PR.
@@ -20,7 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- A single-item write (`PutItem`, `DeleteItem`, `UpdateItem`) and its GSI/LSI index fan-out now run in a single transaction. A failure partway through the fan-out rolls the whole write back rather than leaving a base row with a half-applied (torn) index. This matches DynamoDB, where a single-item write does not half-apply to its indexes.
+- A single-item write (`PutItem`, `DeleteItem`, `UpdateItem`) and its GSI/LSI index fan-out now run in a single transaction. A failure partway through the fan-out rolls the whole write back rather than leaving a base row with a half-applied (torn) index. The same per-item atomicity now also covers `BatchWriteItem` (each write request) and the TTL sweep (each expired-item delete). This matches DynamoDB, where a single-item write does not half-apply to its indexes.
+- Write paths now roll back on a failed `COMMIT` and surface a failed `ROLLBACK` rather than leaving the connection stuck mid-transaction, which would make the next write fail. Every write path shares one transaction helper for this.
+- A client-facing `ValidationException` raised inside a backend method (the 50-tag limit in `set_tags`) keeps its 400 status across the `StorageBackend` boundary instead of collapsing to a 500.
 
 ### Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,11 +13,15 @@ same ground in a form those tools pick up automatically.
 - Open a GitHub issue describing the change if it is more than a small
   bug fix or obvious cleanup. A short paragraph is enough. This catches
   direction questions before a PR round-trips.
-- The storage layer (`src/storage.rs` and related) is scheduled for a
-  significant refactor before 1.0: the `Database` type will become
-  generic over a `StorageBackend` trait. Please open an issue before
-  submitting changes in this area so we can advise whether your change
-  fits the current architecture, the planned one, or is best deferred.
+- The storage layer is mid-refactor. A `StorageBackend` trait now lives
+  in `src/storage_backend/` and the native rusqlite-backed `Storage`
+  implements it. Nothing dynamic dispatches the trait yet; `Database`
+  and the action handlers still operate against `Storage` directly. The
+  `Storage::conn()` and `Storage::conn_mut()` escape hatches are not on
+  the trait and folding them in is the next pass. Please open an issue
+  before submitting changes to `src/storage.rs`, `src/storage_backend/`,
+  or call sites that use `conn()` directly so we can advise whether your
+  change fits the current shape or is better held until the next pass.
 - If you want to add a new dependency, open an issue so we can weigh
   binary size, build time, and licence.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,7 +928,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "dynoxide-rs"
-version = "0.9.10"
+version = "0.10.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,6 +943,7 @@ dependencies = [
  "indicatif",
  "libc",
  "md5",
+ "pollster",
  "proptest",
  "reqwest",
  "rmcp",
@@ -999,7 +1000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1485,7 +1486,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1846,7 +1847,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2018,6 +2019,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
 name = "portable-atomic"
@@ -2382,7 +2389,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2845,7 +2852,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,10 @@ base64 = "0.22"
 bigdecimal = "0.4"
 uuid = { version = "1", features = ["v4", "v7"] }
 md5 = "0.7"
+# Drives the always-ready native handler futures to completion for the
+# synchronous `Database` facade. A minimal block_on that never spawns threads,
+# so it is safe to call from inside the tokio-based HTTP/MCP servers.
+pollster = "0.4"
 
 # Optional encryption dependency
 zeroize = { version = "1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,11 @@ encrypted-full = ["encryption", "http-server", "mcp-server", "import"]
 mcp-server = ["dep:rmcp", "dep:schemars", "dep:tokio", "dep:tokio-util", "dep:axum", "dep:clap", "dep:tracing", "dep:tracing-subscriber", "dep:libc"]
 import = ["dep:clap", "dep:toml", "dep:fake", "dep:sha2", "dep:flate2", "dep:indicatif", "dep:zstd", "dep:tempfile"]
 
+# Compile-only wa-sqlite stub. Surfaces trait-shape drift at type-check
+# time so a real wa-sqlite backend does not absorb that drift later. Not
+# a working backend; bodies are unimplemented!().
+wasm-stub = []
+
 # Backward-compatible alias — identical to default features
 full = ["native-sqlite", "http-server", "mcp-server", "import"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dynoxide-rs"
-version = "0.9.10"
+version = "0.10.0"
 edition = "2024"
 description = "A lightweight, embeddable DynamoDB emulator backed by SQLite"
 license = "MIT OR Apache-2.0"

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -113,9 +113,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
-version = "1.8.15"
+version = "1.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11493b0bad143270fb8ad284a096dd529ba91924c5409adeac856cc1bf047dbc"
+checksum = "50f156acdd2cf55f5aa53ee416c4ac851cf1222694506c0b1f78c85695e9ca9d"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -165,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc0651c57e384202e47153c1260b84a9936e19803d747615edf199dc3b98d17"
+checksum = "5dcd93c82209ac7413532388067dce79be5a8780c1786e5fae3df22e4dee2864"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -202,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dynamodb"
-version = "1.110.0"
+version = "1.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c597424385739456cd04535982831c15bd58f97ca28c5bcb232c0d730d5cb39"
+checksum = "fc418346e3cb248c7d59e642acbcb06488b7c7cd2ba6ebc79e8003f618c60099"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -226,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.97.0"
+version = "1.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aadc669e184501caaa6beafb28c6267fc1baef0810fb58f9b205485ca3f2567"
+checksum = "d69c77aafa20460c68b6b3213c84f6423b6e76dbf89accd3e1789a686ffd9489"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -250,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.99.0"
+version = "1.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1342a7db8f358d3de0aed2007a0b54e875458e39848d54cc1d46700b2bfcb0a8"
+checksum = "1c7e7b09346d5ca22a2a08267555843a6a0127fb20d8964cb6ecfb8fdb190225"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -274,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.101.0"
+version = "1.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab41ad64e4051ecabeea802d6a17845a91e83287e1dd249e6963ea1ba78c428a"
+checksum = "c2249b81a2e73a8027c41c378463a81ec39b8510f184f2caab87de912af0f49b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -299,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b660013a6683ab23797778e21f1f854744fdf05f68204b4cca4c8c04b5d1f4"
+checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -314,7 +314,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.0",
  "percent-encoding",
- "sha2",
+ "sha2 0.11.0",
  "time",
  "tracing",
 ]
@@ -368,11 +368,11 @@ dependencies = [
  "hyper 0.14.32",
  "hyper 1.9.0",
  "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.7",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
@@ -411,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.10.3"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028999056d2d2fd58a697232f9eec4a643cf73a71cf327690a7edad1d2af2110"
+checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -436,11 +436,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.11.6"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ab3c9c29791ba4ba02b780a3049e21ec63dabda09268b175272c3733a79e6"
+checksum = "b71a13df6ada0aafbf21a73bdfcdf9324cfa9df77d96b8446045be3cde61b42e"
 dependencies = [
  "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
@@ -449,6 +450,17 @@ dependencies = [
  "tokio",
  "tracing",
  "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -488,9 +500,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.14"
+version = "1.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c8323699dd9b3c8d5b3c13051ae9cdef58fd179957c882f8374dd8725962d9"
+checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -502,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
@@ -592,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -603,6 +615,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -635,9 +656,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -659,7 +680,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -705,9 +726,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -727,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -753,6 +774,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,6 +797,12 @@ dependencies = [
  "unicode-width",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation"
@@ -892,6 +925,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,9 +1052,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
- "subtle",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -1052,7 +1114,7 @@ dependencies = [
  "dynoxide-rs",
  "iai-callgrind",
  "libc",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "tempfile",
@@ -1061,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "dynoxide-rs"
-version = "0.9.6"
+version = "0.10.0"
 dependencies = [
  "axum",
  "base64",
@@ -1078,7 +1140,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "socket2 0.6.3",
  "tempfile",
  "thiserror",
@@ -1128,7 +1190,7 @@ checksum = "aef603df4ba9adbca6a332db7da6f614f21eafefbaf8e087844e452fdec152d0"
 dependencies = [
  "deunicode",
  "dummy",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1145,9 +1207,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1322,7 +1384,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1387,9 +1449,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -1420,11 +1482,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1495,6 +1557,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1557,16 +1628,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.0",
  "hyper 1.9.0",
  "hyper-util",
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
@@ -1762,9 +1832,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1772,12 +1842,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1845,10 +1915,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1867,9 +1939,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -2073,9 +2145,9 @@ dependencies = [
 
 [[package]]
 name = "pastey"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 
 [[package]]
 name = "percent-encoding"
@@ -2097,9 +2169,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plotters"
@@ -2223,9 +2295,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -2234,13 +2306,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2264,15 +2336,15 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -2368,9 +2440,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.3.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2231b2c085b371c01bc90c0e6c1cab8834711b6394533375bdbf870b0166d419"
+checksum = "67d69668de0b0ccd9cc435f700f3b39a7861863cf37a15e1f304ea78688a4826"
 dependencies = [
  "async-trait",
  "base64",
@@ -2382,7 +2454,7 @@ dependencies = [
  "http-body-util",
  "pastey",
  "pin-project-lite",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rmcp-macros",
  "schemars",
  "serde",
@@ -2399,9 +2471,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.3.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea0e100fadf81be85d7ff70f86cd805c7572601d4ab2946207f36540854b43"
+checksum = "48fdc01c81097b0aed18633e676e269fefa3a78ec1df56b4fe597c1241b92025"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -2460,14 +2532,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -2486,9 +2558,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
@@ -2505,9 +2577,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2612,9 +2684,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2710,7 +2782,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2721,7 +2793,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2789,9 +2872,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
+checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
 dependencies = [
  "bytes",
  "futures-util",
@@ -2940,9 +3023,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -2957,9 +3040,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2982,7 +3065,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "tokio",
 ]
 
@@ -3165,9 +3248,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
@@ -3225,9 +3308,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -3285,11 +3368,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -3298,14 +3381,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3316,9 +3399,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3326,9 +3409,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3339,9 +3422,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -3382,9 +3465,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3578,6 +3661,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "wit-bindgen-core"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3658,9 +3747,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xmlparser"

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "dynoxide-rs"
-version = "0.9.13"
+version = "0.10.0"
 dependencies = [
  "axum",
  "base64",
@@ -1135,6 +1135,7 @@ dependencies = [
  "indicatif",
  "libc",
  "md5",
+ "pollster",
  "rmcp",
  "rusqlite",
  "schemars",
@@ -1179,7 +1180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1659,7 +1660,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1879,7 +1880,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2047,7 +2048,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2200,6 +2201,12 @@ checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
+
+[[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
 name = "portable-atomic"
@@ -2515,7 +2522,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2939,7 +2946,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3489,7 +3496,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/benchmarks/bin/startup_bench.rs
+++ b/benchmarks/bin/startup_bench.rs
@@ -247,7 +247,9 @@ async fn measure_docker_startup(
 
     // Forward LocalStack auth token if available
     let ls_token;
-    if image.contains("localstack") && let Ok(token) = std::env::var("LOCALSTACK_AUTH_TOKEN") {
+    if image.contains("localstack")
+        && let Ok(token) = std::env::var("LOCALSTACK_AUTH_TOKEN")
+    {
         ls_token = format!("LOCALSTACK_AUTH_TOKEN={token}");
         cmd_args.extend_from_slice(&["-e", &ls_token]);
     }

--- a/src/actions/batch_execute_statement.rs
+++ b/src/actions/batch_execute_statement.rs
@@ -1,6 +1,6 @@
 use crate::errors::{DynoxideError, Result};
 use crate::partiql;
-use crate::storage::Storage;
+use crate::storage_backend::StorageBackend;
 use crate::types::{AttributeValue, Item};
 use serde::{Deserialize, Serialize};
 
@@ -40,8 +40,8 @@ pub struct BatchStatementError {
     pub message: String,
 }
 
-pub fn execute(
-    storage: &Storage,
+pub async fn execute<S: StorageBackend>(
+    storage: &S,
     request: BatchExecuteStatementRequest,
 ) -> Result<BatchExecuteStatementResponse> {
     if request.statements.is_empty() {
@@ -71,7 +71,7 @@ pub fn execute(
             },
             Ok(stmt) => {
                 let params = stmt_req.parameters.as_deref().unwrap_or_default();
-                match partiql::executor::execute(storage, &stmt, params, None) {
+                match partiql::executor::execute(storage, &stmt, params, None).await {
                     Ok(Some(items)) => {
                         // For SELECT, return first item (batch returns single item per statement)
                         BatchStatementResponse {

--- a/src/actions/batch_get_item.rs
+++ b/src/actions/batch_get_item.rs
@@ -1,7 +1,7 @@
 use crate::actions::helpers;
 use crate::errors::{DynoxideError, Result};
 use crate::expressions;
-use crate::storage::Storage;
+use crate::storage_backend::StorageBackend;
 use crate::types::{AttributeValue, Item};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -38,7 +38,10 @@ pub struct BatchGetItemResponse {
     pub consumed_capacity: Option<Vec<crate::types::ConsumedCapacity>>,
 }
 
-pub fn execute(storage: &Storage, request: BatchGetItemRequest) -> Result<BatchGetItemResponse> {
+pub async fn execute<S: StorageBackend>(
+    storage: &S,
+    request: BatchGetItemRequest,
+) -> Result<BatchGetItemResponse> {
     // Validate RequestItems is not empty.
     // AWS routes the empty-map case through a separate parameter-required path
     // rather than the standard "N validation errors detected" envelope.
@@ -179,7 +182,7 @@ pub fn execute(storage: &Storage, request: BatchGetItemRequest) -> Result<BatchG
     let mut table_rcu: HashMap<String, f64> = HashMap::new();
 
     for (table_name, keys_and_attrs) in &request.request_items {
-        let meta = helpers::require_table_for_item_op(storage, table_name)?;
+        let meta = helpers::require_table_for_item_op(storage, table_name).await?;
         let key_schema = helpers::parse_key_schema(&meta)?;
 
         // Parse projection if present; also handle legacy AttributesToGet
@@ -220,7 +223,7 @@ pub fn execute(storage: &Storage, request: BatchGetItemRequest) -> Result<BatchG
             // TODO: validation must precede this call -- if reaching this line, caller has already validated keys.
             let (pk, sk) = helpers::extract_key_strings(key, &key_schema)?;
 
-            if let Some(item_json) = storage.get_item(table_name, &pk, &sk)? {
+            if let Some(item_json) = storage.get_item(table_name, &pk, &sk).await? {
                 let item: Item = serde_json::from_str(&item_json).map_err(|e| {
                     DynoxideError::InternalServerError(format!("Bad item JSON: {e}"))
                 })?;

--- a/src/actions/batch_write_item.rs
+++ b/src/actions/batch_write_item.rs
@@ -223,45 +223,58 @@ pub async fn execute<S: StorageBackend>(
                     .get(&key_schema.partition_key)
                     .map(crate::storage::compute_hash_prefix)
                     .unwrap_or_default();
-                let old_json = storage
-                    .put_item_with_hash(table_name, &pk, &sk, &item_json, size, &hash_prefix)
+                // Base write + index fan-out + stream are one atomic unit per
+                // item: a mid-fan-out failure rolls this item's write back.
+                // BatchWriteItem items are independent, so this is one
+                // transaction per write request.
+                let gsi_units = helpers::with_write_transaction(storage, async {
+                    let old_json = storage
+                        .put_item_with_hash(table_name, &pk, &sk, &item_json, size, &hash_prefix)
+                        .await?;
+                    let gsi_units = super::gsi::maintain_gsis_after_write(
+                        storage,
+                        table_name,
+                        &meta,
+                        &pk,
+                        &sk,
+                        &put_req.item,
+                        &key_schema.partition_key,
+                        key_schema.sort_key.as_deref(),
+                    )
                     .await?;
+                    super::lsi::maintain_lsis_after_write(
+                        storage,
+                        table_name,
+                        &meta,
+                        &pk,
+                        &sk,
+                        &put_req.item,
+                        &key_schema.partition_key,
+                        key_schema.sort_key.as_deref(),
+                    )
+                    .await?;
+                    let old_item: Option<Item> =
+                        old_json.and_then(|j| serde_json::from_str(&j).ok());
+                    crate::streams::record_stream_event(
+                        storage,
+                        &meta,
+                        old_item.as_ref(),
+                        Some(&put_req.item),
+                    )
+                    .await?;
+                    Ok(gsi_units)
+                })
+                .await?;
 
                 // Accumulate WCU based on item size
                 *table_wcu.entry(table_name.clone()).or_insert(0.0) +=
                     types::write_capacity_units(size);
-
-                // Maintain GSI tables
-                let gsi_units = super::gsi::maintain_gsis_after_write(
-                    storage,
-                    table_name,
-                    &meta,
-                    &pk,
-                    &sk,
-                    &put_req.item,
-                    &key_schema.partition_key,
-                    key_schema.sort_key.as_deref(),
-                )
-                .await?;
 
                 // Accumulate GSI units per table
                 let table_entry = table_gsi_units.entry(table_name.clone()).or_default();
                 for (gsi_name, units) in &gsi_units {
                     *table_entry.entry(gsi_name.clone()).or_insert(0.0) += units;
                 }
-
-                // Maintain LSI tables
-                super::lsi::maintain_lsis_after_write(
-                    storage,
-                    table_name,
-                    &meta,
-                    &pk,
-                    &sk,
-                    &put_req.item,
-                    &key_schema.partition_key,
-                    key_schema.sort_key.as_deref(),
-                )
-                .await?;
 
                 // Track affected partition for deferred metrics
                 if let Some(pk_val) = put_req.item.get(&key_schema.partition_key) {
@@ -272,25 +285,36 @@ pub async fn execute<S: StorageBackend>(
                         pk_val.clone(),
                     ));
                 }
-
-                // Record stream event
-                let old_item: Option<Item> = old_json.and_then(|j| serde_json::from_str(&j).ok());
-                crate::streams::record_stream_event(
-                    storage,
-                    &meta,
-                    old_item.as_ref(),
-                    Some(&put_req.item),
-                )
-                .await?;
             } else if let Some(ref del_req) = wr.delete_request {
                 helpers::validate_key_only(&del_req.key, &key_schema)?;
                 // TODO: validation must precede this call -- if reaching this line, caller has already validated keys.
                 let (pk, sk) = helpers::extract_key_strings(&del_req.key, &key_schema)?;
-                let old_json = storage.delete_item(table_name, &pk, &sk).await?;
+
+                // Base delete + index fan-out + stream are one atomic unit per item.
+                let (old_item, gsi_units) = helpers::with_write_transaction(storage, async {
+                    let old_json = storage.delete_item(table_name, &pk, &sk).await?;
+                    let old_item: Option<Item> =
+                        old_json.as_ref().and_then(|j| serde_json::from_str(j).ok());
+                    let gsi_units = super::gsi::maintain_gsis_after_delete(
+                        storage, table_name, &meta, &pk, &sk,
+                    )
+                    .await?;
+                    super::lsi::maintain_lsis_after_delete(storage, table_name, &meta, &pk, &sk)
+                        .await?;
+                    if old_item.is_some() {
+                        crate::streams::record_stream_event(
+                            storage,
+                            &meta,
+                            old_item.as_ref(),
+                            None,
+                        )
+                        .await?;
+                    }
+                    Ok((old_item, gsi_units))
+                })
+                .await?;
 
                 // Accumulate WCU: based on old item size if it existed, else 1 WCU
-                let old_item: Option<Item> =
-                    old_json.as_ref().and_then(|j| serde_json::from_str(j).ok());
                 let delete_wcu = if let Some(ref old) = old_item {
                     types::write_capacity_units(types::item_size(old))
                 } else {
@@ -298,20 +322,11 @@ pub async fn execute<S: StorageBackend>(
                 };
                 *table_wcu.entry(table_name.clone()).or_insert(0.0) += delete_wcu;
 
-                // Maintain GSI tables
-                let gsi_units =
-                    super::gsi::maintain_gsis_after_delete(storage, table_name, &meta, &pk, &sk)
-                        .await?;
-
                 // Accumulate GSI units per table
                 let table_entry = table_gsi_units.entry(table_name.clone()).or_default();
                 for (gsi_name, units) in &gsi_units {
                     *table_entry.entry(gsi_name.clone()).or_insert(0.0) += units;
                 }
-
-                // Maintain LSI tables
-                super::lsi::maintain_lsis_after_delete(storage, table_name, &meta, &pk, &sk)
-                    .await?;
 
                 // Track affected partition for deferred metrics
                 if let Some(pk_val) = del_req.key.get(&key_schema.partition_key) {
@@ -321,12 +336,6 @@ pub async fn execute<S: StorageBackend>(
                         key_schema.partition_key.clone(),
                         pk_val.clone(),
                     ));
-                }
-
-                // Record stream event (old_item already parsed above)
-                if old_item.is_some() {
-                    crate::streams::record_stream_event(storage, &meta, old_item.as_ref(), None)
-                        .await?;
                 }
             } else {
                 return Err(DynoxideError::ValidationException(
@@ -403,4 +412,60 @@ pub async fn execute<S: StorageBackend>(
         consumed_capacity,
         item_collection_metrics,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::actions::{batch_write_item, create_table};
+    use crate::storage::Storage;
+    use crate::storage_backend::StorageBackend;
+
+    /// Each batch put is atomic with its own GSI fan-out: a mid-fan-out failure
+    /// rolls that item's base write back rather than leaving a torn index.
+    #[test]
+    fn batch_put_rolls_back_base_write_when_gsi_fan_out_fails() {
+        let storage = Storage::memory().unwrap();
+
+        let create = serde_json::from_value(serde_json::json!({
+            "TableName": "Orders",
+            "KeySchema": [{"AttributeName": "UserId", "KeyType": "HASH"}],
+            "AttributeDefinitions": [
+                {"AttributeName": "UserId", "AttributeType": "S"},
+                {"AttributeName": "Status", "AttributeType": "S"},
+                {"AttributeName": "Priority", "AttributeType": "S"}
+            ],
+            "GlobalSecondaryIndexes": [
+                {"IndexName": "StatusIndex", "KeySchema": [{"AttributeName": "Status", "KeyType": "HASH"}], "Projection": {"ProjectionType": "ALL"}},
+                {"IndexName": "PriorityIndex", "KeySchema": [{"AttributeName": "Priority", "KeyType": "HASH"}], "Projection": {"ProjectionType": "ALL"}}
+            ]
+        }))
+        .unwrap();
+        pollster::block_on(create_table::execute(&storage, create)).unwrap();
+
+        // Break the second GSI's fan-out by dropping its physical table.
+        storage.drop_gsi_table("Orders", "PriorityIndex").unwrap();
+
+        let batch = serde_json::from_value(serde_json::json!({
+            "RequestItems": {
+                "Orders": [
+                    {"PutRequest": {"Item": {"UserId": {"S": "u1"}, "Status": {"S": "SHIPPED"}, "Priority": {"S": "HIGH"}}}}
+                ]
+            }
+        }))
+        .unwrap();
+        let res = pollster::block_on(batch_write_item::execute(&storage, batch));
+        assert!(
+            res.is_err(),
+            "a mid-fan-out failure must surface as an error"
+        );
+
+        // The base write must roll back: no item landed.
+        let count =
+            pollster::block_on(<Storage as StorageBackend>::count_items(&storage, "Orders"))
+                .unwrap();
+        assert_eq!(
+            count, 0,
+            "batch put base write must roll back when fan-out fails"
+        );
+    }
 }

--- a/src/actions/batch_write_item.rs
+++ b/src/actions/batch_write_item.rs
@@ -1,6 +1,6 @@
 use crate::actions::helpers;
 use crate::errors::{DynoxideError, Result};
-use crate::storage::Storage;
+use crate::storage_backend::StorageBackend;
 use crate::types::{self, AttributeValue, Item};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -48,8 +48,8 @@ pub struct BatchWriteItemResponse {
     pub item_collection_metrics: Option<HashMap<String, Vec<crate::types::ItemCollectionMetrics>>>,
 }
 
-pub fn execute(
-    storage: &Storage,
+pub async fn execute<S: StorageBackend>(
+    storage: &S,
     mut request: BatchWriteItemRequest,
 ) -> Result<BatchWriteItemResponse> {
     const MAX_REQUEST_SIZE: usize = 16 * 1024 * 1024; // 16MB
@@ -156,7 +156,7 @@ pub fn execute(
         let mut seen_keys: std::collections::HashSet<(String, String, String)> =
             std::collections::HashSet::new();
         for (table_name, write_requests) in &request.request_items {
-            let meta = helpers::require_table_for_item_op(storage, table_name)?;
+            let meta = helpers::require_table_for_item_op(storage, table_name).await?;
             let key_schema = helpers::parse_key_schema(&meta)?;
             for wr in write_requests {
                 let key_item = if let Some(ref put) = wr.put_request {
@@ -192,7 +192,7 @@ pub fn execute(
     // level and pass pre-parsed defs into the maintenance functions.
 
     for (table_name, write_requests) in &mut request.request_items {
-        let meta = helpers::require_table_for_item_op(storage, table_name)?;
+        let meta = helpers::require_table_for_item_op(storage, table_name).await?;
         let key_schema = helpers::parse_key_schema(&meta)?;
 
         for wr in write_requests {
@@ -223,14 +223,9 @@ pub fn execute(
                     .get(&key_schema.partition_key)
                     .map(crate::storage::compute_hash_prefix)
                     .unwrap_or_default();
-                let old_json = storage.put_item_with_hash(
-                    table_name,
-                    &pk,
-                    &sk,
-                    &item_json,
-                    size,
-                    &hash_prefix,
-                )?;
+                let old_json = storage
+                    .put_item_with_hash(table_name, &pk, &sk, &item_json, size, &hash_prefix)
+                    .await?;
 
                 // Accumulate WCU based on item size
                 *table_wcu.entry(table_name.clone()).or_insert(0.0) +=
@@ -246,7 +241,8 @@ pub fn execute(
                     &put_req.item,
                     &key_schema.partition_key,
                     key_schema.sort_key.as_deref(),
-                )?;
+                )
+                .await?;
 
                 // Accumulate GSI units per table
                 let table_entry = table_gsi_units.entry(table_name.clone()).or_default();
@@ -264,7 +260,8 @@ pub fn execute(
                     &put_req.item,
                     &key_schema.partition_key,
                     key_schema.sort_key.as_deref(),
-                )?;
+                )
+                .await?;
 
                 // Track affected partition for deferred metrics
                 if let Some(pk_val) = put_req.item.get(&key_schema.partition_key) {
@@ -283,12 +280,13 @@ pub fn execute(
                     &meta,
                     old_item.as_ref(),
                     Some(&put_req.item),
-                )?;
+                )
+                .await?;
             } else if let Some(ref del_req) = wr.delete_request {
                 helpers::validate_key_only(&del_req.key, &key_schema)?;
                 // TODO: validation must precede this call -- if reaching this line, caller has already validated keys.
                 let (pk, sk) = helpers::extract_key_strings(&del_req.key, &key_schema)?;
-                let old_json = storage.delete_item(table_name, &pk, &sk)?;
+                let old_json = storage.delete_item(table_name, &pk, &sk).await?;
 
                 // Accumulate WCU: based on old item size if it existed, else 1 WCU
                 let old_item: Option<Item> =
@@ -302,7 +300,8 @@ pub fn execute(
 
                 // Maintain GSI tables
                 let gsi_units =
-                    super::gsi::maintain_gsis_after_delete(storage, table_name, &meta, &pk, &sk)?;
+                    super::gsi::maintain_gsis_after_delete(storage, table_name, &meta, &pk, &sk)
+                        .await?;
 
                 // Accumulate GSI units per table
                 let table_entry = table_gsi_units.entry(table_name.clone()).or_default();
@@ -311,7 +310,8 @@ pub fn execute(
                 }
 
                 // Maintain LSI tables
-                super::lsi::maintain_lsis_after_delete(storage, table_name, &meta, &pk, &sk)?;
+                super::lsi::maintain_lsis_after_delete(storage, table_name, &meta, &pk, &sk)
+                    .await?;
 
                 // Track affected partition for deferred metrics
                 if let Some(pk_val) = del_req.key.get(&key_schema.partition_key) {
@@ -325,7 +325,8 @@ pub fn execute(
 
                 // Record stream event (old_item already parsed above)
                 if old_item.is_some() {
-                    crate::streams::record_stream_event(storage, &meta, old_item.as_ref(), None)?;
+                    crate::streams::record_stream_event(storage, &meta, old_item.as_ref(), None)
+                        .await?;
                 }
             } else {
                 return Err(DynoxideError::ValidationException(
@@ -372,7 +373,7 @@ pub fn execute(
             if !seen.insert(key) {
                 continue;
             }
-            let meta = helpers::require_table(storage, tbl)?;
+            let meta = helpers::require_table(storage, tbl).await?;
             if let Some(icm) = helpers::build_item_collection_metrics(
                 storage,
                 &meta,
@@ -381,7 +382,9 @@ pub fn execute(
                 pk_attr,
                 pk_val,
                 &request.return_item_collection_metrics,
-            )? {
+            )
+            .await?
+            {
                 all_item_collection_metrics
                     .entry(tbl.clone())
                     .or_default()

--- a/src/actions/create_table.rs
+++ b/src/actions/create_table.rs
@@ -176,7 +176,7 @@ pub fn execute(storage: &Storage, request: CreateTableRequest) -> Result<CreateT
                 .stream_view_type
                 .as_deref()
                 .unwrap_or("NEW_AND_OLD_IMAGES");
-            let label = streams::generate_stream_label();
+            let label = streams::generate_stream_label(storage.clock());
             storage.enable_stream(&request.table_name, view_type, &label)?;
         }
     }

--- a/src/actions/create_table.rs
+++ b/src/actions/create_table.rs
@@ -1,6 +1,6 @@
 use crate::actions::{TableDescription, build_table_description};
 use crate::errors::{DynoxideError, Result};
-use crate::storage::Storage;
+use crate::storage_backend::StorageBackend;
 use crate::streams;
 use crate::types::{
     AttributeDefinition, GlobalSecondaryIndex, KeySchemaElement, KeyType, LocalSecondaryIndex,
@@ -85,7 +85,10 @@ pub struct CreateTableResponse {
     pub table_description: TableDescription,
 }
 
-pub fn execute(storage: &Storage, request: CreateTableRequest) -> Result<CreateTableResponse> {
+pub async fn execute<S: StorageBackend>(
+    storage: &S,
+    request: CreateTableRequest,
+) -> Result<CreateTableResponse> {
     // Structural validation (runs for both programmatic and JSON paths)
     validate_typed_request(&request)?;
 
@@ -99,7 +102,7 @@ pub fn execute(storage: &Storage, request: CreateTableRequest) -> Result<CreateT
         }
     }
 
-    if storage.table_exists(&request.table_name)? {
+    if storage.table_exists(&request.table_name).await? {
         return Err(DynoxideError::ResourceInUseException(format!(
             "Table already exists: {}",
             request.table_name
@@ -142,31 +145,37 @@ pub fn execute(storage: &Storage, request: CreateTableRequest) -> Result<CreateT
     let deletion_protection = request.deletion_protection_enabled.unwrap_or(false);
 
     let billing_mode_str = request.billing_mode.as_deref().unwrap_or("PROVISIONED");
-    storage.insert_table_metadata(&crate::storage::CreateTableMetadata {
-        table_name: &request.table_name,
-        key_schema: &key_schema_json,
-        attribute_definitions: &attr_defs_json,
-        gsi_definitions: gsi_json.as_deref(),
-        lsi_definitions: lsi_json.as_deref(),
-        provisioned_throughput: pt_json.as_deref(),
-        created_at: now,
-        sse_specification: sse_json.as_deref(),
-        table_class: request.table_class.as_deref(),
-        deletion_protection_enabled: deletion_protection,
-        billing_mode: Some(billing_mode_str),
-    })?;
+    storage
+        .insert_table_metadata(&crate::storage::CreateTableMetadata {
+            table_name: &request.table_name,
+            key_schema: &key_schema_json,
+            attribute_definitions: &attr_defs_json,
+            gsi_definitions: gsi_json.as_deref(),
+            lsi_definitions: lsi_json.as_deref(),
+            provisioned_throughput: pt_json.as_deref(),
+            created_at: now,
+            sse_specification: sse_json.as_deref(),
+            table_class: request.table_class.as_deref(),
+            deletion_protection_enabled: deletion_protection,
+            billing_mode: Some(billing_mode_str),
+        })
+        .await?;
 
-    storage.create_data_table(&request.table_name)?;
+    storage.create_data_table(&request.table_name).await?;
 
     if let Some(ref gsis) = request.global_secondary_indexes {
         for gsi in gsis {
-            storage.create_gsi_table(&request.table_name, &gsi.index_name)?;
+            storage
+                .create_gsi_table(&request.table_name, &gsi.index_name)
+                .await?;
         }
     }
 
     if let Some(ref lsis) = request.local_secondary_indexes {
         for lsi in lsis {
-            storage.create_lsi_table(&request.table_name, &lsi.index_name)?;
+            storage
+                .create_lsi_table(&request.table_name, &lsi.index_name)
+                .await?;
         }
     }
 
@@ -177,18 +186,21 @@ pub fn execute(storage: &Storage, request: CreateTableRequest) -> Result<CreateT
                 .as_deref()
                 .unwrap_or("NEW_AND_OLD_IMAGES");
             let label = streams::generate_stream_label(storage.clock());
-            storage.enable_stream(&request.table_name, view_type, &label)?;
+            storage
+                .enable_stream(&request.table_name, view_type, &label)
+                .await?;
         }
     }
 
     if let Some(ref tags) = request.tags {
         if !tags.is_empty() {
-            storage.set_tags(&request.table_name, tags)?;
+            storage.set_tags(&request.table_name, tags).await?;
         }
     }
 
     let meta = storage
-        .get_table_metadata(&request.table_name)?
+        .get_table_metadata(&request.table_name)
+        .await?
         .ok_or_else(|| {
             DynoxideError::InternalServerError("Table metadata not found after creation".into())
         })?;

--- a/src/actions/delete_item.rs
+++ b/src/actions/delete_item.rs
@@ -375,3 +375,63 @@ pub async fn execute<S: StorageBackend>(
         item_collection_metrics,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::actions::{create_table, delete_item, put_item};
+    use crate::storage::Storage;
+    use crate::storage_backend::StorageBackend;
+
+    fn seed_two_gsi_table_with_item(storage: &Storage) {
+        let create = serde_json::from_value(serde_json::json!({
+            "TableName": "Orders",
+            "KeySchema": [{"AttributeName": "UserId", "KeyType": "HASH"}],
+            "AttributeDefinitions": [
+                {"AttributeName": "UserId", "AttributeType": "S"},
+                {"AttributeName": "Status", "AttributeType": "S"},
+                {"AttributeName": "Priority", "AttributeType": "S"}
+            ],
+            "GlobalSecondaryIndexes": [
+                {"IndexName": "StatusIndex", "KeySchema": [{"AttributeName": "Status", "KeyType": "HASH"}], "Projection": {"ProjectionType": "ALL"}},
+                {"IndexName": "PriorityIndex", "KeySchema": [{"AttributeName": "Priority", "KeyType": "HASH"}], "Projection": {"ProjectionType": "ALL"}}
+            ]
+        }))
+        .unwrap();
+        pollster::block_on(create_table::execute(storage, create)).unwrap();
+
+        let put = serde_json::from_value(serde_json::json!({
+            "TableName": "Orders",
+            "Item": {"UserId": {"S": "u1"}, "Status": {"S": "SHIPPED"}, "Priority": {"S": "HIGH"}}
+        }))
+        .unwrap();
+        pollster::block_on(put_item::execute(storage, put)).unwrap();
+    }
+
+    /// A delete and its GSI fan-out succeed or fail as one unit: a mid-fan-out
+    /// failure leaves the item (and its index entries) in place.
+    #[test]
+    fn delete_item_rolls_back_base_delete_when_gsi_fan_out_fails() {
+        let storage = Storage::memory().unwrap();
+        seed_two_gsi_table_with_item(&storage);
+
+        // Break the second GSI's fan-out by dropping its physical table.
+        storage.drop_gsi_table("Orders", "PriorityIndex").unwrap();
+
+        let del = serde_json::from_value(serde_json::json!({
+            "TableName": "Orders",
+            "Key": {"UserId": {"S": "u1"}}
+        }))
+        .unwrap();
+        let res = pollster::block_on(delete_item::execute(&storage, del));
+        assert!(
+            res.is_err(),
+            "a mid-fan-out failure must surface as an error"
+        );
+
+        // The base delete must roll back: the item is still present.
+        let count =
+            pollster::block_on(<Storage as StorageBackend>::count_items(&storage, "Orders"))
+                .unwrap();
+        assert_eq!(count, 1, "base delete must roll back when fan-out fails");
+    }
+}

--- a/src/actions/delete_item.rs
+++ b/src/actions/delete_item.rs
@@ -280,9 +280,7 @@ pub async fn execute<S: StorageBackend>(
     // transaction so a mid-fan-out failure rolls the whole delete back, leaving
     // no torn index. Unconditional (not just for ConditionExpression) because
     // the atomicity guarantee applies to every single-item write.
-    storage.begin_transaction().await?;
-
-    let write_result: Result<(Option<String>, HashMap<String, f64>)> = async {
+    let (old_item, gsi_units) = helpers::with_write_transaction(storage, async {
         // Evaluate ConditionExpression against existing item
         if let Some(ref cond_expr) = request.condition_expression {
             let existing_json = storage.get_item(&request.table_name, &pk, &sk).await?;
@@ -326,29 +324,17 @@ pub async fn execute<S: StorageBackend>(
         super::lsi::maintain_lsis_after_delete(storage, &request.table_name, &meta, &pk, &sk)
             .await?;
 
+        // Parse the old item once, here, for the stream record and the response.
+        let old_item: Option<Item> = old_json.as_ref().and_then(|j| serde_json::from_str(j).ok());
+
         // Record stream event (inside the transaction)
-        let old_item_for_stream: Option<Item> =
-            old_json.as_ref().and_then(|j| serde_json::from_str(j).ok());
-        if old_item_for_stream.is_some() {
-            crate::streams::record_stream_event(storage, &meta, old_item_for_stream.as_ref(), None)
-                .await?;
+        if old_item.is_some() {
+            crate::streams::record_stream_event(storage, &meta, old_item.as_ref(), None).await?;
         }
 
-        Ok((old_json, gsi_units))
-    }
-    .await;
-
-    // Commit on success, roll back the whole delete on any failure.
-    match write_result {
-        Ok(_) => storage.commit().await?,
-        Err(ref _e) => {
-            let _ = storage.rollback().await;
-        }
-    }
-
-    let (old_json, gsi_units) = write_result?;
-    let old_item_for_stream: Option<Item> =
-        old_json.as_ref().and_then(|j| serde_json::from_str(j).ok());
+        Ok((old_item, gsi_units))
+    })
+    .await?;
 
     // Handle ReturnValues
     let return_old = request
@@ -357,11 +343,7 @@ pub async fn execute<S: StorageBackend>(
         .unwrap_or("NONE")
         .eq_ignore_ascii_case("ALL_OLD");
 
-    let attributes = if return_old {
-        old_json.and_then(|json| serde_json::from_str::<Item>(&json).ok())
-    } else {
-        None
-    };
+    let attributes = if return_old { old_item.clone() } else { None };
 
     // Build item collection metrics (only for tables with LSIs)
     let pk_value = request.key.get(&key_schema.partition_key).cloned();
@@ -379,10 +361,7 @@ pub async fn execute<S: StorageBackend>(
     .await?;
 
     // Calculate consumed capacity from old item size (write for delete)
-    let old_size = old_item_for_stream
-        .as_ref()
-        .map(types::item_size)
-        .unwrap_or(0);
+    let old_size = old_item.as_ref().map(types::item_size).unwrap_or(0);
     let consumed_capacity = types::consumed_capacity_with_indexes(
         &request.table_name,
         types::write_capacity_units(old_size),

--- a/src/actions/delete_item.rs
+++ b/src/actions/delete_item.rs
@@ -1,6 +1,6 @@
 use crate::actions::helpers;
 use crate::errors::{DynoxideError, Result};
-use crate::storage::Storage;
+use crate::storage_backend::StorageBackend;
 use crate::types::{self, AttributeValue, Item};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -145,7 +145,10 @@ pub struct DeleteItemResponse {
     pub item_collection_metrics: Option<crate::types::ItemCollectionMetrics>,
 }
 
-pub fn execute(storage: &Storage, mut request: DeleteItemRequest) -> Result<DeleteItemResponse> {
+pub async fn execute<S: StorageBackend>(
+    storage: &S,
+    mut request: DeleteItemRequest,
+) -> Result<DeleteItemResponse> {
     // Validate table name format before checking existence (DynamoDB validates input first)
     crate::validation::validate_table_name(&request.table_name)?;
 
@@ -238,7 +241,7 @@ pub fn execute(storage: &Storage, mut request: DeleteItemRequest) -> Result<Dele
         }
     }
 
-    let meta = helpers::require_table_for_item_op(storage, &request.table_name)?;
+    let meta = helpers::require_table_for_item_op(storage, &request.table_name).await?;
     let key_schema = helpers::parse_key_schema(&meta)?;
 
     // Validate ReturnValues parameter (DeleteItem only supports NONE and ALL_OLD)
@@ -276,13 +279,13 @@ pub fn execute(storage: &Storage, mut request: DeleteItemRequest) -> Result<Dele
     // Wrap condition check + delete in a transaction to prevent TOCTOU races
     let has_condition = request.condition_expression.is_some();
     if has_condition {
-        storage.begin_transaction()?;
+        storage.begin_transaction().await?;
     }
 
-    let conditional_result = (|| -> Result<Option<String>> {
+    let conditional_result: Result<Option<String>> = async {
         // Evaluate ConditionExpression against existing item
         if let Some(ref cond_expr) = request.condition_expression {
-            let existing_json = storage.get_item(&request.table_name, &pk, &sk)?;
+            let existing_json = storage.get_item(&request.table_name, &pk, &sk).await?;
             let existing_item: HashMap<String, AttributeValue> = existing_json
                 .as_ref()
                 .and_then(|j| serde_json::from_str(j).ok())
@@ -312,15 +315,16 @@ pub fn execute(storage: &Storage, mut request: DeleteItemRequest) -> Result<Dele
         tracker.check_unused()?;
 
         // Delete item (returns old item_json)
-        storage.delete_item(&request.table_name, &pk, &sk)
-    })();
+        Ok(storage.delete_item(&request.table_name, &pk, &sk).await?)
+    }
+    .await;
 
     // Handle transaction commit/rollback
     if has_condition {
         match conditional_result {
-            Ok(_) => storage.commit()?,
+            Ok(_) => storage.commit().await?,
             Err(ref _e) => {
-                let _ = storage.rollback();
+                let _ = storage.rollback().await;
             }
         }
     }
@@ -329,16 +333,18 @@ pub fn execute(storage: &Storage, mut request: DeleteItemRequest) -> Result<Dele
 
     // Maintain GSI tables
     let gsi_units =
-        super::gsi::maintain_gsis_after_delete(storage, &request.table_name, &meta, &pk, &sk)?;
+        super::gsi::maintain_gsis_after_delete(storage, &request.table_name, &meta, &pk, &sk)
+            .await?;
 
     // Maintain LSI tables
-    super::lsi::maintain_lsis_after_delete(storage, &request.table_name, &meta, &pk, &sk)?;
+    super::lsi::maintain_lsis_after_delete(storage, &request.table_name, &meta, &pk, &sk).await?;
 
     // Record stream event
     let old_item_for_stream: Option<Item> =
         old_json.as_ref().and_then(|j| serde_json::from_str(j).ok());
     if old_item_for_stream.is_some() {
-        crate::streams::record_stream_event(storage, &meta, old_item_for_stream.as_ref(), None)?;
+        crate::streams::record_stream_event(storage, &meta, old_item_for_stream.as_ref(), None)
+            .await?;
     }
 
     // Handle ReturnValues
@@ -366,7 +372,8 @@ pub fn execute(storage: &Storage, mut request: DeleteItemRequest) -> Result<Dele
             .as_ref()
             .unwrap_or(&AttributeValue::S(String::new())),
         &request.return_item_collection_metrics,
-    )?;
+    )
+    .await?;
 
     // Calculate consumed capacity from old item size (write for delete)
     let old_size = old_item_for_stream

--- a/src/actions/delete_item.rs
+++ b/src/actions/delete_item.rs
@@ -276,13 +276,13 @@ pub async fn execute<S: StorageBackend>(
         }
     }
 
-    // Wrap condition check + delete in a transaction to prevent TOCTOU races
-    let has_condition = request.condition_expression.is_some();
-    if has_condition {
-        storage.begin_transaction().await?;
-    }
+    // Wrap the condition check, base delete and the GSI/LSI fan-out in a single
+    // transaction so a mid-fan-out failure rolls the whole delete back, leaving
+    // no torn index. Unconditional (not just for ConditionExpression) because
+    // the atomicity guarantee applies to every single-item write.
+    storage.begin_transaction().await?;
 
-    let conditional_result: Result<Option<String>> = async {
+    let write_result: Result<(Option<String>, HashMap<String, f64>)> = async {
         // Evaluate ConditionExpression against existing item
         if let Some(ref cond_expr) = request.condition_expression {
             let existing_json = storage.get_item(&request.table_name, &pk, &sk).await?;
@@ -315,37 +315,40 @@ pub async fn execute<S: StorageBackend>(
         tracker.check_unused()?;
 
         // Delete item (returns old item_json)
-        Ok(storage.delete_item(&request.table_name, &pk, &sk).await?)
+        let old_json = storage.delete_item(&request.table_name, &pk, &sk).await?;
+
+        // Maintain GSI tables (inside the transaction)
+        let gsi_units =
+            super::gsi::maintain_gsis_after_delete(storage, &request.table_name, &meta, &pk, &sk)
+                .await?;
+
+        // Maintain LSI tables (inside the transaction)
+        super::lsi::maintain_lsis_after_delete(storage, &request.table_name, &meta, &pk, &sk)
+            .await?;
+
+        // Record stream event (inside the transaction)
+        let old_item_for_stream: Option<Item> =
+            old_json.as_ref().and_then(|j| serde_json::from_str(j).ok());
+        if old_item_for_stream.is_some() {
+            crate::streams::record_stream_event(storage, &meta, old_item_for_stream.as_ref(), None)
+                .await?;
+        }
+
+        Ok((old_json, gsi_units))
     }
     .await;
 
-    // Handle transaction commit/rollback
-    if has_condition {
-        match conditional_result {
-            Ok(_) => storage.commit().await?,
-            Err(ref _e) => {
-                let _ = storage.rollback().await;
-            }
+    // Commit on success, roll back the whole delete on any failure.
+    match write_result {
+        Ok(_) => storage.commit().await?,
+        Err(ref _e) => {
+            let _ = storage.rollback().await;
         }
     }
 
-    let old_json = conditional_result?;
-
-    // Maintain GSI tables
-    let gsi_units =
-        super::gsi::maintain_gsis_after_delete(storage, &request.table_name, &meta, &pk, &sk)
-            .await?;
-
-    // Maintain LSI tables
-    super::lsi::maintain_lsis_after_delete(storage, &request.table_name, &meta, &pk, &sk).await?;
-
-    // Record stream event
+    let (old_json, gsi_units) = write_result?;
     let old_item_for_stream: Option<Item> =
         old_json.as_ref().and_then(|j| serde_json::from_str(j).ok());
-    if old_item_for_stream.is_some() {
-        crate::streams::record_stream_event(storage, &meta, old_item_for_stream.as_ref(), None)
-            .await?;
-    }
 
     // Handle ReturnValues
     let return_old = request

--- a/src/actions/delete_table.rs
+++ b/src/actions/delete_table.rs
@@ -1,6 +1,6 @@
 use crate::actions::{TableDescription, build_table_description};
 use crate::errors::{DynoxideError, Result};
-use crate::storage::Storage;
+use crate::storage_backend::StorageBackend;
 use crate::types::{GlobalSecondaryIndex, LocalSecondaryIndex};
 use serde::{Deserialize, Serialize};
 
@@ -59,13 +59,17 @@ pub struct DeleteTableResponse {
     pub table_description: TableDescription,
 }
 
-pub fn execute(storage: &Storage, request: DeleteTableRequest) -> Result<DeleteTableResponse> {
+pub async fn execute<S: StorageBackend>(
+    storage: &S,
+    request: DeleteTableRequest,
+) -> Result<DeleteTableResponse> {
     // Validate table name format before checking existence (DynamoDB validates input first)
     crate::validation::validate_table_name(&request.table_name)?;
 
     // Get metadata before deletion (for the response)
     let meta = storage
-        .get_table_metadata(&request.table_name)?
+        .get_table_metadata(&request.table_name)
+        .await?
         .ok_or_else(|| {
             DynoxideError::ResourceNotFoundException(format!(
                 "Requested resource not found: Table: {} not found",
@@ -85,7 +89,9 @@ pub fn execute(storage: &Storage, request: DeleteTableRequest) -> Result<DeleteT
     if let Some(ref gsi_json) = meta.gsi_definitions {
         if let Ok(gsis) = serde_json::from_str::<Vec<GlobalSecondaryIndex>>(gsi_json) {
             for gsi in &gsis {
-                storage.drop_gsi_table(&request.table_name, &gsi.index_name)?;
+                storage
+                    .drop_gsi_table(&request.table_name, &gsi.index_name)
+                    .await?;
             }
         }
     }
@@ -94,16 +100,18 @@ pub fn execute(storage: &Storage, request: DeleteTableRequest) -> Result<DeleteT
     if let Some(ref lsi_json) = meta.lsi_definitions {
         if let Ok(lsis) = serde_json::from_str::<Vec<LocalSecondaryIndex>>(lsi_json) {
             for lsi in &lsis {
-                storage.drop_lsi_table(&request.table_name, &lsi.index_name)?;
+                storage
+                    .drop_lsi_table(&request.table_name, &lsi.index_name)
+                    .await?;
             }
         }
     }
 
     // Drop data table
-    storage.drop_data_table(&request.table_name)?;
+    storage.drop_data_table(&request.table_name).await?;
 
     // Delete metadata
-    storage.delete_table_metadata(&request.table_name)?;
+    storage.delete_table_metadata(&request.table_name).await?;
 
     // Build response with DELETING status
     let mut desc = build_table_description(&meta, Some(0), Some(0));

--- a/src/actions/describe_stream.rs
+++ b/src/actions/describe_stream.rs
@@ -1,5 +1,5 @@
 use crate::errors::{DynoxideError, Result};
-use crate::storage::Storage;
+use crate::storage_backend::StorageBackend;
 use crate::streams;
 use serde::{Deserialize, Serialize};
 
@@ -59,8 +59,8 @@ pub struct SequenceNumberRange {
     pub ending_sequence_number: Option<String>,
 }
 
-pub fn execute(
-    storage: &Storage,
+pub async fn execute<S: StorageBackend>(
+    storage: &S,
     request: DescribeStreamRequest,
 ) -> Result<DescribeStreamResponse> {
     // Parse table name from ARN
@@ -71,12 +71,15 @@ pub fn execute(
         ))
     })?;
 
-    let meta = storage.get_table_metadata(&table_name)?.ok_or_else(|| {
-        DynoxideError::ResourceNotFoundException(format!(
-            "Requested resource not found: Stream: {}",
-            request.stream_arn
-        ))
-    })?;
+    let meta = storage
+        .get_table_metadata(&table_name)
+        .await?
+        .ok_or_else(|| {
+            DynoxideError::ResourceNotFoundException(format!(
+                "Requested resource not found: Stream: {}",
+                request.stream_arn
+            ))
+        })?;
 
     if !meta.stream_enabled {
         return Err(DynoxideError::ResourceNotFoundException(format!(
@@ -87,7 +90,7 @@ pub fn execute(
 
     let label = meta.stream_label.clone().unwrap_or_default();
     let sid = streams::shard_id(&table_name);
-    let (start_seq, end_seq) = storage.get_shard_sequence_range(&table_name, &sid)?;
+    let (start_seq, end_seq) = storage.get_shard_sequence_range(&table_name, &sid).await?;
 
     Ok(DescribeStreamResponse {
         stream_description: StreamDescription {

--- a/src/actions/describe_table.rs
+++ b/src/actions/describe_table.rs
@@ -1,6 +1,6 @@
 use crate::actions::{TableDescription, build_table_description};
 use crate::errors::{DynoxideError, Result};
-use crate::storage::Storage;
+use crate::storage_backend::StorageBackend;
 use serde::{Deserialize, Serialize};
 
 /// Internal deserialization struct for detecting missing TableName.
@@ -58,12 +58,16 @@ pub struct DescribeTableResponse {
     pub table: TableDescription,
 }
 
-pub fn execute(storage: &Storage, request: DescribeTableRequest) -> Result<DescribeTableResponse> {
+pub async fn execute<S: StorageBackend>(
+    storage: &S,
+    request: DescribeTableRequest,
+) -> Result<DescribeTableResponse> {
     // Validate table name format before checking existence (DynamoDB validates input first)
     crate::validation::validate_table_name(&request.table_name)?;
 
     let meta = storage
-        .get_table_metadata(&request.table_name)?
+        .get_table_metadata(&request.table_name)
+        .await?
         .ok_or_else(|| {
             DynoxideError::ResourceNotFoundException(format!(
                 "Requested resource not found: Table: {} not found",
@@ -72,7 +76,7 @@ pub fn execute(storage: &Storage, request: DescribeTableRequest) -> Result<Descr
         })?;
 
     // Get actual item count and size
-    let item_count = storage.count_items(&request.table_name).ok();
+    let item_count = storage.count_items(&request.table_name).await.ok();
     let table_size_bytes = item_count.map(|_| 0i64); // Approximate; real size tracking is deferred
 
     let desc = build_table_description(&meta, item_count, table_size_bytes);

--- a/src/actions/describe_time_to_live.rs
+++ b/src/actions/describe_time_to_live.rs
@@ -1,5 +1,5 @@
 use crate::errors::{DynoxideError, Result};
-use crate::storage::Storage;
+use crate::storage_backend::StorageBackend;
 use serde::{Deserialize, Serialize};
 
 /// Internal raw deserialization struct.
@@ -55,8 +55,8 @@ pub struct TimeToLiveDescription {
     pub attribute_name: Option<String>,
 }
 
-pub fn execute(
-    storage: &Storage,
+pub async fn execute<S: StorageBackend>(
+    storage: &S,
     request: DescribeTimeToLiveRequest,
 ) -> Result<DescribeTimeToLiveResponse> {
     // Table name format validation already done in Deserialize impl;
@@ -64,7 +64,8 @@ pub fn execute(
     crate::validation::validate_table_name(&request.table_name)?;
 
     let meta = storage
-        .get_table_metadata(&request.table_name)?
+        .get_table_metadata(&request.table_name)
+        .await?
         .ok_or_else(|| {
             DynoxideError::ResourceNotFoundException(format!(
                 "Requested resource not found: Table: {} not found",

--- a/src/actions/execute_statement.rs
+++ b/src/actions/execute_statement.rs
@@ -1,6 +1,6 @@
 use crate::errors::{DynoxideError, Result};
 use crate::partiql;
-use crate::storage::Storage;
+use crate::storage_backend::StorageBackend;
 use crate::types::{AttributeValue, Item};
 use serde::{Deserialize, Serialize};
 
@@ -28,8 +28,8 @@ pub struct ExecuteStatementResponse {
     pub next_token: Option<String>,
 }
 
-pub fn execute(
-    storage: &Storage,
+pub async fn execute<S: StorageBackend>(
+    storage: &S,
     request: ExecuteStatementRequest,
 ) -> Result<ExecuteStatementResponse> {
     let stmt = partiql::parser::parse(&request.statement).map_err(|e| {
@@ -37,7 +37,7 @@ pub fn execute(
     })?;
 
     let params = request.parameters.unwrap_or_default();
-    let result = partiql::executor::execute(storage, &stmt, &params, request.limit)?;
+    let result = partiql::executor::execute(storage, &stmt, &params, request.limit).await?;
 
     Ok(ExecuteStatementResponse {
         items: result,

--- a/src/actions/execute_transaction.rs
+++ b/src/actions/execute_transaction.rs
@@ -1,3 +1,4 @@
+use crate::actions::helpers;
 use crate::errors::{CancellationReason, DynoxideError, Result};
 use crate::partiql;
 use crate::storage_backend::StorageBackend;
@@ -66,57 +67,39 @@ pub async fn execute<S: StorageBackend>(
         parsed.push((ast, params));
     }
 
-    // Begin SQLite transaction
-    storage.begin_transaction().await?;
+    // All statements run inside one SQLite transaction (all-or-nothing).
+    let responses =
+        helpers::with_write_transaction(storage, execute_within_transaction(storage, &parsed))
+            .await?;
 
-    let result = execute_within_transaction(storage, &parsed).await;
-
-    match result {
-        Ok(responses) => {
-            storage.commit().await?;
-
-            // Build ConsumedCapacity if requested (simple estimate: 1 WCU per statement)
-            let consumed_capacity = if matches!(
-                request.return_consumed_capacity.as_deref(),
-                Some("TOTAL") | Some("INDEXES")
-            ) {
-                // Aggregate capacity by table name from parsed statements
-                let mut table_units: std::collections::HashMap<String, f64> =
-                    std::collections::HashMap::new();
-                for (stmt, _) in &parsed {
-                    if let Some(tbl) = partiql::parser::table_name(stmt) {
-                        *table_units.entry(tbl.to_string()).or_default() += 1.0;
-                    }
-                }
-                let caps: Vec<_> = table_units
-                    .iter()
-                    .filter_map(|(table, &units)| {
-                        crate::types::consumed_capacity(
-                            table,
-                            units,
-                            &request.return_consumed_capacity,
-                        )
-                    })
-                    .collect();
-                Some(caps)
-            } else {
-                None
-            };
-
-            Ok(ExecuteTransactionResponse {
-                responses: Some(responses),
-                consumed_capacity,
-            })
-        }
-        Err(e) => {
-            if let Err(rb_err) = storage.rollback().await {
-                return Err(DynoxideError::InternalServerError(format!(
-                    "Transaction failed ({e}) and rollback also failed ({rb_err})"
-                )));
+    // Build ConsumedCapacity if requested (simple estimate: 1 WCU per statement)
+    let consumed_capacity = if matches!(
+        request.return_consumed_capacity.as_deref(),
+        Some("TOTAL") | Some("INDEXES")
+    ) {
+        // Aggregate capacity by table name from parsed statements
+        let mut table_units: std::collections::HashMap<String, f64> =
+            std::collections::HashMap::new();
+        for (stmt, _) in &parsed {
+            if let Some(tbl) = partiql::parser::table_name(stmt) {
+                *table_units.entry(tbl.to_string()).or_default() += 1.0;
             }
-            Err(e)
         }
-    }
+        let caps: Vec<_> = table_units
+            .iter()
+            .filter_map(|(table, &units)| {
+                crate::types::consumed_capacity(table, units, &request.return_consumed_capacity)
+            })
+            .collect();
+        Some(caps)
+    } else {
+        None
+    };
+
+    Ok(ExecuteTransactionResponse {
+        responses: Some(responses),
+        consumed_capacity,
+    })
 }
 
 async fn execute_within_transaction<S: StorageBackend>(

--- a/src/actions/execute_transaction.rs
+++ b/src/actions/execute_transaction.rs
@@ -1,6 +1,6 @@
 use crate::errors::{CancellationReason, DynoxideError, Result};
 use crate::partiql;
-use crate::storage::Storage;
+use crate::storage_backend::StorageBackend;
 use crate::types::{AttributeValue, Item};
 use serde::{Deserialize, Serialize};
 
@@ -36,8 +36,8 @@ pub struct ItemResponse {
     pub item: Option<Item>,
 }
 
-pub fn execute(
-    storage: &Storage,
+pub async fn execute<S: StorageBackend>(
+    storage: &S,
     request: ExecuteTransactionRequest,
 ) -> Result<ExecuteTransactionResponse> {
     let statements = &request.transact_statements;
@@ -67,13 +67,13 @@ pub fn execute(
     }
 
     // Begin SQLite transaction
-    storage.begin_transaction()?;
+    storage.begin_transaction().await?;
 
-    let result = execute_within_transaction(storage, &parsed);
+    let result = execute_within_transaction(storage, &parsed).await;
 
     match result {
         Ok(responses) => {
-            storage.commit()?;
+            storage.commit().await?;
 
             // Build ConsumedCapacity if requested (simple estimate: 1 WCU per statement)
             let consumed_capacity = if matches!(
@@ -109,7 +109,7 @@ pub fn execute(
             })
         }
         Err(e) => {
-            if let Err(rb_err) = storage.rollback() {
+            if let Err(rb_err) = storage.rollback().await {
                 return Err(DynoxideError::InternalServerError(format!(
                     "Transaction failed ({e}) and rollback also failed ({rb_err})"
                 )));
@@ -119,15 +119,15 @@ pub fn execute(
     }
 }
 
-fn execute_within_transaction(
-    storage: &Storage,
+async fn execute_within_transaction<S: StorageBackend>(
+    storage: &S,
     parsed: &[(partiql::parser::Statement, Vec<AttributeValue>)],
 ) -> Result<Vec<ItemResponse>> {
     let mut responses = Vec::with_capacity(parsed.len());
     let mut cancellation_reasons: Vec<CancellationReason> = Vec::with_capacity(parsed.len());
 
     for (stmt, params) in parsed {
-        match partiql::executor::execute(storage, stmt, params, None) {
+        match partiql::executor::execute(storage, stmt, params, None).await {
             Ok(result) => {
                 let item = result.and_then(|items| items.into_iter().next());
                 responses.push(ItemResponse { item });

--- a/src/actions/get_item.rs
+++ b/src/actions/get_item.rs
@@ -1,6 +1,6 @@
 use crate::actions::helpers;
 use crate::errors::{DynoxideError, Result};
-use crate::storage::Storage;
+use crate::storage_backend::StorageBackend;
 use crate::types::{self, AttributeValue, Item};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -108,7 +108,10 @@ pub struct GetItemResponse {
     pub consumed_capacity: Option<types::ConsumedCapacity>,
 }
 
-pub fn execute(storage: &Storage, request: GetItemRequest) -> Result<GetItemResponse> {
+pub async fn execute<S: StorageBackend>(
+    storage: &S,
+    request: GetItemRequest,
+) -> Result<GetItemResponse> {
     // Validate table name format before checking existence (DynamoDB validates input first)
     crate::validation::validate_table_name(&request.table_name)?;
 
@@ -150,7 +153,7 @@ pub fn execute(storage: &Storage, request: GetItemRequest) -> Result<GetItemResp
         }
     }
 
-    let meta = helpers::require_table_for_item_op(storage, &request.table_name)?;
+    let meta = helpers::require_table_for_item_op(storage, &request.table_name).await?;
     let key_schema = helpers::parse_key_schema(&meta)?;
 
     // Validate key has exactly the right attributes
@@ -161,7 +164,7 @@ pub fn execute(storage: &Storage, request: GetItemRequest) -> Result<GetItemResp
     let (pk, sk) = helpers::extract_key_strings(&request.key, &key_schema)?;
 
     // Fetch item
-    let item_json = storage.get_item(&request.table_name, &pk, &sk)?;
+    let item_json = storage.get_item(&request.table_name, &pk, &sk).await?;
     let item: Option<HashMap<String, AttributeValue>> =
         item_json.and_then(|json| serde_json::from_str::<Item>(&json).ok());
 

--- a/src/actions/get_records.rs
+++ b/src/actions/get_records.rs
@@ -1,5 +1,5 @@
 use crate::errors::{DynoxideError, Result};
-use crate::storage::Storage;
+use crate::storage_backend::StorageBackend;
 use crate::types::Item;
 use serde::{Deserialize, Serialize};
 
@@ -63,24 +63,32 @@ pub struct StreamRecord {
     pub approximate_creation_date_time: f64,
 }
 
-pub fn execute(storage: &Storage, request: GetRecordsRequest) -> Result<GetRecordsResponse> {
+pub async fn execute<S: StorageBackend>(
+    storage: &S,
+    request: GetRecordsRequest,
+) -> Result<GetRecordsResponse> {
     let (table_name, shard_id, position) = super::get_shard_iterator::decode_shard_iterator(
         &request.shard_iterator,
     )
     .ok_or_else(|| DynoxideError::ValidationException("Invalid shard iterator".to_string()))?;
 
-    let meta = storage.get_table_metadata(&table_name)?.ok_or_else(|| {
-        DynoxideError::ResourceNotFoundException(format!(
-            "Requested resource not found: Table: {table_name}"
-        ))
-    })?;
+    let meta = storage
+        .get_table_metadata(&table_name)
+        .await?
+        .ok_or_else(|| {
+            DynoxideError::ResourceNotFoundException(format!(
+                "Requested resource not found: Table: {table_name}"
+            ))
+        })?;
 
     let view_type = meta
         .stream_view_type
         .unwrap_or_else(|| "NEW_AND_OLD_IMAGES".to_string());
 
     let limit = request.limit.unwrap_or(1000).min(1000);
-    let raw_records = storage.get_stream_records(&table_name, &shard_id, position, limit)?;
+    let raw_records = storage
+        .get_stream_records(&table_name, &shard_id, position, limit)
+        .await?;
 
     let mut records = Vec::with_capacity(raw_records.len());
     let mut last_seq: i64 = position;

--- a/src/actions/get_shard_iterator.rs
+++ b/src/actions/get_shard_iterator.rs
@@ -1,5 +1,5 @@
 use crate::errors::{DynoxideError, Result};
-use crate::storage::Storage;
+use crate::storage_backend::StorageBackend;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Default, Deserialize)]
@@ -46,8 +46,8 @@ pub fn decode_shard_iterator(iterator: &str) -> Option<(String, String, i64)> {
     Some((data.table_name, data.shard_id, data.position))
 }
 
-pub fn execute(
-    storage: &Storage,
+pub async fn execute<S: StorageBackend>(
+    storage: &S,
     request: GetShardIteratorRequest,
 ) -> Result<GetShardIteratorResponse> {
     // Parse table name from ARN
@@ -58,12 +58,15 @@ pub fn execute(
         ))
     })?;
 
-    let meta = storage.get_table_metadata(&table_name)?.ok_or_else(|| {
-        DynoxideError::ResourceNotFoundException(format!(
-            "Requested resource not found: Stream: {}",
-            request.stream_arn
-        ))
-    })?;
+    let meta = storage
+        .get_table_metadata(&table_name)
+        .await?
+        .ok_or_else(|| {
+            DynoxideError::ResourceNotFoundException(format!(
+                "Requested resource not found: Stream: {}",
+                request.stream_arn
+            ))
+        })?;
 
     if !meta.stream_enabled {
         return Err(DynoxideError::ResourceNotFoundException(format!(
@@ -76,7 +79,7 @@ pub fn execute(
         "TRIM_HORIZON" => 0,
         "LATEST" => {
             // Position at the latest record
-            let seq = storage.next_stream_sequence_number(&table_name)?;
+            let seq = storage.next_stream_sequence_number(&table_name).await?;
             seq - 1 // Will return records after this position
         }
         "AT_SEQUENCE_NUMBER" => {

--- a/src/actions/gsi.rs
+++ b/src/actions/gsi.rs
@@ -3,7 +3,8 @@
 //! Handles keeping GSI tables in sync with base table writes.
 
 use crate::errors::{DynoxideError, Result};
-use crate::storage::{Storage, TableMetadata};
+use crate::storage::TableMetadata;
+use crate::storage_backend::StorageBackend;
 use crate::types::{GlobalSecondaryIndex, Item, KeyType, ProjectionType};
 use std::collections::HashMap;
 
@@ -123,8 +124,8 @@ pub fn build_index_item(
 /// Handles both insert and update cases.
 /// Returns a map of GSI name to write capacity units consumed.
 #[allow(clippy::too_many_arguments)]
-pub fn maintain_gsis_after_write(
-    storage: &Storage,
+pub async fn maintain_gsis_after_write<S: StorageBackend>(
+    storage: &S,
     table_name: &str,
     meta: &TableMetadata,
     table_pk_str: &str,
@@ -138,7 +139,9 @@ pub fn maintain_gsis_after_write(
 
     for gsi in &gsi_defs {
         // First, remove any existing GSI entry for this base table key
-        storage.delete_gsi_item(table_name, &gsi.index_name, table_pk_str, table_sk_str)?;
+        storage
+            .delete_gsi_item(table_name, &gsi.index_name, table_pk_str, table_sk_str)
+            .await?;
 
         // If the item has the GSI pk attribute, insert into GSI
         if let Some(gsi_pk_val) = item.get(&gsi.pk_attr) {
@@ -155,15 +158,17 @@ pub fn maintain_gsis_after_write(
             let item_json = serde_json::to_string(&projected)
                 .map_err(|e| DynoxideError::InternalServerError(e.to_string()))?;
 
-            storage.insert_gsi_item(
-                table_name,
-                &gsi.index_name,
-                &gsi_pk,
-                &gsi_sk,
-                table_pk_str,
-                table_sk_str,
-                &item_json,
-            )?;
+            storage
+                .insert_gsi_item(
+                    table_name,
+                    &gsi.index_name,
+                    &gsi_pk,
+                    &gsi_sk,
+                    table_pk_str,
+                    table_sk_str,
+                    &item_json,
+                )
+                .await?;
 
             gsi_units.insert(
                 gsi.index_name.clone(),
@@ -177,8 +182,8 @@ pub fn maintain_gsis_after_write(
 
 /// Remove an item from all GSI tables after a delete.
 /// Returns a map of GSI name to write capacity units consumed.
-pub fn maintain_gsis_after_delete(
-    storage: &Storage,
+pub async fn maintain_gsis_after_delete<S: StorageBackend>(
+    storage: &S,
     table_name: &str,
     meta: &TableMetadata,
     table_pk_str: &str,
@@ -188,7 +193,9 @@ pub fn maintain_gsis_after_delete(
     let mut gsi_units: HashMap<String, f64> = HashMap::new();
 
     for gsi in &gsi_defs {
-        storage.delete_gsi_item(table_name, &gsi.index_name, table_pk_str, table_sk_str)?;
+        storage
+            .delete_gsi_item(table_name, &gsi.index_name, table_pk_str, table_sk_str)
+            .await?;
         // Delete operations consume 1 WCU minimum per GSI affected
         gsi_units.insert(gsi.index_name.clone(), 1.0);
     }

--- a/src/actions/helpers.rs
+++ b/src/actions/helpers.rs
@@ -5,6 +5,47 @@ use crate::types::{
     AttributeDefinition, AttributeValue, KeySchemaElement, KeyType, ScalarAttributeType,
 };
 use std::collections::HashMap;
+use std::future::Future;
+
+/// Run `body` inside a single backend write transaction.
+///
+/// Commits on success; if the commit itself fails, rolls back and surfaces the
+/// failure rather than leaving the connection stuck mid-transaction (a leftover
+/// open transaction makes the next `begin_transaction` fail). On any error from
+/// `body`, rolls back; if that rollback also fails, surfaces a combined error.
+///
+/// This is the single place the write-transaction lifecycle policy lives, so
+/// every write path handles a failed commit or rollback identically.
+pub async fn with_write_transaction<S, T, F>(storage: &S, body: F) -> Result<T>
+where
+    S: StorageBackend,
+    F: Future<Output = Result<T>>,
+{
+    storage.begin_transaction().await?;
+    match body.await {
+        Ok(value) => match storage.commit().await {
+            Ok(()) => Ok(value),
+            Err(commit_err) => {
+                if let Err(rb_err) = storage.rollback().await {
+                    Err(DynoxideError::InternalServerError(format!(
+                        "commit failed ({commit_err}) and rollback also failed ({rb_err})"
+                    )))
+                } else {
+                    Err(commit_err.into())
+                }
+            }
+        },
+        Err(e) => {
+            if let Err(rb_err) = storage.rollback().await {
+                Err(DynoxideError::InternalServerError(format!(
+                    "operation failed ({e}) and rollback also failed ({rb_err})"
+                )))
+            } else {
+                Err(e)
+            }
+        }
+    }
+}
 
 /// Parsed key schema for convenient access.
 pub struct KeySchema {

--- a/src/actions/helpers.rs
+++ b/src/actions/helpers.rs
@@ -1,5 +1,6 @@
 use crate::errors::{DynoxideError, Result};
-use crate::storage::{Storage, TableMetadata};
+use crate::storage::TableMetadata;
+use crate::storage_backend::StorageBackend;
 use crate::types::{
     AttributeDefinition, AttributeValue, KeySchemaElement, KeyType, ScalarAttributeType,
 };
@@ -14,21 +15,33 @@ pub struct KeySchema {
 }
 
 /// Require that a table exists, returning its metadata.
-pub fn require_table(storage: &Storage, table_name: &str) -> Result<TableMetadata> {
-    storage.get_table_metadata(table_name)?.ok_or_else(|| {
-        DynoxideError::ResourceNotFoundException(format!(
-            "Requested resource not found: Table: {table_name} not found"
-        ))
-    })
+pub async fn require_table<S: StorageBackend>(
+    storage: &S,
+    table_name: &str,
+) -> Result<TableMetadata> {
+    storage
+        .get_table_metadata(table_name)
+        .await?
+        .ok_or_else(|| {
+            DynoxideError::ResourceNotFoundException(format!(
+                "Requested resource not found: Table: {table_name} not found"
+            ))
+        })
 }
 
 /// Like `require_table`, but uses the shorter error message format that DynamoDB
 /// uses for item-level operations (PutItem, GetItem, DeleteItem, UpdateItem,
 /// Query, Scan, BatchGetItem, BatchWriteItem).
-pub fn require_table_for_item_op(storage: &Storage, table_name: &str) -> Result<TableMetadata> {
-    storage.get_table_metadata(table_name)?.ok_or_else(|| {
-        DynoxideError::ResourceNotFoundException("Requested resource not found".to_string())
-    })
+pub async fn require_table_for_item_op<S: StorageBackend>(
+    storage: &S,
+    table_name: &str,
+) -> Result<TableMetadata> {
+    storage
+        .get_table_metadata(table_name)
+        .await?
+        .ok_or_else(|| {
+            DynoxideError::ResourceNotFoundException("Requested resource not found".to_string())
+        })
 }
 
 /// Parse key schema and attribute definitions from table metadata.
@@ -674,8 +687,8 @@ pub fn parse_table_name_from_arn(arn: &str) -> Result<&str> {
 /// Build `ItemCollectionMetrics` if requested and the table has LSIs.
 ///
 /// Returns `None` if the request did not ask for SIZE, or if the table has no LSIs.
-pub fn build_item_collection_metrics(
-    storage: &Storage,
+pub async fn build_item_collection_metrics<S: StorageBackend>(
+    storage: &S,
     meta: &TableMetadata,
     table_name: &str,
     pk_str: &str,
@@ -688,15 +701,16 @@ pub fn build_item_collection_metrics(
         return Ok(None);
     }
 
-    let mut partition_bytes = storage.get_partition_size(table_name, pk_str)?;
+    let mut partition_bytes = storage.get_partition_size(table_name, pk_str).await?;
 
     // Include LSI table sizes — DynamoDB's 10GB item collection limit applies
     // to the aggregate across base table and all LSIs.
     if let Some(ref lsi_json) = meta.lsi_definitions {
         if let Ok(lsis) = serde_json::from_str::<Vec<crate::types::LocalSecondaryIndex>>(lsi_json) {
             for lsi in &lsis {
-                let lsi_size =
-                    storage.get_lsi_partition_size(table_name, &lsi.index_name, pk_str)?;
+                let lsi_size = storage
+                    .get_lsi_partition_size(table_name, &lsi.index_name, pk_str)
+                    .await?;
                 partition_bytes += lsi_size;
             }
         }

--- a/src/actions/import_items.rs
+++ b/src/actions/import_items.rs
@@ -2,10 +2,10 @@ use crate::actions::gsi;
 use crate::actions::helpers;
 use crate::actions::lsi;
 use crate::errors::{DynoxideError, Result};
-use crate::storage::{Storage, escape_table_name};
+use crate::storage::Storage;
+use crate::storage_backend::BaseItemRow;
 use crate::types::item_size;
 use crate::{ImportOptions, ImportResult};
-use rusqlite::params;
 use std::time::SystemTime;
 
 /// Execute a bulk import of items into a table.
@@ -80,16 +80,9 @@ fn execute_inner(
     };
 
     let mut total_bytes: usize = 0;
+    let mut base_rows: Vec<BaseItemRow> = Vec::with_capacity(item_count);
 
     let result = (|| -> Result<()> {
-        // Prepare the INSERT statement once outside the loop
-        let escaped = escape_table_name(table_name);
-        let sql = format!(
-            "INSERT OR REPLACE INTO \"{escaped}\" (pk, sk, item_json, item_size, cached_at, hash_prefix) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)"
-        );
-        let mut insert_stmt = storage.conn().prepare_cached(&sql)?;
-
         for mut item in items {
             // 5. Validate required keys and extract pk/sk
             helpers::validate_item_keys(&item, &key_schema, &meta)?;
@@ -113,16 +106,6 @@ fn execute_inner(
                 .get(&key_schema.partition_key)
                 .map(crate::storage::compute_hash_prefix)
                 .unwrap_or_default();
-
-            // 7. INSERT OR REPLACE into base table
-            insert_stmt.execute(params![
-                pk,
-                sk,
-                item_json,
-                size as i64,
-                cached_at_val,
-                hash_prefix
-            ])?;
 
             // 8. Maintain GSI tables (sparse: skip items missing GSI pk)
             for gsi_def in &gsi_defs {
@@ -249,7 +232,19 @@ fn execute_inner(
                     now_epoch,
                 )?;
             }
+
+            // Collect the base row; all base inserts run as one batch after
+            // the loop (same transaction, identical final state).
+            base_rows.push(BaseItemRow {
+                pk,
+                sk,
+                item_json,
+                item_size: size,
+                cached_at: cached_at_val,
+                hash_prefix,
+            });
         }
+        storage.put_base_items(table_name, &base_rows)?;
         Ok(())
     })();
 

--- a/src/actions/import_items.rs
+++ b/src/actions/import_items.rs
@@ -59,9 +59,6 @@ async fn execute_inner<S: StorageBackend>(
     let gsi_defs = gsi::parse_gsi_defs(&meta)?;
     let lsi_defs = lsi::parse_lsi_defs(&meta)?;
 
-    // 4. Begin transaction
-    storage.begin_transaction().await?;
-
     let now = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap()
@@ -72,17 +69,22 @@ async fn execute_inner<S: StorageBackend>(
         None
     };
 
-    // Pre-fetch the next stream sequence number once (fix: O(n) → O(1))
-    let mut next_seq = if options.record_streams && meta.stream_enabled {
-        storage.next_stream_sequence_number(table_name).await?
-    } else {
-        0
-    };
-
+    // Flush accumulated base rows to one bulk insert every FLUSH_BATCH items so
+    // a large import does not buffer every row's JSON in memory at once.
+    const FLUSH_BATCH: usize = 1000;
     let mut total_bytes: usize = 0;
-    let mut base_rows: Vec<BaseItemRow> = Vec::with_capacity(item_count);
 
-    let result: Result<()> = async {
+    // The whole import is one transaction: any failure rolls everything back.
+    helpers::with_write_transaction(storage, async {
+        // Pre-fetch the next stream sequence number once (fix: O(n) → O(1))
+        let mut next_seq = if options.record_streams && meta.stream_enabled {
+            storage.next_stream_sequence_number(table_name).await?
+        } else {
+            0
+        };
+
+        let mut base_rows: Vec<BaseItemRow> = Vec::with_capacity(item_count.min(FLUSH_BATCH));
+
         for mut item in items {
             // 5. Validate required keys and extract pk/sk
             helpers::validate_item_keys(&item, &key_schema, &meta)?;
@@ -243,8 +245,8 @@ async fn execute_inner<S: StorageBackend>(
                     .await?;
             }
 
-            // Collect the base row; all base inserts run as one batch after
-            // the loop (same transaction, identical final state).
+            // Collect the base row; base inserts flush in batches here (and a
+            // final flush after the loop), all inside this one transaction.
             base_rows.push(BaseItemRow {
                 pk,
                 sk,
@@ -253,24 +255,20 @@ async fn execute_inner<S: StorageBackend>(
                 cached_at: cached_at_val,
                 hash_prefix,
             });
+            if base_rows.len() >= FLUSH_BATCH {
+                storage.put_base_items(table_name, &base_rows).await?;
+                base_rows.clear();
+            }
         }
-        storage.put_base_items(table_name, &base_rows).await?;
+        if !base_rows.is_empty() {
+            storage.put_base_items(table_name, &base_rows).await?;
+        }
         Ok(())
-    }
-    .await;
+    })
+    .await?;
 
-    // 10. Commit or rollback
-    match result {
-        Ok(()) => {
-            storage.commit().await?;
-            Ok(ImportResult {
-                items_imported: item_count,
-                bytes_imported: total_bytes,
-            })
-        }
-        Err(e) => {
-            let _ = storage.rollback().await;
-            Err(e)
-        }
-    }
+    Ok(ImportResult {
+        items_imported: item_count,
+        bytes_imported: total_bytes,
+    })
 }

--- a/src/actions/import_items.rs
+++ b/src/actions/import_items.rs
@@ -272,3 +272,61 @@ async fn execute_inner<S: StorageBackend>(
         bytes_imported: total_bytes,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::ImportOptions;
+    use crate::actions::create_table;
+    use crate::storage::Storage;
+    use crate::storage_backend::StorageBackend;
+
+    /// A failed import rolls the whole batch back: GSI entries written before
+    /// the failure (and any base rows) are undone, leaving the table empty.
+    #[test]
+    fn import_rolls_back_when_gsi_fan_out_fails() {
+        let storage = Storage::memory().unwrap();
+
+        let create = serde_json::from_value(serde_json::json!({
+            "TableName": "Orders",
+            "KeySchema": [{"AttributeName": "UserId", "KeyType": "HASH"}],
+            "AttributeDefinitions": [
+                {"AttributeName": "UserId", "AttributeType": "S"},
+                {"AttributeName": "Status", "AttributeType": "S"}
+            ],
+            "GlobalSecondaryIndexes": [
+                {"IndexName": "StatusIndex", "KeySchema": [{"AttributeName": "Status", "KeyType": "HASH"}], "Projection": {"ProjectionType": "ALL"}}
+            ]
+        }))
+        .unwrap();
+        pollster::block_on(create_table::execute(&storage, create)).unwrap();
+
+        // Break the GSI fan-out by dropping its physical table.
+        storage.drop_gsi_table("Orders", "StatusIndex").unwrap();
+
+        let items: Vec<crate::types::Item> = vec![
+            serde_json::from_value(
+                serde_json::json!({"UserId": {"S": "u1"}, "Status": {"S": "SHIPPED"}}),
+            )
+            .unwrap(),
+        ];
+        let res = pollster::block_on(super::execute(
+            &storage,
+            "Orders",
+            items,
+            &ImportOptions::default(),
+        ));
+        assert!(
+            res.is_err(),
+            "a mid-fan-out failure must surface as an error"
+        );
+
+        // The whole import rolled back: no base rows landed.
+        let count =
+            pollster::block_on(<Storage as StorageBackend>::count_items(&storage, "Orders"))
+                .unwrap();
+        assert_eq!(
+            count, 0,
+            "import must roll back entirely when fan-out fails"
+        );
+    }
+}

--- a/src/actions/import_items.rs
+++ b/src/actions/import_items.rs
@@ -2,8 +2,8 @@ use crate::actions::gsi;
 use crate::actions::helpers;
 use crate::actions::lsi;
 use crate::errors::{DynoxideError, Result};
-use crate::storage::Storage;
 use crate::storage_backend::BaseItemRow;
+use crate::storage_backend::StorageBackend;
 use crate::types::item_size;
 use crate::{ImportOptions, ImportResult};
 use std::time::SystemTime;
@@ -12,13 +12,13 @@ use std::time::SystemTime;
 ///
 /// All items are inserted in a single transaction. If any item fails,
 /// the entire import is rolled back.
-pub fn execute(
-    storage: &Storage,
+pub async fn execute<S: StorageBackend>(
+    storage: &S,
     table_name: &str,
     items: Vec<crate::types::Item>,
     options: &ImportOptions,
 ) -> Result<ImportResult> {
-    execute_inner(storage, table_name, items, options, false)
+    execute_inner(storage, table_name, items, options, false).await
 }
 
 /// Bulk import with option to skip GSI deletes.
@@ -26,24 +26,24 @@ pub fn execute(
 /// When `skip_gsi_deletes` is true, the DELETE-before-INSERT on GSI tables
 /// is skipped entirely. The caller must guarantee there are no pre-existing
 /// rows whose GSI keys could become stale (i.e., fresh database).
-pub fn execute_skip_gsi_deletes(
-    storage: &Storage,
+pub async fn execute_skip_gsi_deletes<S: StorageBackend>(
+    storage: &S,
     table_name: &str,
     items: Vec<crate::types::Item>,
     options: &ImportOptions,
 ) -> Result<ImportResult> {
-    execute_inner(storage, table_name, items, options, true)
+    execute_inner(storage, table_name, items, options, true).await
 }
 
-fn execute_inner(
-    storage: &Storage,
+async fn execute_inner<S: StorageBackend>(
+    storage: &S,
     table_name: &str,
     items: Vec<crate::types::Item>,
     options: &ImportOptions,
     skip_gsi_deletes: bool,
 ) -> Result<ImportResult> {
     // 1. Require table exists
-    let meta = helpers::require_table(storage, table_name)?;
+    let meta = helpers::require_table(storage, table_name).await?;
     let key_schema = helpers::parse_key_schema(&meta)?;
 
     // 2. Empty vec: no-op
@@ -60,7 +60,7 @@ fn execute_inner(
     let lsi_defs = lsi::parse_lsi_defs(&meta)?;
 
     // 4. Begin transaction
-    storage.begin_transaction()?;
+    storage.begin_transaction().await?;
 
     let now = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
@@ -74,7 +74,7 @@ fn execute_inner(
 
     // Pre-fetch the next stream sequence number once (fix: O(n) → O(1))
     let mut next_seq = if options.record_streams && meta.stream_enabled {
-        storage.next_stream_sequence_number(table_name)?
+        storage.next_stream_sequence_number(table_name).await?
     } else {
         0
     };
@@ -82,7 +82,7 @@ fn execute_inner(
     let mut total_bytes: usize = 0;
     let mut base_rows: Vec<BaseItemRow> = Vec::with_capacity(item_count);
 
-    let result = (|| -> Result<()> {
+    let result: Result<()> = async {
         for mut item in items {
             // 5. Validate required keys and extract pk/sk
             helpers::validate_item_keys(&item, &key_schema, &meta)?;
@@ -112,7 +112,9 @@ fn execute_inner(
                 // Delete any existing GSI entry for this base table key
                 // (skipped on fresh import — no stale entries to clean up)
                 if !skip_gsi_deletes {
-                    storage.delete_gsi_item(table_name, &gsi_def.index_name, &pk, &sk)?;
+                    storage
+                        .delete_gsi_item(table_name, &gsi_def.index_name, &pk, &sk)
+                        .await?;
                 }
 
                 // If item has GSI pk attribute, insert into GSI
@@ -144,15 +146,17 @@ fn execute_inner(
                             })?
                         };
 
-                    storage.insert_gsi_item(
-                        table_name,
-                        &gsi_def.index_name,
-                        &gsi_pk,
-                        &gsi_sk,
-                        &pk,
-                        &sk,
-                        &projected_json,
-                    )?;
+                    storage
+                        .insert_gsi_item(
+                            table_name,
+                            &gsi_def.index_name,
+                            &gsi_pk,
+                            &gsi_sk,
+                            &pk,
+                            &sk,
+                            &projected_json,
+                        )
+                        .await?;
                 }
             }
 
@@ -160,7 +164,9 @@ fn execute_inner(
             for lsi_def in &lsi_defs {
                 // Delete any existing LSI entry for this base table key
                 if !skip_gsi_deletes {
-                    storage.delete_lsi_item(table_name, &lsi_def.index_name, &pk, &sk)?;
+                    storage
+                        .delete_lsi_item(table_name, &lsi_def.index_name, &pk, &sk)
+                        .await?;
                 }
 
                 // If item has LSI sk attribute, insert into LSI
@@ -187,15 +193,17 @@ fn execute_inner(
                                 })?
                             };
 
-                        storage.insert_lsi_item(
-                            table_name,
-                            &lsi_def.index_name,
-                            &lsi_pk,
-                            &lsi_sk,
-                            &pk,
-                            &sk,
-                            &projected_json,
-                        )?;
+                        storage
+                            .insert_lsi_item(
+                                table_name,
+                                &lsi_def.index_name,
+                                &lsi_pk,
+                                &lsi_sk,
+                                &pk,
+                                &sk,
+                                &projected_json,
+                            )
+                            .await?;
                     }
                 }
             }
@@ -221,16 +229,18 @@ fn execute_inner(
                     .duration_since(SystemTime::UNIX_EPOCH)
                     .unwrap()
                     .as_secs() as i64;
-                storage.insert_stream_record(
-                    table_name,
-                    "INSERT",
-                    &keys_json,
-                    Some(&item_json),
-                    None,
-                    &seq.to_string(),
-                    &shard_id,
-                    now_epoch,
-                )?;
+                storage
+                    .insert_stream_record(
+                        table_name,
+                        "INSERT",
+                        &keys_json,
+                        Some(&item_json),
+                        None,
+                        &seq.to_string(),
+                        &shard_id,
+                        now_epoch,
+                    )
+                    .await?;
             }
 
             // Collect the base row; all base inserts run as one batch after
@@ -244,21 +254,22 @@ fn execute_inner(
                 hash_prefix,
             });
         }
-        storage.put_base_items(table_name, &base_rows)?;
+        storage.put_base_items(table_name, &base_rows).await?;
         Ok(())
-    })();
+    }
+    .await;
 
     // 10. Commit or rollback
     match result {
         Ok(()) => {
-            storage.commit()?;
+            storage.commit().await?;
             Ok(ImportResult {
                 items_imported: item_count,
                 bytes_imported: total_bytes,
             })
         }
         Err(e) => {
-            let _ = storage.rollback();
+            let _ = storage.rollback().await;
             Err(e)
         }
     }

--- a/src/actions/list_streams.rs
+++ b/src/actions/list_streams.rs
@@ -1,5 +1,5 @@
 use crate::errors::Result;
-use crate::storage::Storage;
+use crate::storage_backend::StorageBackend;
 use crate::streams;
 use serde::{Deserialize, Serialize};
 
@@ -34,8 +34,11 @@ pub struct StreamSummary {
     pub stream_label: String,
 }
 
-pub fn execute(storage: &Storage, request: ListStreamsRequest) -> Result<ListStreamsResponse> {
-    let tables = storage.list_stream_enabled_tables()?;
+pub async fn execute<S: StorageBackend>(
+    storage: &S,
+    request: ListStreamsRequest,
+) -> Result<ListStreamsResponse> {
+    let tables = storage.list_stream_enabled_tables().await?;
 
     let mut summaries: Vec<StreamSummary> = tables
         .into_iter()

--- a/src/actions/list_tables.rs
+++ b/src/actions/list_tables.rs
@@ -1,5 +1,5 @@
 use crate::errors::Result;
-use crate::storage::Storage;
+use crate::storage_backend::StorageBackend;
 use crate::validation;
 use serde::{Deserialize, Serialize};
 
@@ -95,10 +95,13 @@ pub struct ListTablesResponse {
     pub last_evaluated_table_name: Option<String>,
 }
 
-pub fn execute(storage: &Storage, request: ListTablesRequest) -> Result<ListTablesResponse> {
+pub async fn execute<S: StorageBackend>(
+    storage: &S,
+    request: ListTablesRequest,
+) -> Result<ListTablesResponse> {
     let limit = request.limit.unwrap_or(100).clamp(1, 100) as usize;
 
-    let all_tables = storage.list_table_names()?;
+    let all_tables = storage.list_table_names().await?;
 
     // Filter by ExclusiveStartTableName
     let filtered: Vec<String> = if let Some(ref start) = request.exclusive_start_table_name {

--- a/src/actions/list_tags_of_resource.rs
+++ b/src/actions/list_tags_of_resource.rs
@@ -1,6 +1,6 @@
 use crate::actions::helpers;
 use crate::errors::{DynoxideError, Result};
-use crate::storage::Storage;
+use crate::storage_backend::StorageBackend;
 use crate::types::Tag;
 use serde::{Deserialize, Serialize};
 
@@ -16,8 +16,8 @@ pub struct ListTagsOfResourceResponse {
     pub tags: Vec<Tag>,
 }
 
-pub fn execute(
-    storage: &Storage,
+pub async fn execute<S: StorageBackend>(
+    storage: &S,
     request: ListTagsOfResourceRequest,
 ) -> Result<ListTagsOfResourceResponse> {
     let arn = request.resource_arn.as_deref().unwrap_or("");
@@ -29,13 +29,13 @@ pub fn execute(
     let table_name = helpers::parse_table_name_from_arn(arn)?;
 
     // Verify table exists — real DynamoDB returns AccessDeniedException for non-existent ARNs
-    if !storage.table_exists(table_name)? {
+    if !storage.table_exists(table_name).await? {
         return Err(DynoxideError::AccessDeniedException(format!(
             "User: arn:aws:iam::000000000000:root is not authorized to perform: dynamodb:ListTagsOfResource on resource: {arn}"
         )));
     }
 
-    let tags = storage.get_tags(table_name)?;
+    let tags = storage.get_tags(table_name).await?;
 
     Ok(ListTagsOfResourceResponse { tags })
 }

--- a/src/actions/lsi.rs
+++ b/src/actions/lsi.rs
@@ -3,7 +3,8 @@
 //! Handles keeping LSI tables in sync with base table writes.
 
 use crate::errors::{DynoxideError, Result};
-use crate::storage::{Storage, TableMetadata};
+use crate::storage::TableMetadata;
+use crate::storage_backend::StorageBackend;
 use crate::types::{Item, KeyType, LocalSecondaryIndex};
 
 /// Type alias: LSI definitions reuse the shared IndexDef from gsi.
@@ -64,8 +65,8 @@ pub fn parse_lsi_key_schema(
 /// Update all LSI tables after an item write (put/update).
 /// Handles both insert and update cases.
 #[allow(clippy::too_many_arguments)]
-pub fn maintain_lsis_after_write(
-    storage: &Storage,
+pub async fn maintain_lsis_after_write<S: StorageBackend>(
+    storage: &S,
     table_name: &str,
     meta: &TableMetadata,
     table_pk_str: &str,
@@ -78,7 +79,9 @@ pub fn maintain_lsis_after_write(
 
     for lsi in &lsi_defs {
         // First, remove any existing LSI entry for this base table key
-        storage.delete_lsi_item(table_name, &lsi.index_name, table_pk_str, table_sk_str)?;
+        storage
+            .delete_lsi_item(table_name, &lsi.index_name, table_pk_str, table_sk_str)
+            .await?;
 
         // LSI pk is always the same as the table pk. Only insert if item
         // has the LSI sort key attribute (sparse index behaviour).
@@ -92,15 +95,17 @@ pub fn maintain_lsis_after_write(
                 let item_json = serde_json::to_string(&projected)
                     .map_err(|e| DynoxideError::InternalServerError(e.to_string()))?;
 
-                storage.insert_lsi_item(
-                    table_name,
-                    &lsi.index_name,
-                    &lsi_pk,
-                    &lsi_sk,
-                    table_pk_str,
-                    table_sk_str,
-                    &item_json,
-                )?;
+                storage
+                    .insert_lsi_item(
+                        table_name,
+                        &lsi.index_name,
+                        &lsi_pk,
+                        &lsi_sk,
+                        table_pk_str,
+                        table_sk_str,
+                        &item_json,
+                    )
+                    .await?;
             }
         }
     }
@@ -109,8 +114,8 @@ pub fn maintain_lsis_after_write(
 }
 
 /// Remove an item from all LSI tables after a delete.
-pub fn maintain_lsis_after_delete(
-    storage: &Storage,
+pub async fn maintain_lsis_after_delete<S: StorageBackend>(
+    storage: &S,
     table_name: &str,
     meta: &TableMetadata,
     table_pk_str: &str,
@@ -119,7 +124,9 @@ pub fn maintain_lsis_after_delete(
     let lsi_defs = parse_lsi_defs(meta)?;
 
     for lsi in &lsi_defs {
-        storage.delete_lsi_item(table_name, &lsi.index_name, table_pk_str, table_sk_str)?;
+        storage
+            .delete_lsi_item(table_name, &lsi.index_name, table_pk_str, table_sk_str)
+            .await?;
     }
 
     Ok(())

--- a/src/actions/put_item.rs
+++ b/src/actions/put_item.rs
@@ -291,9 +291,7 @@ pub async fn execute<S: StorageBackend>(
     // leaving no torn index. The transaction is unconditional (not just for
     // ConditionExpression) because the atomicity guarantee applies to every
     // single-item write.
-    storage.begin_transaction().await?;
-
-    let write_result: Result<(Option<String>, HashMap<String, f64>)> = async {
+    let (old_json, gsi_units) = helpers::with_write_transaction(storage, async {
         // Evaluate ConditionExpression against existing item (if any)
         let old_json = if request.condition_expression.is_some() {
             let existing_json = storage.get_item(&request.table_name, &pk, &sk).await?;
@@ -407,18 +405,8 @@ pub async fn execute<S: StorageBackend>(
         .await?;
 
         Ok((old_json, gsi_units))
-    }
-    .await;
-
-    // Commit on success, roll back the whole write on any failure.
-    match write_result {
-        Ok(_) => storage.commit().await?,
-        Err(ref _e) => {
-            let _ = storage.rollback().await;
-        }
-    }
-
-    let (old_json, gsi_units) = write_result?;
+    })
+    .await?;
 
     // Handle ReturnValues
     let return_old = request

--- a/src/actions/put_item.rs
+++ b/src/actions/put_item.rs
@@ -1,6 +1,6 @@
 use crate::actions::helpers;
 use crate::errors::{DynoxideError, Result};
-use crate::storage::Storage;
+use crate::storage_backend::StorageBackend;
 use crate::types::{self, AttributeValue, Item};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -144,7 +144,10 @@ pub struct PutItemResponse {
     pub item_collection_metrics: Option<crate::types::ItemCollectionMetrics>,
 }
 
-pub fn execute(storage: &Storage, mut request: PutItemRequest) -> Result<PutItemResponse> {
+pub async fn execute<S: StorageBackend>(
+    storage: &S,
+    mut request: PutItemRequest,
+) -> Result<PutItemResponse> {
     // Validate table name format before checking existence (DynamoDB validates input first)
     crate::validation::validate_table_name(&request.table_name)?;
 
@@ -227,7 +230,7 @@ pub fn execute(storage: &Storage, mut request: PutItemRequest) -> Result<PutItem
         ));
     }
 
-    let meta = helpers::require_table_for_item_op(storage, &request.table_name)?;
+    let meta = helpers::require_table_for_item_op(storage, &request.table_name).await?;
     let key_schema = helpers::parse_key_schema(&meta)?;
 
     // Convert legacy Expected parameter to ConditionExpression if no expression is set
@@ -286,13 +289,13 @@ pub fn execute(storage: &Storage, mut request: PutItemRequest) -> Result<PutItem
     // Wrap condition check + write in a transaction to prevent TOCTOU races
     let has_condition = request.condition_expression.is_some();
     if has_condition {
-        storage.begin_transaction()?;
+        storage.begin_transaction().await?;
     }
 
-    let conditional_result = (|| -> Result<(Option<String>, String)> {
+    let conditional_result: Result<(Option<String>, String)> = async {
         // Evaluate ConditionExpression against existing item (if any)
         let old_json = if request.condition_expression.is_some() {
-            let existing_json = storage.get_item(&request.table_name, &pk, &sk)?;
+            let existing_json = storage.get_item(&request.table_name, &pk, &sk).await?;
             let existing_item: HashMap<String, AttributeValue> = existing_json
                 .as_ref()
                 .and_then(|j| serde_json::from_str(j).ok())
@@ -341,35 +344,40 @@ pub fn execute(storage: &Storage, mut request: PutItemRequest) -> Result<PutItem
         // Store item (returns old item if it existed)
         // If we already fetched old_json for condition check, use put_item but ignore its return
         let old_json = if old_json.is_some() {
-            storage.put_item_with_hash(
-                &request.table_name,
-                &pk,
-                &sk,
-                &item_json,
-                size,
-                &hash_prefix,
-            )?;
+            storage
+                .put_item_with_hash(
+                    &request.table_name,
+                    &pk,
+                    &sk,
+                    &item_json,
+                    size,
+                    &hash_prefix,
+                )
+                .await?;
             old_json
         } else {
-            storage.put_item_with_hash(
-                &request.table_name,
-                &pk,
-                &sk,
-                &item_json,
-                size,
-                &hash_prefix,
-            )?
+            storage
+                .put_item_with_hash(
+                    &request.table_name,
+                    &pk,
+                    &sk,
+                    &item_json,
+                    size,
+                    &hash_prefix,
+                )
+                .await?
         };
 
         Ok((old_json, item_json))
-    })();
+    }
+    .await;
 
     // Handle transaction commit/rollback
     if has_condition {
         match conditional_result {
-            Ok(_) => storage.commit()?,
+            Ok(_) => storage.commit().await?,
             Err(ref _e) => {
-                let _ = storage.rollback();
+                let _ = storage.rollback().await;
             }
         }
     }
@@ -386,7 +394,8 @@ pub fn execute(storage: &Storage, mut request: PutItemRequest) -> Result<PutItem
         &request.item,
         &key_schema.partition_key,
         key_schema.sort_key.as_deref(),
-    )?;
+    )
+    .await?;
 
     // Maintain LSI tables
     super::lsi::maintain_lsis_after_write(
@@ -398,7 +407,8 @@ pub fn execute(storage: &Storage, mut request: PutItemRequest) -> Result<PutItem
         &request.item,
         &key_schema.partition_key,
         key_schema.sort_key.as_deref(),
-    )?;
+    )
+    .await?;
 
     // Record stream event
     let old_item_for_stream: Option<Item> =
@@ -408,7 +418,8 @@ pub fn execute(storage: &Storage, mut request: PutItemRequest) -> Result<PutItem
         &meta,
         old_item_for_stream.as_ref(),
         Some(&request.item),
-    )?;
+    )
+    .await?;
 
     // Handle ReturnValues
     let return_old = request
@@ -437,7 +448,8 @@ pub fn execute(storage: &Storage, mut request: PutItemRequest) -> Result<PutItem
             .as_ref()
             .unwrap_or(&AttributeValue::S(String::new())),
         &request.return_item_collection_metrics,
-    )?;
+    )
+    .await?;
 
     let consumed_capacity = types::consumed_capacity_with_indexes(
         &request.table_name,

--- a/src/actions/put_item.rs
+++ b/src/actions/put_item.rs
@@ -286,13 +286,14 @@ pub async fn execute<S: StorageBackend>(
         }
     }
 
-    // Wrap condition check + write in a transaction to prevent TOCTOU races
-    let has_condition = request.condition_expression.is_some();
-    if has_condition {
-        storage.begin_transaction().await?;
-    }
+    // Wrap the condition check, base write and the GSI/LSI index fan-out in a
+    // single transaction so a mid-fan-out failure rolls the whole write back,
+    // leaving no torn index. The transaction is unconditional (not just for
+    // ConditionExpression) because the atomicity guarantee applies to every
+    // single-item write.
+    storage.begin_transaction().await?;
 
-    let conditional_result: Result<(Option<String>, String)> = async {
+    let write_result: Result<(Option<String>, HashMap<String, f64>)> = async {
         // Evaluate ConditionExpression against existing item (if any)
         let old_json = if request.condition_expression.is_some() {
             let existing_json = storage.get_item(&request.table_name, &pk, &sk).await?;
@@ -368,58 +369,56 @@ pub async fn execute<S: StorageBackend>(
                 .await?
         };
 
-        Ok((old_json, item_json))
+        // Maintain GSI tables (inside the transaction)
+        let gsi_units = super::gsi::maintain_gsis_after_write(
+            storage,
+            &request.table_name,
+            &meta,
+            &pk,
+            &sk,
+            &request.item,
+            &key_schema.partition_key,
+            key_schema.sort_key.as_deref(),
+        )
+        .await?;
+
+        // Maintain LSI tables (inside the transaction)
+        super::lsi::maintain_lsis_after_write(
+            storage,
+            &request.table_name,
+            &meta,
+            &pk,
+            &sk,
+            &request.item,
+            &key_schema.partition_key,
+            key_schema.sort_key.as_deref(),
+        )
+        .await?;
+
+        // Record stream event (inside the transaction)
+        let old_item_for_stream: Option<Item> =
+            old_json.as_ref().and_then(|j| serde_json::from_str(j).ok());
+        crate::streams::record_stream_event(
+            storage,
+            &meta,
+            old_item_for_stream.as_ref(),
+            Some(&request.item),
+        )
+        .await?;
+
+        Ok((old_json, gsi_units))
     }
     .await;
 
-    // Handle transaction commit/rollback
-    if has_condition {
-        match conditional_result {
-            Ok(_) => storage.commit().await?,
-            Err(ref _e) => {
-                let _ = storage.rollback().await;
-            }
+    // Commit on success, roll back the whole write on any failure.
+    match write_result {
+        Ok(_) => storage.commit().await?,
+        Err(ref _e) => {
+            let _ = storage.rollback().await;
         }
     }
 
-    let (old_json, _item_json) = conditional_result?;
-
-    // Maintain GSI tables
-    let gsi_units = super::gsi::maintain_gsis_after_write(
-        storage,
-        &request.table_name,
-        &meta,
-        &pk,
-        &sk,
-        &request.item,
-        &key_schema.partition_key,
-        key_schema.sort_key.as_deref(),
-    )
-    .await?;
-
-    // Maintain LSI tables
-    super::lsi::maintain_lsis_after_write(
-        storage,
-        &request.table_name,
-        &meta,
-        &pk,
-        &sk,
-        &request.item,
-        &key_schema.partition_key,
-        key_schema.sort_key.as_deref(),
-    )
-    .await?;
-
-    // Record stream event
-    let old_item_for_stream: Option<Item> =
-        old_json.as_ref().and_then(|j| serde_json::from_str(j).ok());
-    crate::streams::record_stream_event(
-        storage,
-        &meta,
-        old_item_for_stream.as_ref(),
-        Some(&request.item),
-    )
-    .await?;
+    let (old_json, gsi_units) = write_result?;
 
     // Handle ReturnValues
     let return_old = request
@@ -463,4 +462,90 @@ pub async fn execute<S: StorageBackend>(
         consumed_capacity,
         item_collection_metrics,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::actions::{create_table, put_item};
+    use crate::storage::Storage;
+    use crate::storage_backend::StorageBackend;
+
+    /// A single-item write and its GSI fan-out succeed or fail as one unit:
+    /// when a later GSI write fails mid-fan-out, the base write and the GSI
+    /// entry already written earlier in the same transaction both roll back.
+    #[test]
+    fn put_item_rolls_back_base_write_when_gsi_fan_out_fails() {
+        let storage = Storage::memory().unwrap();
+
+        let create = serde_json::from_value(serde_json::json!({
+            "TableName": "Orders",
+            "KeySchema": [
+                {"AttributeName": "UserId", "KeyType": "HASH"},
+                {"AttributeName": "Timestamp", "KeyType": "RANGE"}
+            ],
+            "AttributeDefinitions": [
+                {"AttributeName": "UserId", "AttributeType": "S"},
+                {"AttributeName": "Timestamp", "AttributeType": "S"},
+                {"AttributeName": "Status", "AttributeType": "S"},
+                {"AttributeName": "Priority", "AttributeType": "S"}
+            ],
+            "GlobalSecondaryIndexes": [
+                {
+                    "IndexName": "StatusIndex",
+                    "KeySchema": [{"AttributeName": "Status", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "ALL"}
+                },
+                {
+                    "IndexName": "PriorityIndex",
+                    "KeySchema": [{"AttributeName": "Priority", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "ALL"}
+                }
+            ]
+        }))
+        .unwrap();
+        pollster::block_on(create_table::execute(&storage, create)).unwrap();
+
+        // Inject a fan-out failure: drop the second GSI's physical table while
+        // its metadata stays. The fan-out maintains StatusIndex first (which
+        // succeeds inside the transaction), then hits the now-missing
+        // PriorityIndex table and errors.
+        storage.drop_gsi_table("Orders", "PriorityIndex").unwrap();
+
+        let put = serde_json::from_value(serde_json::json!({
+            "TableName": "Orders",
+            "Item": {
+                "UserId": {"S": "user1"},
+                "Timestamp": {"S": "2024-01-01"},
+                "Status": {"S": "SHIPPED"},
+                "Priority": {"S": "HIGH"}
+            }
+        }))
+        .unwrap();
+        let res = pollster::block_on(put_item::execute(&storage, put));
+        assert!(
+            res.is_err(),
+            "a mid-fan-out failure must surface as an error"
+        );
+
+        // The base write must roll back entirely.
+        let count =
+            pollster::block_on(<Storage as StorageBackend>::count_items(&storage, "Orders"))
+                .unwrap();
+        assert_eq!(count, 0, "base write must roll back when fan-out fails");
+
+        // The first GSI's entry, written before the failure, must roll back too
+        // (no torn index).
+        let g1 = pollster::block_on(<Storage as StorageBackend>::query_gsi_items(
+            &storage,
+            "Orders",
+            "StatusIndex",
+            "SHIPPED",
+            &Default::default(),
+        ))
+        .unwrap();
+        assert!(
+            g1.is_empty(),
+            "first GSI entry must roll back with the base write"
+        );
+    }
 }

--- a/src/actions/query.rs
+++ b/src/actions/query.rs
@@ -1,7 +1,7 @@
 use crate::actions::helpers;
 use crate::errors::{DynoxideError, Result};
 use crate::expressions;
-use crate::storage::Storage;
+use crate::storage_backend::StorageBackend;
 use crate::types::{AttributeValue, Item};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -178,7 +178,10 @@ pub struct QueryResponse {
     pub consumed_capacity: Option<crate::types::ConsumedCapacity>,
 }
 
-pub fn execute(storage: &Storage, mut request: QueryRequest) -> Result<QueryResponse> {
+pub async fn execute<S: StorageBackend>(
+    storage: &S,
+    mut request: QueryRequest,
+) -> Result<QueryResponse> {
     // Validate table name format before checking existence (DynamoDB validates input first)
     crate::validation::validate_table_name(&request.table_name)?;
 
@@ -312,7 +315,7 @@ pub fn execute(storage: &Storage, mut request: QueryRequest) -> Result<QueryResp
         }
     }
 
-    let meta = helpers::require_table_for_item_op(storage, &request.table_name)?;
+    let meta = helpers::require_table_for_item_op(storage, &request.table_name).await?;
     let table_key_schema = helpers::parse_key_schema(&meta)?;
 
     // Determine effective partition key name early so we can pass it to
@@ -693,12 +696,18 @@ pub fn execute(storage: &Storage, mut request: QueryRequest) -> Result<QueryResp
     };
     let rows = if let Some(ref index_name) = request.index_name {
         if is_lsi {
-            storage.query_lsi_items(&request.table_name, index_name, &pk_str, &query_params)?
+            storage
+                .query_lsi_items(&request.table_name, index_name, &pk_str, &query_params)
+                .await?
         } else {
-            storage.query_gsi_items(&request.table_name, index_name, &pk_str, &query_params)?
+            storage
+                .query_gsi_items(&request.table_name, index_name, &pk_str, &query_params)
+                .await?
         }
     } else {
-        storage.query_items(&request.table_name, &pk_str, &query_params)?
+        storage
+            .query_items(&request.table_name, &pk_str, &query_params)
+            .await?
     };
 
     // Parse filter expression if present
@@ -789,7 +798,10 @@ pub fn execute(storage: &Storage, mut request: QueryRequest) -> Result<QueryResp
                 .and_then(|sk_name| index_item.get(sk_name))
                 .and_then(|v| v.to_key_string())
                 .unwrap_or_default();
-            if let Some(full_json) = storage.get_item(&request.table_name, &base_pk, &base_sk)? {
+            if let Some(full_json) = storage
+                .get_item(&request.table_name, &base_pk, &base_sk)
+                .await?
+            {
                 let full_item: Item = serde_json::from_str(&full_json).map_err(|e| {
                     DynoxideError::InternalServerError(format!("Bad item JSON: {e}"))
                 })?;

--- a/src/actions/scan.rs
+++ b/src/actions/scan.rs
@@ -1,7 +1,7 @@
 use crate::actions::helpers;
 use crate::errors::{DynoxideError, Result};
 use crate::expressions;
-use crate::storage::Storage;
+use crate::storage_backend::StorageBackend;
 use crate::types::{AttributeValue, Item};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -168,7 +168,10 @@ pub struct ScanResponse {
     pub consumed_capacity: Option<crate::types::ConsumedCapacity>,
 }
 
-pub fn execute(storage: &Storage, mut request: ScanRequest) -> Result<ScanResponse> {
+pub async fn execute<S: StorageBackend>(
+    storage: &S,
+    mut request: ScanRequest,
+) -> Result<ScanResponse> {
     // Validate table name format before checking existence (DynamoDB validates input first)
     crate::validation::validate_table_name(&request.table_name)?;
 
@@ -325,7 +328,7 @@ pub fn execute(storage: &Storage, mut request: ScanRequest) -> Result<ScanRespon
         ));
     }
 
-    let meta = helpers::require_table_for_item_op(storage, &request.table_name)?;
+    let meta = helpers::require_table_for_item_op(storage, &request.table_name).await?;
     let table_key_schema = helpers::parse_key_schema(&meta)?;
 
     // Convert legacy AttributesToGet to ProjectionExpression if no expression-based
@@ -457,12 +460,18 @@ pub fn execute(storage: &Storage, mut request: ScanRequest) -> Result<ScanRespon
     };
     let rows = if let Some(ref index_name) = request.index_name {
         if is_lsi {
-            storage.scan_lsi_items(&request.table_name, index_name, &scan_params)?
+            storage
+                .scan_lsi_items(&request.table_name, index_name, &scan_params)
+                .await?
         } else {
-            storage.scan_gsi_items(&request.table_name, index_name, &scan_params)?
+            storage
+                .scan_gsi_items(&request.table_name, index_name, &scan_params)
+                .await?
         }
     } else {
-        storage.scan_items(&request.table_name, &scan_params)?
+        storage
+            .scan_items(&request.table_name, &scan_params)
+            .await?
     };
 
     // Create tracker for unused expression attribute names/values

--- a/src/actions/tag_resource.rs
+++ b/src/actions/tag_resource.rs
@@ -1,6 +1,6 @@
 use crate::actions::helpers;
 use crate::errors::{DynoxideError, Result};
-use crate::storage::Storage;
+use crate::storage_backend::StorageBackend;
 use crate::types::Tag;
 use serde::{Deserialize, Serialize};
 
@@ -15,7 +15,10 @@ pub struct TagResourceRequest {
 #[derive(Debug, Default, Serialize)]
 pub struct TagResourceResponse {}
 
-pub fn execute(storage: &Storage, request: TagResourceRequest) -> Result<TagResourceResponse> {
+pub async fn execute<S: StorageBackend>(
+    storage: &S,
+    request: TagResourceRequest,
+) -> Result<TagResourceResponse> {
     let arn = request.resource_arn.as_deref().unwrap_or("");
     if arn.is_empty() {
         return Err(DynoxideError::ValidationException(
@@ -35,13 +38,13 @@ pub fn execute(storage: &Storage, request: TagResourceRequest) -> Result<TagReso
     }
 
     // Verify table exists
-    if !storage.table_exists(table_name)? {
+    if !storage.table_exists(table_name).await? {
         return Err(DynoxideError::ResourceNotFoundException(format!(
             "Requested resource not found: ResourcArn: {arn} not found"
         )));
     }
 
-    storage.set_tags(table_name, &request.tags)?;
+    storage.set_tags(table_name, &request.tags).await?;
 
     Ok(TagResourceResponse {})
 }

--- a/src/actions/transact_get_items.rs
+++ b/src/actions/transact_get_items.rs
@@ -1,7 +1,7 @@
 use crate::actions::helpers;
 use crate::errors::{CancellationReason, DynoxideError, Result};
 use crate::expressions;
-use crate::storage::Storage;
+use crate::storage_backend::StorageBackend;
 use crate::types::{AttributeValue, Item};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -46,8 +46,8 @@ pub struct TransactGetResponse {
     pub item: Option<Item>,
 }
 
-pub fn execute(
-    storage: &Storage,
+pub async fn execute<S: StorageBackend>(
+    storage: &S,
     request: TransactGetItemsRequest,
 ) -> Result<TransactGetItemsResponse> {
     // Validate: at least 1 action
@@ -86,7 +86,7 @@ pub fn execute(
 
     for transact_item in &request.transact_items {
         let get = &transact_item.get;
-        match validate_action(storage, get) {
+        match validate_action(storage, get).await {
             Ok(schema) => {
                 reasons.push(CancellationReason {
                     code: "None".to_string(),
@@ -150,7 +150,7 @@ pub fn execute(
         // TODO: validation must precede this call -- if reaching this line, caller has already validated keys.
         let (pk, sk) = helpers::extract_key_strings(&get.key, key_schema)?;
 
-        let item_json = storage.get_item(&get.table_name, &pk, &sk)?;
+        let item_json = storage.get_item(&get.table_name, &pk, &sk).await?;
 
         let item: Option<Item> = item_json.and_then(|j| serde_json::from_str(&j).ok());
 
@@ -226,9 +226,12 @@ pub fn execute(
 /// TransactGet action: table-name shape, table existence, parsed key schema,
 /// and key shape against that schema. Returns the resolved KeySchema so the
 /// caller can avoid re-parsing it before extract_key_strings.
-fn validate_action(storage: &Storage, get: &TransactGet) -> Result<helpers::KeySchema> {
+async fn validate_action<S: StorageBackend>(
+    storage: &S,
+    get: &TransactGet,
+) -> Result<helpers::KeySchema> {
     crate::validation::validate_table_name(&get.table_name)?;
-    let meta = helpers::require_table_for_item_op(storage, &get.table_name)?;
+    let meta = helpers::require_table_for_item_op(storage, &get.table_name).await?;
     let key_schema = helpers::parse_key_schema(&meta)?;
     helpers::validate_key_only(&get.key, &key_schema)?;
     Ok(key_schema)

--- a/src/actions/transact_write_items.rs
+++ b/src/actions/transact_write_items.rs
@@ -152,52 +152,37 @@ pub async fn execute<S: StorageBackend>(
         ));
     }
 
-    // Begin SQLite transaction
-    storage.begin_transaction().await?;
+    // All actions run inside one SQLite transaction (all-or-nothing).
+    helpers::with_write_transaction(storage, execute_within_transaction(storage, items)).await?;
 
-    let result = execute_within_transaction(storage, items).await;
-
-    match result {
-        Ok(()) => {
-            storage.commit().await?;
-            // Build consumed capacity per table
-            let consumed_capacity = if matches!(
-                request.return_consumed_capacity.as_deref(),
-                Some("TOTAL") | Some("INDEXES")
-            ) {
-                let mut table_sizes: HashMap<String, usize> = HashMap::new();
-                for item in items {
-                    let (table, size) = get_action_table_and_size(item);
-                    *table_sizes.entry(table).or_default() += size;
-                }
-                let caps: Vec<_> = table_sizes
-                    .iter()
-                    .filter_map(|(table, &size)| {
-                        crate::types::consumed_capacity(
-                            table,
-                            crate::types::write_capacity_units(size),
-                            &request.return_consumed_capacity,
-                        )
-                    })
-                    .collect();
-                Some(caps)
-            } else {
-                None
-            };
-            Ok(TransactWriteItemsResponse {
-                consumed_capacity,
-                item_collection_metrics: None,
+    // Build consumed capacity per table
+    let consumed_capacity = if matches!(
+        request.return_consumed_capacity.as_deref(),
+        Some("TOTAL") | Some("INDEXES")
+    ) {
+        let mut table_sizes: HashMap<String, usize> = HashMap::new();
+        for item in items {
+            let (table, size) = get_action_table_and_size(item);
+            *table_sizes.entry(table).or_default() += size;
+        }
+        let caps: Vec<_> = table_sizes
+            .iter()
+            .filter_map(|(table, &size)| {
+                crate::types::consumed_capacity(
+                    table,
+                    crate::types::write_capacity_units(size),
+                    &request.return_consumed_capacity,
+                )
             })
-        }
-        Err(e) => {
-            if let Err(rb_err) = storage.rollback().await {
-                return Err(DynoxideError::InternalServerError(format!(
-                    "Transaction failed ({e}) and rollback also failed ({rb_err})"
-                )));
-            }
-            Err(e)
-        }
-    }
+            .collect();
+        Some(caps)
+    } else {
+        None
+    };
+    Ok(TransactWriteItemsResponse {
+        consumed_capacity,
+        item_collection_metrics: None,
+    })
 }
 
 async fn execute_within_transaction<S: StorageBackend>(

--- a/src/actions/transact_write_items.rs
+++ b/src/actions/transact_write_items.rs
@@ -1,6 +1,6 @@
 use crate::actions::helpers;
 use crate::errors::{CancellationReason, DynoxideError, Result};
-use crate::storage::Storage;
+use crate::storage_backend::StorageBackend;
 use crate::types::{self, AttributeValue, Item};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -108,8 +108,8 @@ pub struct TransactWriteItemsResponse {
     pub item_collection_metrics: Option<HashMap<String, Vec<crate::types::ItemCollectionMetrics>>>,
 }
 
-pub fn execute(
-    storage: &Storage,
+pub async fn execute<S: StorageBackend>(
+    storage: &S,
     request: TransactWriteItemsRequest,
 ) -> Result<TransactWriteItemsResponse> {
     let items = &request.transact_items;
@@ -136,7 +136,7 @@ pub fn execute(
     // Validate: no duplicate item targets
     let mut seen_targets = HashSet::new();
     for item in items {
-        let target = get_item_target(storage, item)?;
+        let target = get_item_target(storage, item).await?;
         if !seen_targets.insert(target) {
             return Err(DynoxideError::ValidationException(
                 "Transaction request cannot include multiple operations on one item".to_string(),
@@ -153,13 +153,13 @@ pub fn execute(
     }
 
     // Begin SQLite transaction
-    storage.begin_transaction()?;
+    storage.begin_transaction().await?;
 
-    let result = execute_within_transaction(storage, items);
+    let result = execute_within_transaction(storage, items).await;
 
     match result {
         Ok(()) => {
-            storage.commit()?;
+            storage.commit().await?;
             // Build consumed capacity per table
             let consumed_capacity = if matches!(
                 request.return_consumed_capacity.as_deref(),
@@ -190,7 +190,7 @@ pub fn execute(
             })
         }
         Err(e) => {
-            if let Err(rb_err) = storage.rollback() {
+            if let Err(rb_err) = storage.rollback().await {
                 return Err(DynoxideError::InternalServerError(format!(
                     "Transaction failed ({e}) and rollback also failed ({rb_err})"
                 )));
@@ -200,12 +200,15 @@ pub fn execute(
     }
 }
 
-fn execute_within_transaction(storage: &Storage, items: &[TransactWriteItem]) -> Result<()> {
+async fn execute_within_transaction<S: StorageBackend>(
+    storage: &S,
+    items: &[TransactWriteItem],
+) -> Result<()> {
     let mut cancellation_reasons: Vec<CancellationReason> = Vec::with_capacity(items.len());
     let mut has_failure = false;
 
     for item in items {
-        let reason = execute_single_action(storage, item);
+        let reason = execute_single_action(storage, item).await;
         match reason {
             Ok(()) => {
                 cancellation_reasons.push(CancellationReason {
@@ -251,15 +254,18 @@ fn execute_within_transaction(storage: &Storage, items: &[TransactWriteItem]) ->
     Ok(())
 }
 
-fn execute_single_action(storage: &Storage, item: &TransactWriteItem) -> Result<()> {
+async fn execute_single_action<S: StorageBackend>(
+    storage: &S,
+    item: &TransactWriteItem,
+) -> Result<()> {
     if let Some(ref put) = item.put {
-        execute_put(storage, put)
+        execute_put(storage, put).await
     } else if let Some(ref update) = item.update {
-        execute_update(storage, update)
+        execute_update(storage, update).await
     } else if let Some(ref delete) = item.delete {
-        execute_delete(storage, delete)
+        execute_delete(storage, delete).await
     } else if let Some(ref check) = item.condition_check {
-        execute_condition_check(storage, check)
+        execute_condition_check(storage, check).await
     } else {
         Err(DynoxideError::ValidationException(
             "TransactItem must contain exactly one of Put, Update, Delete, or ConditionCheck"
@@ -268,9 +274,9 @@ fn execute_single_action(storage: &Storage, item: &TransactWriteItem) -> Result<
     }
 }
 
-fn execute_put(storage: &Storage, put: &TransactPut) -> Result<()> {
+async fn execute_put<S: StorageBackend>(storage: &S, put: &TransactPut) -> Result<()> {
     crate::validation::validate_table_name(&put.table_name)?;
-    let meta = helpers::require_table_for_item_op(storage, &put.table_name)?;
+    let meta = helpers::require_table_for_item_op(storage, &put.table_name).await?;
     let key_schema = helpers::parse_key_schema(&meta)?;
 
     helpers::validate_item_keys(&put.item, &key_schema, &meta)?;
@@ -304,7 +310,7 @@ fn execute_put(storage: &Storage, put: &TransactPut) -> Result<()> {
 
     // Evaluate condition if present
     if let Some(ref cond_expr) = put.condition_expression {
-        let existing_json = storage.get_item(&put.table_name, &pk, &sk)?;
+        let existing_json = storage.get_item(&put.table_name, &pk, &sk).await?;
         let existing_item: Item = existing_json
             .as_ref()
             .and_then(|j| serde_json::from_str(j).ok())
@@ -329,8 +335,9 @@ fn execute_put(storage: &Storage, put: &TransactPut) -> Result<()> {
         .get(&key_schema.partition_key)
         .map(crate::storage::compute_hash_prefix)
         .unwrap_or_default();
-    let old_json =
-        storage.put_item_with_hash(&put.table_name, &pk, &sk, &item_json, size, &hash_prefix)?;
+    let old_json = storage
+        .put_item_with_hash(&put.table_name, &pk, &sk, &item_json, size, &hash_prefix)
+        .await?;
 
     let _ = super::gsi::maintain_gsis_after_write(
         storage,
@@ -341,7 +348,8 @@ fn execute_put(storage: &Storage, put: &TransactPut) -> Result<()> {
         &item,
         &key_schema.partition_key,
         key_schema.sort_key.as_deref(),
-    )?;
+    )
+    .await?;
 
     super::lsi::maintain_lsis_after_write(
         storage,
@@ -352,25 +360,26 @@ fn execute_put(storage: &Storage, put: &TransactPut) -> Result<()> {
         &item,
         &key_schema.partition_key,
         key_schema.sort_key.as_deref(),
-    )?;
+    )
+    .await?;
 
     // Record stream event
     let old_item: Option<Item> = old_json.and_then(|j| serde_json::from_str(&j).ok());
-    crate::streams::record_stream_event(storage, &meta, old_item.as_ref(), Some(&item))?;
+    crate::streams::record_stream_event(storage, &meta, old_item.as_ref(), Some(&item)).await?;
 
     Ok(())
 }
 
-fn execute_update(storage: &Storage, update: &TransactUpdate) -> Result<()> {
+async fn execute_update<S: StorageBackend>(storage: &S, update: &TransactUpdate) -> Result<()> {
     crate::validation::validate_table_name(&update.table_name)?;
-    let meta = helpers::require_table_for_item_op(storage, &update.table_name)?;
+    let meta = helpers::require_table_for_item_op(storage, &update.table_name).await?;
     let key_schema = helpers::parse_key_schema(&meta)?;
 
     helpers::validate_key_only(&update.key, &key_schema)?;
     // TODO: validation must precede this call -- if reaching this line, caller has already validated keys.
     let (pk, sk) = helpers::extract_key_strings(&update.key, &key_schema)?;
 
-    let existing_json = storage.get_item(&update.table_name, &pk, &sk)?;
+    let existing_json = storage.get_item(&update.table_name, &pk, &sk).await?;
     let existing_item: Item = existing_json
         .as_ref()
         .and_then(|j| serde_json::from_str(j).ok())
@@ -444,7 +453,9 @@ fn execute_update(storage: &Storage, update: &TransactUpdate) -> Result<()> {
         .get(&key_schema.partition_key)
         .map(crate::storage::compute_hash_prefix)
         .unwrap_or_default();
-    storage.put_item_with_hash(&update.table_name, &pk, &sk, &item_json, size, &hash_prefix)?;
+    storage
+        .put_item_with_hash(&update.table_name, &pk, &sk, &item_json, size, &hash_prefix)
+        .await?;
 
     let _ = super::gsi::maintain_gsis_after_write(
         storage,
@@ -455,7 +466,8 @@ fn execute_update(storage: &Storage, update: &TransactUpdate) -> Result<()> {
         &item,
         &key_schema.partition_key,
         key_schema.sort_key.as_deref(),
-    )?;
+    )
+    .await?;
 
     super::lsi::maintain_lsis_after_write(
         storage,
@@ -466,18 +478,19 @@ fn execute_update(storage: &Storage, update: &TransactUpdate) -> Result<()> {
         &item,
         &key_schema.partition_key,
         key_schema.sort_key.as_deref(),
-    )?;
+    )
+    .await?;
 
     // Record stream event
     let old_item: Option<Item> = old_for_stream.and_then(|j| serde_json::from_str(&j).ok());
-    crate::streams::record_stream_event(storage, &meta, old_item.as_ref(), Some(&item))?;
+    crate::streams::record_stream_event(storage, &meta, old_item.as_ref(), Some(&item)).await?;
 
     Ok(())
 }
 
-fn execute_delete(storage: &Storage, delete: &TransactDelete) -> Result<()> {
+async fn execute_delete<S: StorageBackend>(storage: &S, delete: &TransactDelete) -> Result<()> {
     crate::validation::validate_table_name(&delete.table_name)?;
-    let meta = helpers::require_table_for_item_op(storage, &delete.table_name)?;
+    let meta = helpers::require_table_for_item_op(storage, &delete.table_name).await?;
     let key_schema = helpers::parse_key_schema(&meta)?;
 
     helpers::validate_key_only(&delete.key, &key_schema)?;
@@ -498,7 +511,7 @@ fn execute_delete(storage: &Storage, delete: &TransactDelete) -> Result<()> {
 
     // Evaluate condition if present
     if let Some(ref cond_expr) = delete.condition_expression {
-        let existing_json = storage.get_item(&delete.table_name, &pk, &sk)?;
+        let existing_json = storage.get_item(&delete.table_name, &pk, &sk).await?;
         let existing_item: Item = existing_json
             .as_ref()
             .and_then(|j| serde_json::from_str(j).ok())
@@ -517,29 +530,33 @@ fn execute_delete(storage: &Storage, delete: &TransactDelete) -> Result<()> {
 
     tracker.check_unused()?;
 
-    let old_json = storage.delete_item(&delete.table_name, &pk, &sk)?;
-    let _ = super::gsi::maintain_gsis_after_delete(storage, &delete.table_name, &meta, &pk, &sk)?;
-    super::lsi::maintain_lsis_after_delete(storage, &delete.table_name, &meta, &pk, &sk)?;
+    let old_json = storage.delete_item(&delete.table_name, &pk, &sk).await?;
+    let _ = super::gsi::maintain_gsis_after_delete(storage, &delete.table_name, &meta, &pk, &sk)
+        .await?;
+    super::lsi::maintain_lsis_after_delete(storage, &delete.table_name, &meta, &pk, &sk).await?;
 
     // Record stream event
     let old_item: Option<Item> = old_json.and_then(|j| serde_json::from_str(&j).ok());
     if old_item.is_some() {
-        crate::streams::record_stream_event(storage, &meta, old_item.as_ref(), None)?;
+        crate::streams::record_stream_event(storage, &meta, old_item.as_ref(), None).await?;
     }
 
     Ok(())
 }
 
-fn execute_condition_check(storage: &Storage, check: &TransactConditionCheck) -> Result<()> {
+async fn execute_condition_check<S: StorageBackend>(
+    storage: &S,
+    check: &TransactConditionCheck,
+) -> Result<()> {
     crate::validation::validate_table_name(&check.table_name)?;
-    let meta = helpers::require_table_for_item_op(storage, &check.table_name)?;
+    let meta = helpers::require_table_for_item_op(storage, &check.table_name).await?;
     let key_schema = helpers::parse_key_schema(&meta)?;
 
     helpers::validate_key_only(&check.key, &key_schema)?;
     // TODO: validation must precede this call -- if reaching this line, caller has already validated keys.
     let (pk, sk) = helpers::extract_key_strings(&check.key, &key_schema)?;
 
-    let existing_json = storage.get_item(&check.table_name, &pk, &sk)?;
+    let existing_json = storage.get_item(&check.table_name, &pk, &sk).await?;
     let existing_item: Item = existing_json
         .as_ref()
         .and_then(|j| serde_json::from_str(j).ok())
@@ -619,31 +636,34 @@ fn get_action_table_and_size(item: &TransactWriteItem) -> (String, usize) {
 }
 
 /// Get a unique target key (table + pk + sk) for duplicate detection.
-fn get_item_target(storage: &Storage, item: &TransactWriteItem) -> Result<String> {
+async fn get_item_target<S: StorageBackend>(
+    storage: &S,
+    item: &TransactWriteItem,
+) -> Result<String> {
     if let Some(ref put) = item.put {
         crate::validation::validate_table_name(&put.table_name)?;
-        let meta = helpers::require_table_for_item_op(storage, &put.table_name)?;
+        let meta = helpers::require_table_for_item_op(storage, &put.table_name).await?;
         let key_schema = helpers::parse_key_schema(&meta)?;
         // TODO: validation must precede this call -- if reaching this line, caller has already validated keys.
         let (pk, sk) = helpers::extract_key_strings(&put.item, &key_schema)?;
         Ok(format!("{}#{}#{}", put.table_name, pk, sk))
     } else if let Some(ref update) = item.update {
         crate::validation::validate_table_name(&update.table_name)?;
-        let meta = helpers::require_table_for_item_op(storage, &update.table_name)?;
+        let meta = helpers::require_table_for_item_op(storage, &update.table_name).await?;
         let key_schema = helpers::parse_key_schema(&meta)?;
         // TODO: validation must precede this call -- if reaching this line, caller has already validated keys.
         let (pk, sk) = helpers::extract_key_strings(&update.key, &key_schema)?;
         Ok(format!("{}#{}#{}", update.table_name, pk, sk))
     } else if let Some(ref delete) = item.delete {
         crate::validation::validate_table_name(&delete.table_name)?;
-        let meta = helpers::require_table_for_item_op(storage, &delete.table_name)?;
+        let meta = helpers::require_table_for_item_op(storage, &delete.table_name).await?;
         let key_schema = helpers::parse_key_schema(&meta)?;
         // TODO: validation must precede this call -- if reaching this line, caller has already validated keys.
         let (pk, sk) = helpers::extract_key_strings(&delete.key, &key_schema)?;
         Ok(format!("{}#{}#{}", delete.table_name, pk, sk))
     } else if let Some(ref check) = item.condition_check {
         crate::validation::validate_table_name(&check.table_name)?;
-        let meta = helpers::require_table_for_item_op(storage, &check.table_name)?;
+        let meta = helpers::require_table_for_item_op(storage, &check.table_name).await?;
         let key_schema = helpers::parse_key_schema(&meta)?;
         // TODO: validation must precede this call -- if reaching this line, caller has already validated keys.
         let (pk, sk) = helpers::extract_key_strings(&check.key, &key_schema)?;

--- a/src/actions/untag_resource.rs
+++ b/src/actions/untag_resource.rs
@@ -1,6 +1,6 @@
 use crate::actions::helpers;
 use crate::errors::{DynoxideError, Result};
-use crate::storage::Storage;
+use crate::storage_backend::StorageBackend;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Default, Deserialize)]
@@ -14,7 +14,10 @@ pub struct UntagResourceRequest {
 #[derive(Debug, Default, Serialize)]
 pub struct UntagResourceResponse {}
 
-pub fn execute(storage: &Storage, request: UntagResourceRequest) -> Result<UntagResourceResponse> {
+pub async fn execute<S: StorageBackend>(
+    storage: &S,
+    request: UntagResourceRequest,
+) -> Result<UntagResourceResponse> {
     let arn = request.resource_arn.as_deref().unwrap_or("");
     if arn.is_empty() {
         return Err(DynoxideError::ValidationException(
@@ -31,13 +34,13 @@ pub fn execute(storage: &Storage, request: UntagResourceRequest) -> Result<Untag
     }
 
     // Verify table exists
-    if !storage.table_exists(table_name)? {
+    if !storage.table_exists(table_name).await? {
         return Err(DynoxideError::ResourceNotFoundException(
             "Requested resource not found".to_string(),
         ));
     }
 
-    storage.remove_tags(table_name, &request.tag_keys)?;
+    storage.remove_tags(table_name, &request.tag_keys).await?;
 
     Ok(UntagResourceResponse {})
 }

--- a/src/actions/update_item.rs
+++ b/src/actions/update_item.rs
@@ -1,6 +1,6 @@
 use crate::actions::helpers;
 use crate::errors::{DynoxideError, Result};
-use crate::storage::Storage;
+use crate::storage_backend::StorageBackend;
 use crate::types::{self, AttributeValue};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -187,7 +187,10 @@ fn wrap_invalid_update_expression(err: String) -> String {
     }
 }
 
-pub fn execute(storage: &Storage, mut request: UpdateItemRequest) -> Result<UpdateItemResponse> {
+pub async fn execute<S: StorageBackend>(
+    storage: &S,
+    mut request: UpdateItemRequest,
+) -> Result<UpdateItemResponse> {
     // Validate table name format before checking existence (DynamoDB validates input first)
     crate::validation::validate_table_name(&request.table_name)?;
 
@@ -372,7 +375,7 @@ pub fn execute(storage: &Storage, mut request: UpdateItemRequest) -> Result<Upda
         }
     }
 
-    let meta = helpers::require_table_for_item_op(storage, &request.table_name)?;
+    let meta = helpers::require_table_for_item_op(storage, &request.table_name).await?;
     let key_schema = helpers::parse_key_schema(&meta)?;
 
     // Validate ReturnValues parameter
@@ -405,7 +408,7 @@ pub fn execute(storage: &Storage, mut request: UpdateItemRequest) -> Result<Upda
     // Wrap condition check + write in a transaction to prevent TOCTOU races
     let has_condition = request.condition_expression.is_some();
     if has_condition {
-        storage.begin_transaction()?;
+        storage.begin_transaction().await?;
     }
 
     // Execution tracker — tracking disabled because unused-reference validation was
@@ -417,10 +420,10 @@ pub fn execute(storage: &Storage, mut request: UpdateItemRequest) -> Result<Upda
     );
 
     // Execute the condition check + update + write atomically within a transaction.
-    // The closure captures everything from get_item through put_item.
-    let transactional_work = || -> Result<UpdateWorkResult> {
+    // The block captures everything from get_item through put_item.
+    let result: Result<UpdateWorkResult> = async {
         // Fetch existing item (or create empty one for upsert)
-        let existing_json = storage.get_item(&request.table_name, &pk, &sk)?;
+        let existing_json = storage.get_item(&request.table_name, &pk, &sk).await?;
         let existing_item: HashMap<String, AttributeValue> = existing_json
             .as_ref()
             .and_then(|j| serde_json::from_str(j).ok())
@@ -539,14 +542,16 @@ pub fn execute(storage: &Storage, mut request: UpdateItemRequest) -> Result<Upda
             .get(&key_schema.partition_key)
             .map(crate::storage::compute_hash_prefix)
             .unwrap_or_default();
-        storage.put_item_with_hash(
-            &request.table_name,
-            &pk,
-            &sk,
-            &item_json,
-            size,
-            &hash_prefix,
-        )?;
+        storage
+            .put_item_with_hash(
+                &request.table_name,
+                &pk,
+                &sk,
+                &item_json,
+                size,
+                &hash_prefix,
+            )
+            .await?;
 
         Ok(UpdateWorkResult {
             existing_json,
@@ -555,16 +560,15 @@ pub fn execute(storage: &Storage, mut request: UpdateItemRequest) -> Result<Upda
             item_json,
             size,
         })
-    };
-
-    let result = transactional_work();
+    }
+    .await;
 
     // Commit or rollback the condition+write transaction
     if has_condition {
         match result {
-            Ok(_) => storage.commit()?,
+            Ok(_) => storage.commit().await?,
             Err(ref _e) => {
-                let _ = storage.rollback();
+                let _ = storage.rollback().await;
             }
         }
     }
@@ -587,7 +591,8 @@ pub fn execute(storage: &Storage, mut request: UpdateItemRequest) -> Result<Upda
         &item,
         &key_schema.partition_key,
         key_schema.sort_key.as_deref(),
-    )?;
+    )
+    .await?;
 
     // Maintain LSI tables
     super::lsi::maintain_lsis_after_write(
@@ -599,7 +604,8 @@ pub fn execute(storage: &Storage, mut request: UpdateItemRequest) -> Result<Upda
         &item,
         &key_schema.partition_key,
         key_schema.sort_key.as_deref(),
-    )?;
+    )
+    .await?;
 
     // Record stream event
     let old_for_stream = if existing_json.is_some() {
@@ -607,7 +613,7 @@ pub fn execute(storage: &Storage, mut request: UpdateItemRequest) -> Result<Upda
     } else {
         None
     };
-    crate::streams::record_stream_event(storage, &meta, old_for_stream, Some(&item))?;
+    crate::streams::record_stream_event(storage, &meta, old_for_stream, Some(&item)).await?;
 
     // Handle ReturnValues
     let return_values = request.return_values.as_deref().unwrap_or("NONE");
@@ -667,7 +673,8 @@ pub fn execute(storage: &Storage, mut request: UpdateItemRequest) -> Result<Upda
             .as_ref()
             .unwrap_or(&AttributeValue::S(String::new())),
         &request.return_item_collection_metrics,
-    )?;
+    )
+    .await?;
 
     let consumed_capacity = types::consumed_capacity_with_indexes(
         &request.table_name,

--- a/src/actions/update_item.rs
+++ b/src/actions/update_item.rs
@@ -846,3 +846,75 @@ fn validate_not_key_attr(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::actions::{create_table, put_item, update_item};
+    use crate::storage::Storage;
+    use crate::storage_backend::StorageBackend;
+
+    /// An update and its GSI fan-out succeed or fail as one unit: a mid-fan-out
+    /// failure leaves the item at its pre-update value.
+    #[test]
+    fn update_item_rolls_back_base_write_when_gsi_fan_out_fails() {
+        let storage = Storage::memory().unwrap();
+
+        let create = serde_json::from_value(serde_json::json!({
+            "TableName": "Orders",
+            "KeySchema": [{"AttributeName": "UserId", "KeyType": "HASH"}],
+            "AttributeDefinitions": [
+                {"AttributeName": "UserId", "AttributeType": "S"},
+                {"AttributeName": "Status", "AttributeType": "S"},
+                {"AttributeName": "Priority", "AttributeType": "S"}
+            ],
+            "GlobalSecondaryIndexes": [
+                {"IndexName": "StatusIndex", "KeySchema": [{"AttributeName": "Status", "KeyType": "HASH"}], "Projection": {"ProjectionType": "ALL"}},
+                {"IndexName": "PriorityIndex", "KeySchema": [{"AttributeName": "Priority", "KeyType": "HASH"}], "Projection": {"ProjectionType": "ALL"}}
+            ]
+        }))
+        .unwrap();
+        pollster::block_on(create_table::execute(&storage, create)).unwrap();
+
+        let put = serde_json::from_value(serde_json::json!({
+            "TableName": "Orders",
+            "Item": {"UserId": {"S": "u1"}, "Status": {"S": "SHIPPED"}, "Priority": {"S": "HIGH"}, "Note": {"S": "before"}}
+        }))
+        .unwrap();
+        pollster::block_on(put_item::execute(&storage, put)).unwrap();
+
+        // Break the second GSI's fan-out by dropping its physical table.
+        storage.drop_gsi_table("Orders", "PriorityIndex").unwrap();
+
+        let update = serde_json::from_value(serde_json::json!({
+            "TableName": "Orders",
+            "Key": {"UserId": {"S": "u1"}},
+            "UpdateExpression": "SET Note = :n",
+            "ExpressionAttributeValues": {":n": {"S": "after"}}
+        }))
+        .unwrap();
+        let res = pollster::block_on(update_item::execute(&storage, update));
+        assert!(
+            res.is_err(),
+            "a mid-fan-out failure must surface as an error"
+        );
+
+        // The base write must roll back: the item is still present at its
+        // pre-update value.
+        let rows = pollster::block_on(<Storage as StorageBackend>::scan_items(
+            &storage,
+            "Orders",
+            &Default::default(),
+        ))
+        .unwrap();
+        assert_eq!(
+            rows.len(),
+            1,
+            "the item must still be present after rollback"
+        );
+        let raw = &rows[0].2;
+        assert!(
+            raw.contains("\"before\"") && !raw.contains("\"after\""),
+            "update must roll back when fan-out fails, leaving the original value: {raw}"
+        );
+    }
+}

--- a/src/actions/update_item.rs
+++ b/src/actions/update_item.rs
@@ -404,12 +404,6 @@ pub async fn execute<S: StorageBackend>(
         .as_ref()
         .map(|updates| updates.keys().cloned().collect());
 
-    // Wrap the condition check, base write and the GSI/LSI fan-out in a single
-    // transaction so a mid-fan-out failure rolls the whole update back, leaving
-    // no torn index. Unconditional because the atomicity guarantee applies to
-    // every single-item write.
-    storage.begin_transaction().await?;
-
     // Execution tracker — tracking disabled because unused-reference validation was
     // already done statically by Tracker 1 (pre-validation block above). This tracker
     // only needs name/value resolution, not usage tracking.
@@ -418,10 +412,20 @@ pub async fn execute<S: StorageBackend>(
         &request.expression_attribute_values,
     );
 
-    // Execute the condition check + update + write + index fan-out atomically
-    // within the transaction. The block captures everything from get_item
+    // Wrap the condition check, base write and the GSI/LSI fan-out in a single
+    // transaction so a mid-fan-out failure rolls the whole update back, leaving
+    // no torn index. Unconditional because the atomicity guarantee applies to
+    // every single-item write. The block captures everything from get_item
     // through the GSI/LSI fan-out and stream record.
-    let result: Result<(UpdateWorkResult, HashMap<String, f64>)> = async {
+    let (
+        UpdateWorkResult {
+            old_item,
+            item,
+            item_json,
+            size,
+        },
+        gsi_units,
+    ) = helpers::with_write_transaction(storage, async {
         // Fetch existing item (or create empty one for upsert)
         let existing_json = storage.get_item(&request.table_name, &pk, &sk).await?;
         let existing_item: HashMap<String, AttributeValue> = existing_json
@@ -596,26 +600,8 @@ pub async fn execute<S: StorageBackend>(
             },
             gsi_units,
         ))
-    }
-    .await;
-
-    // Commit on success, roll back the whole update on any failure.
-    match result {
-        Ok(_) => storage.commit().await?,
-        Err(ref _e) => {
-            let _ = storage.rollback().await;
-        }
-    }
-
-    let (
-        UpdateWorkResult {
-            old_item,
-            item,
-            item_json,
-            size,
-        },
-        gsi_units,
-    ) = result?;
+    })
+    .await?;
 
     // Handle ReturnValues
     let return_values = request.return_values.as_deref().unwrap_or("NONE");

--- a/src/actions/update_item.rs
+++ b/src/actions/update_item.rs
@@ -7,7 +7,6 @@ use std::collections::HashMap;
 
 /// Internal result from the transactional update work closure.
 struct UpdateWorkResult {
-    existing_json: Option<String>,
     old_item: HashMap<String, AttributeValue>,
     item: HashMap<String, AttributeValue>,
     item_json: String,
@@ -405,11 +404,11 @@ pub async fn execute<S: StorageBackend>(
         .as_ref()
         .map(|updates| updates.keys().cloned().collect());
 
-    // Wrap condition check + write in a transaction to prevent TOCTOU races
-    let has_condition = request.condition_expression.is_some();
-    if has_condition {
-        storage.begin_transaction().await?;
-    }
+    // Wrap the condition check, base write and the GSI/LSI fan-out in a single
+    // transaction so a mid-fan-out failure rolls the whole update back, leaving
+    // no torn index. Unconditional because the atomicity guarantee applies to
+    // every single-item write.
+    storage.begin_transaction().await?;
 
     // Execution tracker — tracking disabled because unused-reference validation was
     // already done statically by Tracker 1 (pre-validation block above). This tracker
@@ -419,9 +418,10 @@ pub async fn execute<S: StorageBackend>(
         &request.expression_attribute_values,
     );
 
-    // Execute the condition check + update + write atomically within a transaction.
-    // The block captures everything from get_item through put_item.
-    let result: Result<UpdateWorkResult> = async {
+    // Execute the condition check + update + write + index fan-out atomically
+    // within the transaction. The block captures everything from get_item
+    // through the GSI/LSI fan-out and stream record.
+    let result: Result<(UpdateWorkResult, HashMap<String, f64>)> = async {
         // Fetch existing item (or create empty one for upsert)
         let existing_json = storage.get_item(&request.table_name, &pk, &sk).await?;
         let existing_item: HashMap<String, AttributeValue> = existing_json
@@ -553,67 +553,69 @@ pub async fn execute<S: StorageBackend>(
             )
             .await?;
 
-        Ok(UpdateWorkResult {
-            existing_json,
+        // Maintain GSI tables (inside the transaction)
+        let gsi_units = super::gsi::maintain_gsis_after_write(
+            storage,
+            &request.table_name,
+            &meta,
+            &pk,
+            &sk,
+            &item,
+            &key_schema.partition_key,
+            key_schema.sort_key.as_deref(),
+        )
+        .await?;
+
+        // Maintain LSI tables (inside the transaction)
+        super::lsi::maintain_lsis_after_write(
+            storage,
+            &request.table_name,
+            &meta,
+            &pk,
+            &sk,
+            &item,
+            &key_schema.partition_key,
+            key_schema.sort_key.as_deref(),
+        )
+        .await?;
+
+        // Record stream event (inside the transaction)
+        let old_for_stream = if existing_json.is_some() {
+            Some(&old_item)
+        } else {
+            None
+        };
+        crate::streams::record_stream_event(storage, &meta, old_for_stream, Some(&item)).await?;
+
+        Ok((
+            UpdateWorkResult {
+                old_item,
+                item,
+                item_json,
+                size,
+            },
+            gsi_units,
+        ))
+    }
+    .await;
+
+    // Commit on success, roll back the whole update on any failure.
+    match result {
+        Ok(_) => storage.commit().await?,
+        Err(ref _e) => {
+            let _ = storage.rollback().await;
+        }
+    }
+
+    let (
+        UpdateWorkResult {
             old_item,
             item,
             item_json,
             size,
-        })
-    }
-    .await;
-
-    // Commit or rollback the condition+write transaction
-    if has_condition {
-        match result {
-            Ok(_) => storage.commit().await?,
-            Err(ref _e) => {
-                let _ = storage.rollback().await;
-            }
-        }
-    }
-
-    let UpdateWorkResult {
-        existing_json,
-        old_item,
-        item,
-        item_json,
-        size,
-    } = result?;
-
-    // Maintain GSI tables
-    let gsi_units = super::gsi::maintain_gsis_after_write(
-        storage,
-        &request.table_name,
-        &meta,
-        &pk,
-        &sk,
-        &item,
-        &key_schema.partition_key,
-        key_schema.sort_key.as_deref(),
-    )
-    .await?;
-
-    // Maintain LSI tables
-    super::lsi::maintain_lsis_after_write(
-        storage,
-        &request.table_name,
-        &meta,
-        &pk,
-        &sk,
-        &item,
-        &key_schema.partition_key,
-        key_schema.sort_key.as_deref(),
-    )
-    .await?;
-
-    // Record stream event
-    let old_for_stream = if existing_json.is_some() {
-        Some(&old_item)
-    } else {
-        None
-    };
-    crate::streams::record_stream_event(storage, &meta, old_for_stream, Some(&item)).await?;
+        },
+        gsi_units,
+    ) = result?;
 
     // Handle ReturnValues
     let return_values = request.return_values.as_deref().unwrap_or("NONE");

--- a/src/actions/update_table.rs
+++ b/src/actions/update_table.rs
@@ -2,7 +2,7 @@ use crate::actions::create_table::StreamSpecification;
 use crate::actions::{TableDescription, build_table_description};
 use crate::actions::{gsi, helpers};
 use crate::errors::{DynoxideError, Result};
-use crate::storage::Storage;
+use crate::storage_backend::StorageBackend;
 use crate::streams;
 use crate::types::{AttributeDefinition, GlobalSecondaryIndex, KeySchemaElement, Projection};
 use crate::validation;
@@ -144,7 +144,10 @@ pub struct UpdateTableResponse {
     pub table_description: TableDescription,
 }
 
-pub fn execute(storage: &Storage, request: UpdateTableRequest) -> Result<UpdateTableResponse> {
+pub async fn execute<S: StorageBackend>(
+    storage: &S,
+    request: UpdateTableRequest,
+) -> Result<UpdateTableResponse> {
     // Table name validation is handled in the Deserialize impl
 
     // Phase 1: Validate request parameters BEFORE table existence check
@@ -153,7 +156,7 @@ pub fn execute(storage: &Storage, request: UpdateTableRequest) -> Result<UpdateT
     validate_update_request(&request)?;
 
     // Phase 2: Table existence check
-    let meta = helpers::require_table(storage, &request.table_name)?;
+    let meta = helpers::require_table(storage, &request.table_name).await?;
 
     let current_billing_mode = meta.billing_mode.as_deref().unwrap_or("PROVISIONED");
 
@@ -354,9 +357,9 @@ pub fn execute(storage: &Storage, request: UpdateTableRequest) -> Result<UpdateT
     let is_decrease = new_rcu < cur_rcu || new_wcu < cur_wcu;
 
     // All validation passed — perform mutations inside a transaction
-    storage.begin_transaction()?;
+    storage.begin_transaction().await?;
 
-    let result = (|| -> Result<()> {
+    let result: Result<()> = async {
         if let Some(ref updates) = request.global_secondary_index_updates {
             for update in updates {
                 if let Some(ref create) = update.create {
@@ -367,16 +370,20 @@ pub fn execute(storage: &Storage, request: UpdateTableRequest) -> Result<UpdateT
                         provisioned_throughput: None,
                     };
 
-                    storage.create_gsi_table(&request.table_name, &create.index_name)?;
+                    storage
+                        .create_gsi_table(&request.table_name, &create.index_name)
+                        .await?;
 
                     let gsi_p = gsi::gsi_to_def(&gsi_def)?;
-                    backfill_gsi(storage, &request.table_name, &key_schema, &gsi_p)?;
+                    backfill_gsi(storage, &request.table_name, &key_schema, &gsi_p).await?;
 
                     current_gsis.push(gsi_def);
                 }
 
                 if let Some(ref delete) = update.delete {
-                    storage.drop_gsi_table(&request.table_name, &delete.index_name)?;
+                    storage
+                        .drop_gsi_table(&request.table_name, &delete.index_name)
+                        .await?;
                     current_gsis.retain(|g| g.index_name != delete.index_name);
                 }
             }
@@ -394,7 +401,9 @@ pub fn execute(storage: &Storage, request: UpdateTableRequest) -> Result<UpdateT
             )
         };
 
-        storage.update_table_metadata(&request.table_name, &attr_defs_json, gsi_json.as_deref())?;
+        storage
+            .update_table_metadata(&request.table_name, &attr_defs_json, gsi_json.as_deref())
+            .await?;
 
         // Update provisioned throughput if requested
         if is_pt_update {
@@ -419,20 +428,28 @@ pub fn execute(storage: &Storage, request: UpdateTableRequest) -> Result<UpdateT
             }
             let pt_json = serde_json::to_string(&stored)
                 .map_err(|e| DynoxideError::InternalServerError(e.to_string()))?;
-            storage.update_provisioned_throughput(&request.table_name, &pt_json)?;
+            storage
+                .update_provisioned_throughput(&request.table_name, &pt_json)
+                .await?;
         }
 
         // Handle deletion protection changes
         if let Some(enabled) = request.deletion_protection_enabled {
-            storage.update_deletion_protection(&request.table_name, enabled)?;
+            storage
+                .update_deletion_protection(&request.table_name, enabled)
+                .await?;
         }
 
         // Handle billing mode changes
         if let Some(ref billing_mode) = request.billing_mode {
-            storage.update_billing_mode(&request.table_name, billing_mode)?;
+            storage
+                .update_billing_mode(&request.table_name, billing_mode)
+                .await?;
             if billing_mode == "PAY_PER_REQUEST" {
                 // Clear provisioned throughput to avoid stale data
-                storage.clear_provisioned_throughput(&request.table_name)?;
+                storage
+                    .clear_provisioned_throughput(&request.table_name)
+                    .await?;
             }
         }
 
@@ -444,25 +461,28 @@ pub fn execute(storage: &Storage, request: UpdateTableRequest) -> Result<UpdateT
                     .as_deref()
                     .unwrap_or("NEW_AND_OLD_IMAGES");
                 let label = streams::generate_stream_label(storage.clock());
-                storage.enable_stream(&request.table_name, view_type, &label)?;
+                storage
+                    .enable_stream(&request.table_name, view_type, &label)
+                    .await?;
             } else {
-                storage.disable_stream(&request.table_name)?;
+                storage.disable_stream(&request.table_name).await?;
             }
         }
 
         Ok(())
-    })();
+    }
+    .await;
 
     match result {
-        Ok(()) => storage.commit()?,
+        Ok(()) => storage.commit().await?,
         Err(e) => {
-            let _ = storage.rollback();
+            let _ = storage.rollback().await;
             return Err(e);
         }
     }
 
     // Build response from updated metadata
-    let updated_meta = helpers::require_table(storage, &request.table_name)?;
+    let updated_meta = helpers::require_table(storage, &request.table_name).await?;
     let mut desc = build_table_description(&updated_meta, Some(0), Some(0));
 
     // DynamoDB returns UPDATING status during throughput changes
@@ -727,8 +747,8 @@ fn parse_stored_throughput(
 }
 
 /// Backfill existing items into a newly created GSI, processing in batches.
-fn backfill_gsi(
-    storage: &Storage,
+async fn backfill_gsi<S: StorageBackend>(
+    storage: &S,
     table_name: &str,
     key_schema: &helpers::KeySchema,
     gsi_def: &gsi::GsiDef,
@@ -738,15 +758,17 @@ fn backfill_gsi(
     let mut last_sk: Option<String> = None;
 
     loop {
-        let items = storage.scan_items(
-            table_name,
-            &crate::storage::ScanParams {
-                limit: Some(BATCH_SIZE),
-                exclusive_start_pk: last_pk.as_deref(),
-                exclusive_start_sk: last_sk.as_deref(),
-                ..Default::default()
-            },
-        )?;
+        let items = storage
+            .scan_items(
+                table_name,
+                &crate::storage::ScanParams {
+                    limit: Some(BATCH_SIZE),
+                    exclusive_start_pk: last_pk.as_deref(),
+                    exclusive_start_sk: last_sk.as_deref(),
+                    ..Default::default()
+                },
+            )
+            .await?;
 
         if items.is_empty() {
             break;
@@ -785,7 +807,9 @@ fn backfill_gsi(
             }
         }
 
-        storage.insert_gsi_items(table_name, &gsi_def.index_name, &rows)?;
+        storage
+            .insert_gsi_items(table_name, &gsi_def.index_name, &rows)
+            .await?;
 
         let last = &items[items.len() - 1];
         last_pk = Some(last.0.clone());

--- a/src/actions/update_table.rs
+++ b/src/actions/update_table.rs
@@ -444,7 +444,7 @@ pub fn execute(storage: &Storage, request: UpdateTableRequest) -> Result<UpdateT
                     .stream_view_type
                     .as_deref()
                     .unwrap_or("NEW_AND_OLD_IMAGES");
-                let label = streams::generate_stream_label();
+                let label = streams::generate_stream_label(storage.clock());
                 storage.enable_stream(&request.table_name, view_type, &label)?;
             } else {
                 storage.disable_stream(&request.table_name)?;

--- a/src/actions/update_table.rs
+++ b/src/actions/update_table.rs
@@ -356,10 +356,8 @@ pub async fn execute<S: StorageBackend>(
     let is_increase = new_rcu > cur_rcu || new_wcu > cur_wcu;
     let is_decrease = new_rcu < cur_rcu || new_wcu < cur_wcu;
 
-    // All validation passed — perform mutations inside a transaction
-    storage.begin_transaction().await?;
-
-    let result: Result<()> = async {
+    // All validation passed; perform mutations inside a single transaction.
+    helpers::with_write_transaction(storage, async {
         if let Some(ref updates) = request.global_secondary_index_updates {
             for update in updates {
                 if let Some(ref create) = update.create {
@@ -470,16 +468,8 @@ pub async fn execute<S: StorageBackend>(
         }
 
         Ok(())
-    }
-    .await;
-
-    match result {
-        Ok(()) => storage.commit().await?,
-        Err(e) => {
-            let _ = storage.rollback().await;
-            return Err(e);
-        }
-    }
+    })
+    .await?;
 
     // Build response from updated metadata
     let updated_meta = helpers::require_table(storage, &request.table_name).await?;

--- a/src/actions/update_table.rs
+++ b/src/actions/update_table.rs
@@ -6,7 +6,6 @@ use crate::storage::Storage;
 use crate::streams;
 use crate::types::{AttributeDefinition, GlobalSecondaryIndex, KeySchemaElement, Projection};
 use crate::validation;
-use rusqlite;
 use serde::{Deserialize, Serialize};
 
 /// Internal raw deserialization struct.
@@ -738,17 +737,6 @@ fn backfill_gsi(
     let mut last_pk: Option<String> = None;
     let mut last_sk: Option<String> = None;
 
-    let gsi_table_name = format!("{}::gsi::{}", table_name, gsi_def.index_name);
-    let insert_sql = format!(
-        "INSERT OR REPLACE INTO \"{}\" (gsi_pk, gsi_sk, table_pk, table_sk, item_json) \
-         VALUES (?1, ?2, ?3, ?4, ?5)",
-        crate::storage::escape_table_name(&gsi_table_name)
-    );
-    let mut stmt = storage
-        .conn()
-        .prepare_cached(&insert_sql)
-        .map_err(|e| DynoxideError::InternalServerError(e.to_string()))?;
-
     loop {
         let items = storage.scan_items(
             table_name,
@@ -764,6 +752,7 @@ fn backfill_gsi(
             break;
         }
 
+        let mut rows: Vec<crate::storage_backend::GsiItemRow> = Vec::new();
         for (pk, sk, item_json) in &items {
             let item: crate::types::Item = serde_json::from_str(item_json)
                 .map_err(|e| DynoxideError::InternalServerError(format!("Bad item JSON: {e}")))?;
@@ -786,10 +775,17 @@ fn backfill_gsi(
                 let projected_json = serde_json::to_string(&projected)
                     .map_err(|e| DynoxideError::InternalServerError(e.to_string()))?;
 
-                stmt.execute(rusqlite::params![gsi_pk, gsi_sk, pk, sk, projected_json])
-                    .map_err(DynoxideError::from)?;
+                rows.push(crate::storage_backend::GsiItemRow {
+                    gsi_pk,
+                    gsi_sk,
+                    table_pk: pk.clone(),
+                    table_sk: sk.clone(),
+                    item_json: projected_json,
+                });
             }
         }
+
+        storage.insert_gsi_items(table_name, &gsi_def.index_name, &rows)?;
 
         let last = &items[items.len() - 1];
         last_pk = Some(last.0.clone());

--- a/src/actions/update_time_to_live.rs
+++ b/src/actions/update_time_to_live.rs
@@ -1,5 +1,5 @@
 use crate::errors::{DynoxideError, Result};
-use crate::storage::Storage;
+use crate::storage_backend::StorageBackend;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Default, Deserialize)]
@@ -24,8 +24,8 @@ pub struct UpdateTimeToLiveResponse {
     pub time_to_live_specification: TimeToLiveSpecification,
 }
 
-pub fn execute(
-    storage: &Storage,
+pub async fn execute<S: StorageBackend>(
+    storage: &S,
     request: UpdateTimeToLiveRequest,
 ) -> Result<UpdateTimeToLiveResponse> {
     // Validate table name format before checking existence (DynamoDB validates input first)
@@ -40,7 +40,8 @@ pub fn execute(
 
     // Verify table exists
     let meta = storage
-        .get_table_metadata(&request.table_name)?
+        .get_table_metadata(&request.table_name)
+        .await?
         .ok_or_else(|| {
             DynoxideError::ResourceNotFoundException(format!(
                 "Requested resource not found: Table: {} not found",
@@ -65,11 +66,13 @@ pub fn execute(
         None
     };
 
-    storage.update_ttl_config(
-        &request.table_name,
-        attr_name,
-        request.time_to_live_specification.enabled,
-    )?;
+    storage
+        .update_ttl_config(
+            &request.table_name,
+            attr_name,
+            request.time_to_live_specification.enabled,
+        )
+        .await?;
 
     Ok(UpdateTimeToLiveResponse {
         time_to_live_specification: request.time_to_live_specification,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -88,21 +88,28 @@ pub enum DynoxideError {
     SqliteError(#[from] rusqlite::Error),
 }
 
-/// Backend-layer failures (`BackendError`) are storage-level faults: a locked
+/// Most backend failures (`BackendError`) are storage-level faults: a locked
 /// database, an I/O error, a constraint the application layer did not
-/// anticipate. None of them is part of DynamoDB's client-facing error contract,
-/// so they all surface as `InternalServerError` (HTTP 500), matching how a raw
-/// `rusqlite::Error` surfaces today via `SqliteError`. Client-facing failures
-/// (conditional checks, validation) never travel through `BackendError`; the
-/// handlers construct those `DynoxideError` variants directly, so this
-/// conversion is not lossy on the native path.
+/// anticipate. None of those is part of DynamoDB's client-facing error
+/// contract, so they surface as `InternalServerError` (HTTP 500), matching how
+/// a raw `rusqlite::Error` surfaces via `SqliteError`.
+///
+/// The one exception is `BackendError::Validation`: a backend method such as
+/// `set_tags` enforces a client-facing limit (the 50-tag cap) and raises a
+/// `ValidationException`. That crosses the trait boundary as
+/// `BackendError::Validation` and is restored here to its `ValidationException`
+/// (HTTP 400) so the envelope is unchanged from calling `Storage` directly.
 ///
 /// A one-way `From` is deliberate rather than merging the two types:
 /// `BackendError` is the narrow storage vocabulary, `DynoxideError` the wider
 /// API vocabulary. A merge is deferred.
 impl From<crate::storage_backend::BackendError> for DynoxideError {
     fn from(err: crate::storage_backend::BackendError) -> Self {
-        DynoxideError::InternalServerError(err.to_string())
+        use crate::storage_backend::BackendError;
+        match err {
+            BackendError::Validation(msg) => DynoxideError::ValidationException(msg),
+            other => DynoxideError::InternalServerError(other.to_string()),
+        }
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -88,6 +88,24 @@ pub enum DynoxideError {
     SqliteError(#[from] rusqlite::Error),
 }
 
+/// Backend-layer failures (`BackendError`) are storage-level faults: a locked
+/// database, an I/O error, a constraint the application layer did not
+/// anticipate. None of them is part of DynamoDB's client-facing error contract,
+/// so they all surface as `InternalServerError` (HTTP 500), matching how a raw
+/// `rusqlite::Error` surfaces today via `SqliteError`. Client-facing failures
+/// (conditional checks, validation) never travel through `BackendError`; the
+/// handlers construct those `DynoxideError` variants directly, so this
+/// conversion is not lossy on the native path.
+///
+/// A one-way `From` is deliberate rather than merging the two types:
+/// `BackendError` is the narrow storage vocabulary, `DynoxideError` the wider
+/// API vocabulary. A merge is deferred.
+impl From<crate::storage_backend::BackendError> for DynoxideError {
+    fn from(err: crate::storage_backend::BackendError) -> Self {
+        DynoxideError::InternalServerError(err.to_string())
+    }
+}
+
 impl DynoxideError {
     /// Returns the DynamoDB `__type` string for this error.
     pub fn error_type(&self) -> &'static str {
@@ -378,5 +396,14 @@ mod tests {
         // Uses capital Message (not lowercase)
         assert!(json.get("Message").is_some());
         assert!(json.get("message").is_none());
+    }
+
+    #[test]
+    fn test_backend_error_maps_to_internal() {
+        use crate::storage_backend::BackendError;
+        let err: DynoxideError = BackendError::Locked.into();
+        assert_eq!(err.status_code(), 500);
+        assert!(err.error_type().contains("InternalServerError"));
+        assert!(err.to_string().contains("locked"));
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -20,7 +20,12 @@ pub struct CancellationReason {
 ///
 /// Each variant corresponds to a DynamoDB API error, carrying a human-readable
 /// message that matches DynamoDB's actual error messages.
+///
+/// Marked `#[non_exhaustive]` as of 0.10.0 (itself a breaking release), so
+/// later variant additions stay non-breaking. Downstream `match` arms over
+/// this enum must include a wildcard.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum DynoxideError {
     /// Table or resource not found.
     #[error("{0}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,7 @@ impl Database {
         &self,
         request: actions::create_table::CreateTableRequest,
     ) -> Result<actions::create_table::CreateTableResponse> {
-        self.with_storage(|s| actions::create_table::execute(s, request))
+        self.with_storage(|s| pollster::block_on(actions::create_table::execute(s, request)))
     }
 
     /// Delete a DynamoDB table.
@@ -203,7 +203,7 @@ impl Database {
         &self,
         request: actions::delete_table::DeleteTableRequest,
     ) -> Result<actions::delete_table::DeleteTableResponse> {
-        self.with_storage(|s| actions::delete_table::execute(s, request))
+        self.with_storage(|s| pollster::block_on(actions::delete_table::execute(s, request)))
     }
 
     /// Describe a DynamoDB table.
@@ -211,7 +211,7 @@ impl Database {
         &self,
         request: actions::describe_table::DescribeTableRequest,
     ) -> Result<actions::describe_table::DescribeTableResponse> {
-        self.with_storage(|s| actions::describe_table::execute(s, request))
+        self.with_storage(|s| pollster::block_on(actions::describe_table::execute(s, request)))
     }
 
     /// Update a DynamoDB table (add/remove GSIs).
@@ -219,7 +219,7 @@ impl Database {
         &self,
         request: actions::update_table::UpdateTableRequest,
     ) -> Result<actions::update_table::UpdateTableResponse> {
-        self.with_storage(|s| actions::update_table::execute(s, request))
+        self.with_storage(|s| pollster::block_on(actions::update_table::execute(s, request)))
     }
 
     /// List DynamoDB tables.
@@ -227,7 +227,7 @@ impl Database {
         &self,
         request: actions::list_tables::ListTablesRequest,
     ) -> Result<actions::list_tables::ListTablesResponse> {
-        self.with_storage(|s| actions::list_tables::execute(s, request))
+        self.with_storage(|s| pollster::block_on(actions::list_tables::execute(s, request)))
     }
 
     // -------------------------------------------------------------------
@@ -239,7 +239,7 @@ impl Database {
         &self,
         request: actions::tag_resource::TagResourceRequest,
     ) -> Result<actions::tag_resource::TagResourceResponse> {
-        self.with_storage(|s| actions::tag_resource::execute(s, request))
+        self.with_storage(|s| pollster::block_on(actions::tag_resource::execute(s, request)))
     }
 
     /// Remove tags from a DynamoDB table.
@@ -247,7 +247,7 @@ impl Database {
         &self,
         request: actions::untag_resource::UntagResourceRequest,
     ) -> Result<actions::untag_resource::UntagResourceResponse> {
-        self.with_storage(|s| actions::untag_resource::execute(s, request))
+        self.with_storage(|s| pollster::block_on(actions::untag_resource::execute(s, request)))
     }
 
     /// List tags for a DynamoDB table.
@@ -255,7 +255,9 @@ impl Database {
         &self,
         request: actions::list_tags_of_resource::ListTagsOfResourceRequest,
     ) -> Result<actions::list_tags_of_resource::ListTagsOfResourceResponse> {
-        self.with_storage(|s| actions::list_tags_of_resource::execute(s, request))
+        self.with_storage(|s| {
+            pollster::block_on(actions::list_tags_of_resource::execute(s, request))
+        })
     }
 
     // -------------------------------------------------------------------
@@ -267,7 +269,7 @@ impl Database {
         &self,
         request: actions::put_item::PutItemRequest,
     ) -> Result<actions::put_item::PutItemResponse> {
-        self.with_storage(|s| actions::put_item::execute(s, request))
+        self.with_storage(|s| pollster::block_on(actions::put_item::execute(s, request)))
     }
 
     /// Get an item from a DynamoDB table.
@@ -275,7 +277,7 @@ impl Database {
         &self,
         request: actions::get_item::GetItemRequest,
     ) -> Result<actions::get_item::GetItemResponse> {
-        self.with_storage(|s| actions::get_item::execute(s, request))
+        self.with_storage(|s| pollster::block_on(actions::get_item::execute(s, request)))
     }
 
     /// Delete an item from a DynamoDB table.
@@ -283,7 +285,7 @@ impl Database {
         &self,
         request: actions::delete_item::DeleteItemRequest,
     ) -> Result<actions::delete_item::DeleteItemResponse> {
-        self.with_storage(|s| actions::delete_item::execute(s, request))
+        self.with_storage(|s| pollster::block_on(actions::delete_item::execute(s, request)))
     }
 
     /// Update an item in a DynamoDB table.
@@ -291,7 +293,7 @@ impl Database {
         &self,
         request: actions::update_item::UpdateItemRequest,
     ) -> Result<actions::update_item::UpdateItemResponse> {
-        self.with_storage(|s| actions::update_item::execute(s, request))
+        self.with_storage(|s| pollster::block_on(actions::update_item::execute(s, request)))
     }
 
     // -------------------------------------------------------------------
@@ -303,7 +305,7 @@ impl Database {
         &self,
         request: actions::batch_get_item::BatchGetItemRequest,
     ) -> Result<actions::batch_get_item::BatchGetItemResponse> {
-        self.with_storage(|s| actions::batch_get_item::execute(s, request))
+        self.with_storage(|s| pollster::block_on(actions::batch_get_item::execute(s, request)))
     }
 
     /// Batch write items to one or more DynamoDB tables.
@@ -311,7 +313,7 @@ impl Database {
         &self,
         request: actions::batch_write_item::BatchWriteItemRequest,
     ) -> Result<actions::batch_write_item::BatchWriteItemResponse> {
-        self.with_storage(|s| actions::batch_write_item::execute(s, request))
+        self.with_storage(|s| pollster::block_on(actions::batch_write_item::execute(s, request)))
     }
 
     /// Import items in bulk, bypassing per-item size validation.
@@ -334,7 +336,11 @@ impl Database {
         items: Vec<Item>,
         options: ImportOptions,
     ) -> Result<ImportResult> {
-        self.with_storage(|s| actions::import_items::execute(s, table_name, items, &options))
+        self.with_storage(|s| {
+            pollster::block_on(actions::import_items::execute(
+                s, table_name, items, &options,
+            ))
+        })
     }
 
     /// Import items in bulk, skipping GSI DELETE-before-INSERT.
@@ -350,7 +356,9 @@ impl Database {
         options: ImportOptions,
     ) -> Result<ImportResult> {
         self.with_storage(|s| {
-            actions::import_items::execute_skip_gsi_deletes(s, table_name, items, &options)
+            pollster::block_on(actions::import_items::execute_skip_gsi_deletes(
+                s, table_name, items, &options,
+            ))
         })
     }
 
@@ -380,12 +388,12 @@ impl Database {
         &self,
         request: actions::query::QueryRequest,
     ) -> Result<actions::query::QueryResponse> {
-        self.with_storage(|s| actions::query::execute(s, request))
+        self.with_storage(|s| pollster::block_on(actions::query::execute(s, request)))
     }
 
     /// Scan a DynamoDB table.
     pub fn scan(&self, request: actions::scan::ScanRequest) -> Result<actions::scan::ScanResponse> {
-        self.with_storage(|s| actions::scan::execute(s, request))
+        self.with_storage(|s| pollster::block_on(actions::scan::execute(s, request)))
     }
 
     // -------------------------------------------------------------------
@@ -443,8 +451,9 @@ impl Database {
             }
         }
 
-        let resp =
-            self.with_storage(|s| actions::transact_write_items::execute(s, request.clone()))?;
+        let resp = self.with_storage(|s| {
+            pollster::block_on(actions::transact_write_items::execute(s, request.clone()))
+        })?;
 
         // Cache the response if token was provided
         if let Some(ref token) = request.client_request_token {
@@ -461,7 +470,7 @@ impl Database {
         &self,
         request: actions::transact_get_items::TransactGetItemsRequest,
     ) -> Result<actions::transact_get_items::TransactGetItemsResponse> {
-        self.with_storage(|s| actions::transact_get_items::execute(s, request))
+        self.with_storage(|s| pollster::block_on(actions::transact_get_items::execute(s, request)))
     }
 
     // -------------------------------------------------------------------
@@ -473,7 +482,7 @@ impl Database {
         &self,
         request: actions::list_streams::ListStreamsRequest,
     ) -> Result<actions::list_streams::ListStreamsResponse> {
-        self.with_storage(|s| actions::list_streams::execute(s, request))
+        self.with_storage(|s| pollster::block_on(actions::list_streams::execute(s, request)))
     }
 
     /// Describe a DynamoDB Stream.
@@ -481,7 +490,7 @@ impl Database {
         &self,
         request: actions::describe_stream::DescribeStreamRequest,
     ) -> Result<actions::describe_stream::DescribeStreamResponse> {
-        self.with_storage(|s| actions::describe_stream::execute(s, request))
+        self.with_storage(|s| pollster::block_on(actions::describe_stream::execute(s, request)))
     }
 
     /// Get a shard iterator.
@@ -489,7 +498,7 @@ impl Database {
         &self,
         request: actions::get_shard_iterator::GetShardIteratorRequest,
     ) -> Result<actions::get_shard_iterator::GetShardIteratorResponse> {
-        self.with_storage(|s| actions::get_shard_iterator::execute(s, request))
+        self.with_storage(|s| pollster::block_on(actions::get_shard_iterator::execute(s, request)))
     }
 
     /// Get stream records.
@@ -497,7 +506,7 @@ impl Database {
         &self,
         request: actions::get_records::GetRecordsRequest,
     ) -> Result<actions::get_records::GetRecordsResponse> {
-        self.with_storage(|s| actions::get_records::execute(s, request))
+        self.with_storage(|s| pollster::block_on(actions::get_records::execute(s, request)))
     }
 
     // -------------------------------------------------------------------
@@ -509,7 +518,7 @@ impl Database {
         &self,
         request: actions::update_time_to_live::UpdateTimeToLiveRequest,
     ) -> Result<actions::update_time_to_live::UpdateTimeToLiveResponse> {
-        self.with_storage(|s| actions::update_time_to_live::execute(s, request))
+        self.with_storage(|s| pollster::block_on(actions::update_time_to_live::execute(s, request)))
     }
 
     /// Describe time to live configuration.
@@ -517,13 +526,15 @@ impl Database {
         &self,
         request: actions::describe_time_to_live::DescribeTimeToLiveRequest,
     ) -> Result<actions::describe_time_to_live::DescribeTimeToLiveResponse> {
-        self.with_storage(|s| actions::describe_time_to_live::execute(s, request))
+        self.with_storage(|s| {
+            pollster::block_on(actions::describe_time_to_live::execute(s, request))
+        })
     }
 
     /// Run a TTL sweep, deleting expired items from all TTL-enabled tables.
     /// Returns the number of items deleted.
     pub fn sweep_ttl(&self) -> Result<usize> {
-        self.with_storage(ttl::sweep_expired_items)
+        self.with_storage(|s| pollster::block_on(ttl::sweep_expired_items(s)))
     }
 
     // -------------------------------------------------------------------
@@ -535,7 +546,7 @@ impl Database {
         &self,
         request: actions::execute_statement::ExecuteStatementRequest,
     ) -> Result<actions::execute_statement::ExecuteStatementResponse> {
-        self.with_storage(|s| actions::execute_statement::execute(s, request))
+        self.with_storage(|s| pollster::block_on(actions::execute_statement::execute(s, request)))
     }
 
     /// Execute PartiQL statements transactionally (all-or-nothing).
@@ -543,7 +554,7 @@ impl Database {
         &self,
         request: actions::execute_transaction::ExecuteTransactionRequest,
     ) -> Result<actions::execute_transaction::ExecuteTransactionResponse> {
-        self.with_storage(|s| actions::execute_transaction::execute(s, request))
+        self.with_storage(|s| pollster::block_on(actions::execute_transaction::execute(s, request)))
     }
 
     /// Execute a batch of PartiQL statements.
@@ -551,7 +562,9 @@ impl Database {
         &self,
         request: actions::batch_execute_statement::BatchExecuteStatementRequest,
     ) -> Result<actions::batch_execute_statement::BatchExecuteStatementResponse> {
-        self.with_storage(|s| actions::batch_execute_statement::execute(s, request))
+        self.with_storage(|s| {
+            pollster::block_on(actions::batch_execute_statement::execute(s, request))
+        })
     }
 
     // -------------------------------------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,17 +98,45 @@ type TokenCache = HashMap<
     ),
 >;
 
+/// The native storage backend: the rusqlite-backed [`storage::Storage`].
+///
+/// `Database`'s type parameter defaults to this, so existing native callers
+/// keep writing `Database` and get the synchronous rusqlite-backed engine.
+pub type RusqliteBackend = storage::Storage;
+
+/// The native, synchronous `Database`.
+///
+/// Alias for the default [`Database`] monomorphisation over
+/// [`RusqliteBackend`]. It exposes the historical synchronous public API
+/// unchanged: each method drives an async handler future to completion with
+/// `block_on`. Because the native backend's futures never suspend, that
+/// `block_on` never parks the thread.
+pub type NativeDatabase = Database<RusqliteBackend>;
+
 /// The main entry point for the DynamoDB emulator.
 ///
-/// Wraps a SQLite-backed storage layer and provides DynamoDB-compatible
-/// operations. Thread-safe via `Arc<Mutex<>>` — clone freely across threads.
-#[derive(Clone)]
-pub struct Database {
-    inner: Arc<Mutex<storage::Storage>>,
+/// Generic over the storage backend `S`, monomorphised (no `dyn`). The type
+/// parameter defaults to [`RusqliteBackend`], so `Database` means the native
+/// engine and the public synchronous API is preserved via [`NativeDatabase`].
+///
+/// Wraps a storage layer and provides DynamoDB-compatible operations.
+/// Thread-safe via `Arc<Mutex<>>`, so clone freely across threads.
+pub struct Database<S = RusqliteBackend> {
+    inner: Arc<Mutex<S>>,
     idempotency_tokens: Arc<Mutex<TokenCache>>,
 }
 
-impl Database {
+// Hand-written so cloning never requires `S: Clone`; only the `Arc`s clone.
+impl<S> Clone for Database<S> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            idempotency_tokens: Arc::clone(&self.idempotency_tokens),
+        }
+    }
+}
+
+impl Database<RusqliteBackend> {
     /// Open a persistent database at the given path.
     pub fn new(path: &str) -> Result<Self> {
         let storage = storage::Storage::new(path)?;
@@ -706,5 +734,50 @@ mod tests {
 
         let tables = handle.join().unwrap();
         assert!(tables.is_empty());
+    }
+
+    #[test]
+    fn test_native_database_alias_round_trips() {
+        // The `NativeDatabase` alias is the default `Database<RusqliteBackend>`
+        // and must drive the async handlers through the synchronous facade
+        // transparently: a put/get round-trip behaves exactly as before.
+        let db: NativeDatabase = Database::memory().unwrap();
+
+        db.create_table(actions::create_table::CreateTableRequest {
+            table_name: "tbl".to_string(),
+            key_schema: vec![types::KeySchemaElement {
+                attribute_name: "pk".to_string(),
+                key_type: types::KeyType::HASH,
+            }],
+            attribute_definitions: vec![types::AttributeDefinition {
+                attribute_name: "pk".to_string(),
+                attribute_type: types::ScalarAttributeType::S,
+            }],
+            ..Default::default()
+        })
+        .unwrap();
+
+        let mut item = HashMap::new();
+        item.insert("pk".to_string(), AttributeValue::S("a".to_string()));
+        db.put_item(actions::put_item::PutItemRequest {
+            table_name: "tbl".to_string(),
+            item,
+            ..Default::default()
+        })
+        .unwrap();
+
+        let mut key = HashMap::new();
+        key.insert("pk".to_string(), AttributeValue::S("a".to_string()));
+        let got = db
+            .get_item(actions::get_item::GetItemRequest {
+                table_name: "tbl".to_string(),
+                key,
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(
+            got.item.unwrap().get("pk"),
+            Some(&AttributeValue::S("a".to_string()))
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ pub mod server;
 #[cfg(feature = "mcp-server")]
 pub(crate) mod snapshots;
 pub mod storage;
+pub mod storage_backend;
 pub mod streams;
 pub mod ttl;
 pub mod types;
@@ -66,6 +67,7 @@ use std::time::Instant;
 
 pub use errors::{DynoxideError, Result};
 pub use storage::{DatabaseInfo, TableInfoEntry, TableMetadata, TableStats};
+pub use storage_backend::BackendError;
 pub use types::{AttributeValue, ConversionError, Item};
 
 /// Options for `Database::import_items()`.

--- a/src/partiql/executor.rs
+++ b/src/partiql/executor.rs
@@ -6,7 +6,7 @@ use crate::errors::{DynoxideError, Result};
 use crate::partiql::parser::{
     CompOp, PartiqlValue, SetValue, Statement, WhereClause, WhereCondition,
 };
-use crate::storage::Storage;
+use crate::storage_backend::StorageBackend;
 use crate::types::{AttributeValue, Item};
 use std::collections::HashMap;
 
@@ -14,8 +14,8 @@ use std::collections::HashMap;
 ///
 /// Returns `Some(items)` for SELECT (may be empty), `None` for write operations.
 /// An optional `limit` restricts how many items a SELECT returns.
-pub fn execute(
-    storage: &Storage,
+pub async fn execute<S: StorageBackend>(
+    storage: &S,
     stmt: &Statement,
     parameters: &[AttributeValue],
     limit: Option<usize>,
@@ -25,20 +25,23 @@ pub fn execute(
             table_name,
             projections,
             where_clause,
-        } => execute_select(
-            storage,
-            table_name,
-            projections,
-            where_clause.as_ref(),
-            parameters,
-            limit,
-        ),
+        } => {
+            execute_select(
+                storage,
+                table_name,
+                projections,
+                where_clause.as_ref(),
+                parameters,
+                limit,
+            )
+            .await
+        }
         Statement::Insert {
             table_name,
             item,
             if_not_exists,
         } => {
-            execute_insert(storage, table_name, item, parameters, *if_not_exists)?;
+            execute_insert(storage, table_name, item, parameters, *if_not_exists).await?;
             Ok(None)
         }
         Statement::Update {
@@ -54,14 +57,15 @@ pub fn execute(
                 remove_paths,
                 where_clause.as_ref(),
                 parameters,
-            )?;
+            )
+            .await?;
             Ok(None)
         }
         Statement::Delete {
             table_name,
             where_clause,
         } => {
-            execute_delete(storage, table_name, where_clause.as_ref(), parameters)?;
+            execute_delete(storage, table_name, where_clause.as_ref(), parameters).await?;
             Ok(None)
         }
     }
@@ -79,15 +83,15 @@ fn insert_nested_projection(result: &mut Item, path: &str, val: AttributeValue) 
     result.insert(key.to_string(), val);
 }
 
-fn execute_select(
-    storage: &Storage,
+async fn execute_select<S: StorageBackend>(
+    storage: &S,
     table_name: &str,
     projections: &[String],
     where_clause: Option<&WhereClause>,
     parameters: &[AttributeValue],
     limit: Option<usize>,
 ) -> Result<Option<Vec<Item>>> {
-    let meta = require_table(storage, table_name)?;
+    let meta = require_table(storage, table_name).await?;
     let key_schema = crate::actions::helpers::parse_key_schema(&meta)?;
 
     // Check for COUNT(*) projection
@@ -99,7 +103,8 @@ fn execute_select(
             parameters,
             &key_schema,
             None,
-        )?;
+        )
+        .await?;
         let count = items.len();
         let mut result = HashMap::new();
         result.insert("Count".to_string(), AttributeValue::N(count.to_string()));
@@ -113,7 +118,8 @@ fn execute_select(
         parameters,
         &key_schema,
         limit,
-    )?;
+    )
+    .await?;
 
     // Apply projections
     let items = if projections.is_empty() {
@@ -137,8 +143,8 @@ fn execute_select(
 }
 
 /// Collect items that match the WHERE clause, optionally limited.
-fn collect_matching_items(
-    storage: &Storage,
+async fn collect_matching_items<S: StorageBackend>(
+    storage: &S,
     table_name: &str,
     where_clause: Option<&WhereClause>,
     parameters: &[AttributeValue],
@@ -154,7 +160,9 @@ fn collect_matching_items(
             .to_key_string()
             .ok_or_else(|| DynoxideError::ValidationException("Invalid key value".to_string()))?;
 
-        let rows = storage.query_items(table_name, &pk_str, &Default::default())?;
+        let rows = storage
+            .query_items(table_name, &pk_str, &Default::default())
+            .await?;
 
         let iter = rows
             .into_iter()
@@ -167,7 +175,7 @@ fn collect_matching_items(
             iter.collect()
         }
     } else {
-        let rows = storage.scan_items(table_name, &Default::default())?;
+        let rows = storage.scan_items(table_name, &Default::default()).await?;
 
         let iter = rows
             .into_iter()
@@ -203,8 +211,8 @@ fn find_pk_condition<'a>(
     }
 }
 
-fn execute_insert(
-    storage: &Storage,
+async fn execute_insert<S: StorageBackend>(
+    storage: &S,
     table_name: &str,
     item_template: &HashMap<String, PartiqlValue>,
     parameters: &[AttributeValue],
@@ -225,7 +233,7 @@ fn execute_insert(
         item.insert(k.clone(), resolved);
     }
 
-    let meta = require_table(storage, table_name)?;
+    let meta = require_table(storage, table_name).await?;
     let key_schema = crate::actions::helpers::parse_key_schema(&meta)?;
 
     // Validate keys present
@@ -239,7 +247,7 @@ fn execute_insert(
     let (pk, sk) = crate::actions::helpers::extract_key_strings(&item, &key_schema)?;
 
     // PartiQL INSERT must reject duplicates (unlike PutItem which overwrites)
-    let existing = storage.get_item(table_name, &pk, &sk)?;
+    let existing = storage.get_item(table_name, &pk, &sk).await?;
     if existing.is_some() {
         if if_not_exists {
             // Silently succeed — no-op
@@ -258,8 +266,9 @@ fn execute_insert(
         .get(&key_schema.partition_key)
         .map(crate::storage::compute_hash_prefix)
         .unwrap_or_default();
-    let old_json =
-        storage.put_item_with_hash(table_name, &pk, &sk, &item_json, item_size, &hash_prefix)?;
+    let old_json = storage
+        .put_item_with_hash(table_name, &pk, &sk, &item_json, item_size, &hash_prefix)
+        .await?;
 
     // GSI maintenance
     let table_sk_attr = key_schema.sort_key.as_deref();
@@ -272,7 +281,8 @@ fn execute_insert(
         &item,
         &key_schema.partition_key,
         table_sk_attr,
-    )?;
+    )
+    .await?;
 
     // LSI maintenance
     crate::actions::lsi::maintain_lsis_after_write(
@@ -284,24 +294,25 @@ fn execute_insert(
         &item,
         &key_schema.partition_key,
         table_sk_attr,
-    )?;
+    )
+    .await?;
 
     // Stream record
     let old_item: Option<Item> = old_json.as_ref().and_then(|j| serde_json::from_str(j).ok());
-    crate::streams::record_stream_event(storage, &meta, old_item.as_ref(), Some(&item))?;
+    crate::streams::record_stream_event(storage, &meta, old_item.as_ref(), Some(&item)).await?;
 
     Ok(())
 }
 
-fn execute_update(
-    storage: &Storage,
+async fn execute_update<S: StorageBackend>(
+    storage: &S,
     table_name: &str,
     set_clauses: &[crate::partiql::parser::SetClause],
     remove_paths: &[String],
     where_clause: Option<&WhereClause>,
     parameters: &[AttributeValue],
 ) -> Result<()> {
-    let meta = require_table(storage, table_name)?;
+    let meta = require_table(storage, table_name).await?;
     let key_schema = crate::actions::helpers::parse_key_schema(&meta)?;
 
     // WHERE clause is required for UPDATE to identify the item
@@ -347,7 +358,7 @@ fn execute_update(
     };
 
     // Get existing item
-    let existing_json = storage.get_item(table_name, &pk_str, &sk_str)?;
+    let existing_json = storage.get_item(table_name, &pk_str, &sk_str).await?;
     let mut item: Item = existing_json
         .as_ref()
         .and_then(|j| serde_json::from_str(j).ok())
@@ -383,14 +394,16 @@ fn execute_update(
         .get(&key_schema.partition_key)
         .map(crate::storage::compute_hash_prefix)
         .unwrap_or_default();
-    storage.put_item_with_hash(
-        table_name,
-        &pk_str,
-        &sk_str,
-        &item_json,
-        item_size,
-        &hash_prefix,
-    )?;
+    storage
+        .put_item_with_hash(
+            table_name,
+            &pk_str,
+            &sk_str,
+            &item_json,
+            item_size,
+            &hash_prefix,
+        )
+        .await?;
 
     // GSI maintenance
     let table_sk_attr = key_schema.sort_key.as_deref();
@@ -403,7 +416,8 @@ fn execute_update(
         &item,
         &key_schema.partition_key,
         table_sk_attr,
-    )?;
+    )
+    .await?;
 
     // LSI maintenance
     crate::actions::lsi::maintain_lsis_after_write(
@@ -415,7 +429,8 @@ fn execute_update(
         &item,
         &key_schema.partition_key,
         table_sk_attr,
-    )?;
+    )
+    .await?;
 
     // Stream record
     let old_ref = if existing_json.is_some() {
@@ -423,18 +438,18 @@ fn execute_update(
     } else {
         None
     };
-    crate::streams::record_stream_event(storage, &meta, old_ref, Some(&item))?;
+    crate::streams::record_stream_event(storage, &meta, old_ref, Some(&item)).await?;
 
     Ok(())
 }
 
-fn execute_delete(
-    storage: &Storage,
+async fn execute_delete<S: StorageBackend>(
+    storage: &S,
     table_name: &str,
     where_clause: Option<&WhereClause>,
     parameters: &[AttributeValue],
 ) -> Result<()> {
-    let meta = require_table(storage, table_name)?;
+    let meta = require_table(storage, table_name).await?;
     let key_schema = crate::actions::helpers::parse_key_schema(&meta)?;
 
     let wc = where_clause.ok_or_else(|| {
@@ -486,20 +501,22 @@ fn execute_delete(
         String::new()
     };
 
-    let old_json = storage.delete_item(table_name, &pk_str, &sk_str)?;
+    let old_json = storage.delete_item(table_name, &pk_str, &sk_str).await?;
 
     // GSI maintenance
     let _ = crate::actions::gsi::maintain_gsis_after_delete(
         storage, table_name, &meta, &pk_str, &sk_str,
-    )?;
+    )
+    .await?;
 
     // LSI maintenance
-    crate::actions::lsi::maintain_lsis_after_delete(storage, table_name, &meta, &pk_str, &sk_str)?;
+    crate::actions::lsi::maintain_lsis_after_delete(storage, table_name, &meta, &pk_str, &sk_str)
+        .await?;
 
     // Stream record
     let old_item: Option<Item> = old_json.as_ref().and_then(|j| serde_json::from_str(j).ok());
     if old_item.is_some() {
-        crate::streams::record_stream_event(storage, &meta, old_item.as_ref(), None)?;
+        crate::streams::record_stream_event(storage, &meta, old_item.as_ref(), None).await?;
     }
 
     Ok(())
@@ -509,8 +526,11 @@ fn execute_delete(
 // Helpers
 // ---------------------------------------------------------------------------
 
-fn require_table(storage: &Storage, table_name: &str) -> Result<crate::storage::TableMetadata> {
-    crate::actions::helpers::require_table(storage, table_name)
+async fn require_table<S: StorageBackend>(
+    storage: &S,
+    table_name: &str,
+) -> Result<crate::storage::TableMetadata> {
+    crate::actions::helpers::require_table(storage, table_name).await
 }
 
 /// Find a comparison condition matching a given path with Eq operator,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,8 +1,10 @@
 use crate::errors::{DynoxideError, Result};
+use crate::storage_backend::clock::{Clock, SystemClock};
 use crate::types::AttributeValue;
 use rusqlite::{Connection, params};
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 /// Current schema version. Stored in the `_config` table for future migrations.
 const SCHEMA_VERSION: &str = "6";
@@ -237,6 +239,8 @@ pub struct Storage {
     /// In-memory cache of table metadata to avoid repeated SQLite reads.
     /// Safe to use `RefCell` because `Storage` is always behind `Arc<Mutex<>>`.
     metadata_cache: RefCell<HashMap<String, TableMetadata>>,
+    /// Wall-clock used by stream / TTL paths. Defaults to [`SystemClock`].
+    clock: Arc<dyn Clock>,
 }
 
 impl Storage {
@@ -246,9 +250,25 @@ impl Storage {
         let mut storage = Self {
             conn,
             metadata_cache: RefCell::new(HashMap::new()),
+            clock: Arc::new(SystemClock),
         };
         storage.initialize().map_err(Self::maybe_encrypted_error)?;
         Ok(storage)
+    }
+
+    /// Replace the [`Clock`] used by the stream and TTL paths. Returns `self`
+    /// so callers can chain construction (`Storage::memory()?.with_clock(c)`).
+    ///
+    /// Default for every constructor is [`SystemClock`]. Tests use this to
+    /// inject a `ManualClock`.
+    pub fn with_clock(mut self, clock: Arc<dyn Clock>) -> Self {
+        self.clock = clock;
+        self
+    }
+
+    /// Borrow the active [`Clock`]. Used by stream and TTL paths.
+    pub(crate) fn clock(&self) -> &dyn Clock {
+        self.clock.as_ref()
     }
 
     /// If a SQLite error is SQLITE_NOTADB, return a clearer error message
@@ -289,6 +309,7 @@ impl Storage {
         let mut storage = Self {
             conn,
             metadata_cache: RefCell::new(HashMap::new()),
+            clock: Arc::new(SystemClock),
         };
         storage.initialize()?;
         Ok(storage)
@@ -300,6 +321,7 @@ impl Storage {
         let mut storage = Self {
             conn,
             metadata_cache: RefCell::new(HashMap::new()),
+            clock: Arc::new(SystemClock),
         };
         storage.initialize()?;
         Ok(storage)

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -903,6 +903,33 @@ impl Storage {
         Ok(())
     }
 
+    /// Bulk-insert many rows into one GSI table using a single cached
+    /// prepared statement. Equivalent to calling [`Self::insert_gsi_item`]
+    /// once per row, but reuses the statement across the batch.
+    pub fn insert_gsi_items(
+        &self,
+        table_name: &str,
+        index_name: &str,
+        rows: &[crate::storage_backend::GsiItemRow],
+    ) -> Result<()> {
+        let gsi_table_name = format!("{table_name}::gsi::{index_name}");
+        let sql = format!(
+            "INSERT OR REPLACE INTO \"{}\" (gsi_pk, gsi_sk, table_pk, table_sk, item_json) VALUES (?1, ?2, ?3, ?4, ?5)",
+            escape_table_name(&gsi_table_name)
+        );
+        let mut stmt = self.conn.prepare_cached(&sql)?;
+        for row in rows {
+            stmt.execute(params![
+                row.gsi_pk,
+                row.gsi_sk,
+                row.table_pk,
+                row.table_sk,
+                row.item_json
+            ])?;
+        }
+        Ok(())
+    }
+
     /// Delete an item from a GSI table by base table primary key.
     pub fn delete_gsi_item(
         &self,
@@ -1415,6 +1442,34 @@ impl Storage {
         )?;
 
         Ok(old_item)
+    }
+
+    /// Bulk-insert many base-table rows using a single cached prepared
+    /// statement (`INSERT OR REPLACE`). Unlike [`Self::put_item_with_hash`],
+    /// which preserves any existing `cached_at`, this writes `cached_at`
+    /// verbatim from each row, matching the import flow's semantics.
+    pub fn put_base_items(
+        &self,
+        table_name: &str,
+        rows: &[crate::storage_backend::BaseItemRow],
+    ) -> Result<()> {
+        let escaped = escape_table_name(table_name);
+        let sql = format!(
+            "INSERT OR REPLACE INTO \"{escaped}\" (pk, sk, item_json, item_size, cached_at, hash_prefix) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)"
+        );
+        let mut stmt = self.conn.prepare_cached(&sql)?;
+        for row in rows {
+            stmt.execute(params![
+                row.pk,
+                row.sk,
+                row.item_json,
+                row.item_size as i64,
+                row.cached_at,
+                row.hash_prefix
+            ])?;
+        }
+        Ok(())
     }
 
     /// Get a single item by primary key.

--- a/src/storage_backend/clock.rs
+++ b/src/storage_backend/clock.rs
@@ -1,0 +1,104 @@
+//! `Clock` capability used by the trait surface to abstract time access.
+//!
+//! Clock injection is scoped to the call sites that the
+//! [`StorageBackend`](super::StorageBackend) trait surfaces, namely the
+//! stream and TTL paths in [`crate::streams`] and [`crate::ttl`]. Other
+//! `std::time::*` call sites in the codebase (idempotency cache,
+//! action-handler `created_at` stamps, snapshot epoch helpers) sit inside
+//! native-only code paths the trait does not expose, so they remain on
+//! `std::time::SystemTime` directly.
+
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Provides wall-clock time to the trait's stream and TTL paths.
+///
+/// Implementations must be `Send + Sync` so a single shared `Arc<dyn Clock>`
+/// can sit inside [`crate::storage::Storage`].
+pub trait Clock: Send + Sync {
+    /// Whole seconds since the Unix epoch.
+    fn now_unix_secs(&self) -> u64;
+
+    /// Fractional seconds since the Unix epoch, retaining sub-second precision
+    /// for callers that need it (e.g., `cached_at` in import flows that route
+    /// through stream events).
+    fn now_unix_secs_f64(&self) -> f64;
+}
+
+/// Production clock backed by [`std::time::SystemTime`].
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SystemClock;
+
+impl SystemClock {
+    /// Return a shareable [`Arc<dyn Clock>`] handle to a `SystemClock`.
+    pub fn arc() -> Arc<dyn Clock> {
+        Arc::new(Self)
+    }
+}
+
+impl Clock for SystemClock {
+    fn now_unix_secs(&self) -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+    }
+
+    fn now_unix_secs_f64(&self) -> f64 {
+        let d = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default();
+        d.as_secs_f64()
+    }
+}
+
+/// Clock whose value is set explicitly. Intended for tests; carrying it in
+/// release builds costs only the size of the type itself, and it lets
+/// integration tests outside `src/` reach `ManualClock` without juggling
+/// feature flags.
+///
+/// Use [`ManualClock::new`] to start at a specific epoch, then [`ManualClock::set`]
+/// or [`ManualClock::tick`] to advance time deterministically inside tests.
+#[derive(Debug, Default, Clone)]
+pub struct ManualClock {
+    inner: Arc<std::sync::Mutex<f64>>,
+}
+
+impl ManualClock {
+    /// Construct a `ManualClock` pinned at `secs` epoch seconds.
+    pub fn new(secs: u64) -> Self {
+        Self {
+            inner: Arc::new(std::sync::Mutex::new(secs as f64)),
+        }
+    }
+
+    /// Set the current time to exactly `secs` epoch seconds.
+    pub fn set(&self, secs: u64) {
+        if let Ok(mut guard) = self.inner.lock() {
+            *guard = secs as f64;
+        }
+    }
+
+    /// Advance the clock by `delta`.
+    pub fn tick(&self, delta: std::time::Duration) {
+        if let Ok(mut guard) = self.inner.lock() {
+            *guard += delta.as_secs_f64();
+        }
+    }
+
+    /// Return a shareable `Arc<dyn Clock>` handle to this `ManualClock`.
+    /// The handle stays in sync with the original via the shared inner state.
+    pub fn arc(&self) -> Arc<dyn Clock> {
+        Arc::new(self.clone())
+    }
+}
+
+impl Clock for ManualClock {
+    fn now_unix_secs(&self) -> u64 {
+        self.inner.lock().map(|v| *v as u64).unwrap_or_default()
+    }
+
+    fn now_unix_secs_f64(&self) -> f64 {
+        self.inner.lock().map(|v| *v).unwrap_or_default()
+    }
+}

--- a/src/storage_backend/error.rs
+++ b/src/storage_backend/error.rs
@@ -1,0 +1,67 @@
+//! Backend-neutral error type returned by the [`StorageBackend`] trait.
+//!
+//! `BackendError` is the trait surface's error type. The native rusqlite-backed
+//! `Storage` impl converts `rusqlite::Error` into `BackendError` via
+//! [`from_rusqlite`], keeping the trait surface free of rusqlite types.
+//!
+//! `DynoxideError` is unchanged. Action handlers that call rusqlite directly
+//! through `Storage::conn()` continue to surface `DynoxideError::SqliteError`.
+//!
+//! [`StorageBackend`]: super::StorageBackend
+//! [`from_rusqlite`]: from_rusqlite
+
+/// Backend-neutral error variants surfaced by the [`StorageBackend`] trait.
+///
+/// [`StorageBackend`]: super::StorageBackend
+#[derive(Debug, thiserror::Error)]
+pub enum BackendError {
+    /// The opened file is not a valid SQLite database, or is encrypted with the
+    /// wrong key.
+    #[error("backend: not a valid database")]
+    NotADatabase,
+
+    /// The database or a table within it is locked or busy.
+    #[error("backend: database is locked or busy")]
+    Locked,
+
+    /// A backend-level constraint (uniqueness, check, foreign key) was violated.
+    #[error("backend: constraint violation: {0}")]
+    Constraint(String),
+
+    /// An I/O error from the backend.
+    #[error("backend: I/O error: {0}")]
+    Io(String),
+
+    /// Any other backend failure. Carries the original error's `Display` output.
+    #[error("backend: {0}")]
+    Other(String),
+}
+
+/// Convert a [`rusqlite::Error`] to a [`BackendError`].
+///
+/// The mapping covers the SQLite error codes the native rusqlite impl expects
+/// to surface across the trait. Anything not explicitly mapped falls through
+/// to [`BackendError::Other`] carrying the original error's `Display` output,
+/// so no rusqlite variant produces an empty backend error.
+///
+/// This is a named helper rather than a `From` impl on purpose: the
+/// `?`-conversion would otherwise silently turn rusqlite errors into
+/// `BackendError` in code that should keep them rusqlite-typed (action handlers
+/// using `Storage::conn()` directly).
+pub fn from_rusqlite(err: rusqlite::Error) -> BackendError {
+    use rusqlite::Error::SqliteFailure;
+    use rusqlite::ErrorCode;
+
+    match &err {
+        SqliteFailure(ffi_err, msg) => match ffi_err.code {
+            ErrorCode::NotADatabase => BackendError::NotADatabase,
+            ErrorCode::DatabaseBusy | ErrorCode::DatabaseLocked => BackendError::Locked,
+            ErrorCode::ConstraintViolation => {
+                BackendError::Constraint(msg.clone().unwrap_or_default())
+            }
+            ErrorCode::SystemIoFailure => BackendError::Io(msg.clone().unwrap_or_default()),
+            _ => BackendError::Other(err.to_string()),
+        },
+        _ => BackendError::Other(err.to_string()),
+    }
+}

--- a/src/storage_backend/error.rs
+++ b/src/storage_backend/error.rs
@@ -32,6 +32,13 @@ pub enum BackendError {
     #[error("backend: I/O error: {0}")]
     Io(String),
 
+    /// A client-facing validation failure raised by a backend method (for
+    /// example the tag-count limit in `set_tags`). Carries the original
+    /// message so `From<BackendError> for DynoxideError` can restore it as a
+    /// `ValidationException` rather than collapsing it to a 500.
+    #[error("{0}")]
+    Validation(String),
+
     /// Any other backend failure. Carries the original error's `Display` output.
     #[error("backend: {0}")]
     Other(String),

--- a/src/storage_backend/error.rs
+++ b/src/storage_backend/error.rs
@@ -12,8 +12,14 @@
 
 /// Backend-neutral error variants surfaced by the [`StorageBackend`] trait.
 ///
+/// Marked `#[non_exhaustive]`: a future backend may surface failure modes the
+/// native one cannot, so downstream code must not assume the variant set is
+/// closed. Added before the trait's first release so later additions stay
+/// non-breaking.
+///
 /// [`StorageBackend`]: super::StorageBackend
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum BackendError {
     /// The opened file is not a valid SQLite database, or is encrypted with the
     /// wrong key.

--- a/src/storage_backend/mod.rs
+++ b/src/storage_backend/mod.rs
@@ -3,9 +3,11 @@
 //! Defines the [`StorageBackend`] trait that decouples Dynoxide's data layer
 //! from a specific SQLite binding. The native [`rusqlite`]-backed
 //! [`Storage`](crate::storage::Storage) implements the trait. A compile-only
-//! wa-sqlite stub implements it on `wasm32-unknown-unknown` so trait-shape
-//! drift surfaces at type-check time rather than once a real wa-sqlite
-//! backend is wired up.
+//! wa-sqlite stub gated behind the `wasm-stub` feature also implements it,
+//! so trait-shape drift surfaces at type-check time rather than once a real
+//! wa-sqlite backend is wired up. Building dynoxide for a non-native target
+//! (e.g., `wasm32-unknown-unknown` itself) is not yet supported; the stub
+//! validates the trait surface, not the rest of the codebase.
 //!
 //! Today the trait is consumed monomorphically. Nothing constructs
 //! `dyn StorageBackend`, nothing awaits it at runtime in production code.
@@ -28,6 +30,8 @@ pub mod clock;
 pub mod error;
 #[cfg(feature = "native-sqlite")]
 pub mod rusqlite_impl;
+#[cfg(feature = "wasm-stub")]
+pub mod wasm_stub;
 
 use crate::storage::{
     CreateTableMetadata, DatabaseInfo, QueryParams, ScanParams, StreamRecord, TableMetadata,

--- a/src/storage_backend/mod.rs
+++ b/src/storage_backend/mod.rs
@@ -28,7 +28,11 @@
 
 pub mod clock;
 pub mod error;
-#[cfg(feature = "native-sqlite")]
+// The native rusqlite-backed `Storage` exists whenever either SQLite backend
+// feature is on (the crate refuses to build with neither), and the handlers
+// now consume `StorageBackend` through it, so the impl must track the same
+// condition rather than `native-sqlite` alone.
+#[cfg(any(feature = "native-sqlite", feature = "_has-encryption"))]
 pub mod rusqlite_impl;
 #[cfg(feature = "wasm-stub")]
 pub mod wasm_stub;

--- a/src/storage_backend/mod.rs
+++ b/src/storage_backend/mod.rs
@@ -26,6 +26,8 @@
 
 pub mod clock;
 pub mod error;
+#[cfg(feature = "native-sqlite")]
+pub mod rusqlite_impl;
 
 use crate::storage::{
     CreateTableMetadata, DatabaseInfo, QueryParams, ScanParams, StreamRecord, TableMetadata,

--- a/src/storage_backend/mod.rs
+++ b/src/storage_backend/mod.rs
@@ -1,0 +1,386 @@
+//! Storage backend abstraction.
+//!
+//! Defines the [`StorageBackend`] trait that decouples Dynoxide's data layer
+//! from a specific SQLite binding. The native [`rusqlite`]-backed
+//! [`Storage`](crate::storage::Storage) implements the trait. A compile-only
+//! wa-sqlite stub implements it on `wasm32-unknown-unknown` so trait-shape
+//! drift surfaces at type-check time rather than once a real wa-sqlite
+//! backend is wired up.
+//!
+//! Today the trait is consumed monomorphically. Nothing constructs
+//! `dyn StorageBackend`, nothing awaits it at runtime in production code.
+//! `Database`, action handlers, and `DynoxideError` continue to operate
+//! against the native `Storage` type directly. The escape hatches
+//! `Storage::conn()` and `Storage::conn_mut()` are not exposed by the trait;
+//! folding them in (or migrating their callers off them) is a follow-up to
+//! the wa-sqlite work.
+//!
+//! # No `Send + Sync` super-trait
+//!
+//! [`Storage`](crate::storage::Storage) carries a `RefCell<HashMap<...>>` for
+//! its metadata cache, so `Storage: !Sync`. A `Send + Sync` super-trait would
+//! refuse the impl on `Storage`. With no dynamic dispatch site in scope,
+//! auto-trait propagation across `.await` is decided per-callsite anyway, so
+//! adding `Send` to the super-trait would not earn any compile-time
+//! guarantee on the futures returned by trait methods.
+
+pub mod clock;
+pub mod error;
+
+use crate::storage::{
+    CreateTableMetadata, DatabaseInfo, QueryParams, ScanParams, StreamRecord, TableMetadata,
+    TableStats,
+};
+use crate::types::Tag;
+
+pub use clock::{Clock, ManualClock, SystemClock};
+pub use error::{BackendError, from_rusqlite};
+
+/// Backend-neutral storage interface.
+///
+/// Method signatures mirror [`Storage`](crate::storage::Storage)'s public
+/// surface 1:1, with three mechanical transformations:
+///
+/// 1. `Result<T, DynoxideError>` becomes `Result<T, BackendError>`.
+/// 2. `fn` becomes `async fn`.
+/// 3. Filesystem-typed and rusqlite-typed methods are excluded; they remain
+///    on the native [`Storage`](crate::storage::Storage) only.
+///
+/// The trait is not consumed dynamically today. Its job is to lock the shape
+/// a future wa-sqlite backend will satisfy; type-level fit is validated by
+/// the compile-only stub in
+/// [`wasm_stub`](crate::storage_backend::wasm_stub).
+///
+/// The `#[allow(async_fn_in_trait)]` reflects the monomorphic-only consumption
+/// model. The lint can be revisited if and when `dyn StorageBackend` becomes
+/// a real callsite.
+#[allow(async_fn_in_trait)]
+pub trait StorageBackend {
+    // -----------------------------------------------------------------------
+    // Table metadata
+    // -----------------------------------------------------------------------
+
+    async fn insert_table_metadata(&self, m: &CreateTableMetadata<'_>) -> Result<(), BackendError>;
+
+    async fn get_table_metadata(
+        &self,
+        table_name: &str,
+    ) -> Result<Option<TableMetadata>, BackendError>;
+
+    async fn delete_table_metadata(&self, table_name: &str) -> Result<bool, BackendError>;
+
+    async fn update_table_metadata(
+        &self,
+        table_name: &str,
+        attribute_definitions: &str,
+        gsi_definitions: Option<&str>,
+    ) -> Result<(), BackendError>;
+
+    async fn update_provisioned_throughput(
+        &self,
+        table_name: &str,
+        provisioned_throughput: &str,
+    ) -> Result<(), BackendError>;
+
+    async fn clear_provisioned_throughput(&self, table_name: &str) -> Result<(), BackendError>;
+
+    async fn update_billing_mode(
+        &self,
+        table_name: &str,
+        billing_mode: &str,
+    ) -> Result<(), BackendError>;
+
+    async fn get_tags(&self, table_name: &str) -> Result<Vec<Tag>, BackendError>;
+
+    async fn set_tags(&self, table_name: &str, new_tags: &[Tag]) -> Result<(), BackendError>;
+
+    async fn update_deletion_protection(
+        &self,
+        table_name: &str,
+        enabled: bool,
+    ) -> Result<(), BackendError>;
+
+    async fn remove_tags(&self, table_name: &str, keys: &[String]) -> Result<(), BackendError>;
+
+    async fn list_table_names(&self) -> Result<Vec<String>, BackendError>;
+
+    async fn table_exists(&self, table_name: &str) -> Result<bool, BackendError>;
+
+    // -----------------------------------------------------------------------
+    // Dynamic data tables (DDL)
+    // -----------------------------------------------------------------------
+
+    async fn create_data_table(&self, table_name: &str) -> Result<(), BackendError>;
+
+    async fn drop_data_table(&self, table_name: &str) -> Result<(), BackendError>;
+
+    async fn create_gsi_table(
+        &self,
+        table_name: &str,
+        index_name: &str,
+    ) -> Result<(), BackendError>;
+
+    async fn drop_gsi_table(&self, table_name: &str, index_name: &str) -> Result<(), BackendError>;
+
+    async fn create_lsi_table(
+        &self,
+        table_name: &str,
+        index_name: &str,
+    ) -> Result<(), BackendError>;
+
+    async fn drop_lsi_table(&self, table_name: &str, index_name: &str) -> Result<(), BackendError>;
+
+    // -----------------------------------------------------------------------
+    // GSI item operations
+    // -----------------------------------------------------------------------
+
+    #[allow(clippy::too_many_arguments)]
+    async fn insert_gsi_item(
+        &self,
+        table_name: &str,
+        index_name: &str,
+        gsi_pk: &str,
+        gsi_sk: &str,
+        table_pk: &str,
+        table_sk: &str,
+        item_json: &str,
+    ) -> Result<(), BackendError>;
+
+    async fn delete_gsi_item(
+        &self,
+        table_name: &str,
+        index_name: &str,
+        table_pk: &str,
+        table_sk: &str,
+    ) -> Result<(), BackendError>;
+
+    async fn query_gsi_items(
+        &self,
+        table_name: &str,
+        index_name: &str,
+        gsi_pk: &str,
+        params: &QueryParams<'_>,
+    ) -> Result<Vec<(String, String, String)>, BackendError>;
+
+    async fn scan_gsi_items(
+        &self,
+        table_name: &str,
+        index_name: &str,
+        params: &ScanParams<'_>,
+    ) -> Result<Vec<(String, String, String)>, BackendError>;
+
+    // -----------------------------------------------------------------------
+    // LSI item operations
+    // -----------------------------------------------------------------------
+
+    #[allow(clippy::too_many_arguments)]
+    async fn insert_lsi_item(
+        &self,
+        table_name: &str,
+        index_name: &str,
+        pk: &str,
+        sk: &str,
+        base_pk: &str,
+        base_sk: &str,
+        item_json: &str,
+    ) -> Result<(), BackendError>;
+
+    async fn delete_lsi_item(
+        &self,
+        table_name: &str,
+        index_name: &str,
+        base_pk: &str,
+        base_sk: &str,
+    ) -> Result<(), BackendError>;
+
+    async fn query_lsi_items(
+        &self,
+        table_name: &str,
+        index_name: &str,
+        pk: &str,
+        params: &QueryParams<'_>,
+    ) -> Result<Vec<(String, String, String)>, BackendError>;
+
+    async fn scan_lsi_items(
+        &self,
+        table_name: &str,
+        index_name: &str,
+        params: &ScanParams<'_>,
+    ) -> Result<Vec<(String, String, String)>, BackendError>;
+
+    // -----------------------------------------------------------------------
+    // Transactions
+    // -----------------------------------------------------------------------
+
+    async fn begin_transaction(&self) -> Result<(), BackendError>;
+    async fn commit(&self) -> Result<(), BackendError>;
+    async fn rollback(&self) -> Result<(), BackendError>;
+
+    // -----------------------------------------------------------------------
+    // Bulk-loading PRAGMAs
+    // -----------------------------------------------------------------------
+
+    async fn enable_bulk_loading(&self) -> Result<(), BackendError>;
+    async fn disable_bulk_loading(&self) -> Result<(), BackendError>;
+
+    // -----------------------------------------------------------------------
+    // Item CRUD
+    // -----------------------------------------------------------------------
+
+    async fn put_item(
+        &self,
+        table_name: &str,
+        pk: &str,
+        sk: &str,
+        item_json: &str,
+        item_size: usize,
+    ) -> Result<Option<String>, BackendError>;
+
+    #[allow(clippy::too_many_arguments)]
+    async fn put_item_with_hash(
+        &self,
+        table_name: &str,
+        pk: &str,
+        sk: &str,
+        item_json: &str,
+        item_size: usize,
+        hash_prefix: &str,
+    ) -> Result<Option<String>, BackendError>;
+
+    async fn get_item(
+        &self,
+        table_name: &str,
+        pk: &str,
+        sk: &str,
+    ) -> Result<Option<String>, BackendError>;
+
+    async fn get_partition_size(&self, table_name: &str, pk: &str) -> Result<i64, BackendError>;
+
+    async fn get_lsi_partition_size(
+        &self,
+        table_name: &str,
+        index_name: &str,
+        pk: &str,
+    ) -> Result<i64, BackendError>;
+
+    async fn delete_item(
+        &self,
+        table_name: &str,
+        pk: &str,
+        sk: &str,
+    ) -> Result<Option<String>, BackendError>;
+
+    async fn query_items(
+        &self,
+        table_name: &str,
+        pk: &str,
+        params: &QueryParams<'_>,
+    ) -> Result<Vec<(String, String, String)>, BackendError>;
+
+    async fn scan_items(
+        &self,
+        table_name: &str,
+        params: &ScanParams<'_>,
+    ) -> Result<Vec<(String, String, String)>, BackendError>;
+
+    async fn count_items(&self, table_name: &str) -> Result<i64, BackendError>;
+
+    // -----------------------------------------------------------------------
+    // Introspection
+    // -----------------------------------------------------------------------
+
+    async fn db_size_bytes(&self) -> Result<u64, BackendError>;
+    async fn table_count(&self) -> Result<usize, BackendError>;
+    async fn table_stats(&self) -> Result<Vec<TableStats>, BackendError>;
+    async fn database_info(&self) -> Result<DatabaseInfo, BackendError>;
+    async fn vacuum(&self) -> Result<(), BackendError>;
+
+    // -----------------------------------------------------------------------
+    // Streams
+    // -----------------------------------------------------------------------
+
+    async fn enable_stream(
+        &self,
+        table_name: &str,
+        view_type: &str,
+        label: &str,
+    ) -> Result<(), BackendError>;
+
+    async fn disable_stream(&self, table_name: &str) -> Result<(), BackendError>;
+
+    #[allow(clippy::too_many_arguments)]
+    async fn insert_stream_record(
+        &self,
+        table_name: &str,
+        event_name: &str,
+        keys_json: &str,
+        new_image: Option<&str>,
+        old_image: Option<&str>,
+        sequence_number: &str,
+        shard_id: &str,
+        created_at: i64,
+    ) -> Result<(), BackendError>;
+
+    #[allow(clippy::too_many_arguments)]
+    async fn insert_stream_record_with_identity(
+        &self,
+        table_name: &str,
+        event_name: &str,
+        keys_json: &str,
+        new_image: Option<&str>,
+        old_image: Option<&str>,
+        sequence_number: &str,
+        shard_id: &str,
+        created_at: i64,
+        user_identity: Option<&str>,
+    ) -> Result<(), BackendError>;
+
+    async fn next_stream_sequence_number(&self, table_name: &str) -> Result<i64, BackendError>;
+
+    async fn get_stream_records(
+        &self,
+        table_name: &str,
+        shard_id: &str,
+        after_sequence: i64,
+        limit: usize,
+    ) -> Result<Vec<StreamRecord>, BackendError>;
+
+    async fn list_stream_enabled_tables(&self) -> Result<Vec<TableMetadata>, BackendError>;
+
+    // -----------------------------------------------------------------------
+    // TTL operations
+    // -----------------------------------------------------------------------
+
+    async fn update_ttl_config(
+        &self,
+        table_name: &str,
+        attribute_name: Option<&str>,
+        enabled: bool,
+    ) -> Result<(), BackendError>;
+
+    async fn list_ttl_enabled_tables(&self) -> Result<Vec<TableMetadata>, BackendError>;
+
+    async fn get_shard_sequence_range(
+        &self,
+        table_name: &str,
+        shard_id: &str,
+    ) -> Result<(Option<String>, Option<String>), BackendError>;
+
+    // -----------------------------------------------------------------------
+    // Cache tracking
+    // -----------------------------------------------------------------------
+
+    async fn touch_cached_at(
+        &self,
+        table_name: &str,
+        pk: &str,
+        sk: &str,
+        timestamp: f64,
+    ) -> Result<(), BackendError>;
+
+    async fn get_lru_items(
+        &self,
+        table_name: &str,
+        limit: usize,
+    ) -> Result<Vec<(String, String, i64)>, BackendError>;
+}

--- a/src/storage_backend/mod.rs
+++ b/src/storage_backend/mod.rs
@@ -42,6 +42,46 @@ use crate::types::Tag;
 pub use clock::{Clock, ManualClock, SystemClock};
 pub use error::{BackendError, from_rusqlite};
 
+/// One base-table row for a bulk insert via [`StorageBackend::put_base_items`].
+///
+/// Unlike [`StorageBackend::put_item_with_hash`], which preserves any existing
+/// `cached_at` value, the bulk path writes `cached_at` verbatim: this mirrors
+/// the import flow, which sets the timestamp explicitly (or clears it) for
+/// every row it loads.
+#[derive(Debug, Clone)]
+pub struct BaseItemRow {
+    /// Partition key string.
+    pub pk: String,
+    /// Sort key string (empty for tables without a sort key).
+    pub sk: String,
+    /// Serialised item JSON.
+    pub item_json: String,
+    /// Item size in bytes.
+    pub item_size: usize,
+    /// Cache timestamp written verbatim; `None` clears the column.
+    pub cached_at: Option<f64>,
+    /// Hash prefix used for parallel-scan ordering.
+    pub hash_prefix: String,
+}
+
+/// One GSI-table row for a bulk insert via [`StorageBackend::insert_gsi_items`].
+///
+/// The fields mirror the argument order of the single-row
+/// [`StorageBackend::insert_gsi_item`].
+#[derive(Debug, Clone)]
+pub struct GsiItemRow {
+    /// GSI partition key string.
+    pub gsi_pk: String,
+    /// GSI sort key string (empty when the index has no sort key).
+    pub gsi_sk: String,
+    /// Base-table partition key string.
+    pub table_pk: String,
+    /// Base-table sort key string.
+    pub table_sk: String,
+    /// Projected item JSON.
+    pub item_json: String,
+}
+
 /// Backend-neutral storage interface.
 ///
 /// Method signatures mirror [`Storage`](crate::storage::Storage)'s public
@@ -62,6 +102,16 @@ pub use error::{BackendError, from_rusqlite};
 /// a real callsite.
 #[allow(async_fn_in_trait)]
 pub trait StorageBackend {
+    // -----------------------------------------------------------------------
+    // Capabilities
+    // -----------------------------------------------------------------------
+
+    /// Wall-clock access for the stream and TTL paths.
+    ///
+    /// Sync because reading the clock is not I/O. The native backend returns
+    /// its injected [`Clock`]; a real wa-sqlite backend supplies its own.
+    fn clock(&self) -> &dyn Clock;
+
     // -----------------------------------------------------------------------
     // Table metadata
     // -----------------------------------------------------------------------
@@ -150,6 +200,19 @@ pub trait StorageBackend {
         table_pk: &str,
         table_sk: &str,
         item_json: &str,
+    ) -> Result<(), BackendError>;
+
+    /// Bulk-insert many rows into one GSI table.
+    ///
+    /// Batch-shaped so a backend can amortise per-row round-trips (the native
+    /// backend reuses a single cached prepared statement). Used by the GSI
+    /// backfill path; the per-row [`insert_gsi_item`](Self::insert_gsi_item)
+    /// covers single writes during normal fan-out.
+    async fn insert_gsi_items(
+        &self,
+        table_name: &str,
+        index_name: &str,
+        rows: &[GsiItemRow],
     ) -> Result<(), BackendError>;
 
     async fn delete_gsi_item(
@@ -252,6 +315,19 @@ pub trait StorageBackend {
         item_size: usize,
         hash_prefix: &str,
     ) -> Result<Option<String>, BackendError>;
+
+    /// Bulk-insert many base-table rows in one call (`INSERT OR REPLACE`).
+    ///
+    /// Batch-shaped so a backend can amortise per-row round-trips (the native
+    /// backend reuses a single cached prepared statement). Used by the import
+    /// path. Writes `cached_at` verbatim from each [`BaseItemRow`]; see the
+    /// note there for how this differs from
+    /// [`put_item_with_hash`](Self::put_item_with_hash).
+    async fn put_base_items(
+        &self,
+        table_name: &str,
+        rows: &[BaseItemRow],
+    ) -> Result<(), BackendError>;
 
     async fn get_item(
         &self,

--- a/src/storage_backend/rusqlite_impl.rs
+++ b/src/storage_backend/rusqlite_impl.rs
@@ -11,7 +11,7 @@ use crate::storage::{
     CreateTableMetadata, DatabaseInfo, QueryParams, ScanParams, Storage, StreamRecord,
     TableMetadata, TableStats,
 };
-use crate::storage_backend::{BackendError, StorageBackend, error};
+use crate::storage_backend::{BackendError, BaseItemRow, Clock, GsiItemRow, StorageBackend, error};
 use crate::types::Tag;
 
 /// Convert a [`DynoxideError`] into a [`BackendError`].
@@ -29,6 +29,10 @@ fn dyno_to_backend(err: DynoxideError) -> BackendError {
 }
 
 impl StorageBackend for Storage {
+    fn clock(&self) -> &dyn Clock {
+        Storage::clock(self)
+    }
+
     async fn insert_table_metadata(&self, m: &CreateTableMetadata<'_>) -> Result<(), BackendError> {
         Storage::insert_table_metadata(self, m).map_err(dyno_to_backend)
     }
@@ -151,6 +155,15 @@ impl StorageBackend for Storage {
         .map_err(dyno_to_backend)
     }
 
+    async fn insert_gsi_items(
+        &self,
+        table_name: &str,
+        index_name: &str,
+        rows: &[GsiItemRow],
+    ) -> Result<(), BackendError> {
+        Storage::insert_gsi_items(self, table_name, index_name, rows).map_err(dyno_to_backend)
+    }
+
     async fn delete_gsi_item(
         &self,
         table_name: &str,
@@ -270,6 +283,14 @@ impl StorageBackend for Storage {
     ) -> Result<Option<String>, BackendError> {
         Storage::put_item_with_hash(self, table_name, pk, sk, item_json, item_size, hash_prefix)
             .map_err(dyno_to_backend)
+    }
+
+    async fn put_base_items(
+        &self,
+        table_name: &str,
+        rows: &[BaseItemRow],
+    ) -> Result<(), BackendError> {
+        Storage::put_base_items(self, table_name, rows).map_err(dyno_to_backend)
     }
 
     async fn get_item(

--- a/src/storage_backend/rusqlite_impl.rs
+++ b/src/storage_backend/rusqlite_impl.rs
@@ -1,0 +1,470 @@
+//! Native [`StorageBackend`] implementation backed by the rusqlite-typed
+//! [`Storage`].
+//!
+//! Each impl method is a thin async wrapper over the existing sync method on
+//! `Storage`: the body invokes the sync method synchronously and returns a
+//! ready future. No `spawn_blocking` is used — today's behaviour of running
+//! rusqlite calls on the active executor thread is preserved exactly.
+
+use crate::errors::DynoxideError;
+use crate::storage::{
+    CreateTableMetadata, DatabaseInfo, QueryParams, ScanParams, Storage, StreamRecord,
+    TableMetadata, TableStats,
+};
+use crate::storage_backend::{BackendError, StorageBackend, error};
+use crate::types::Tag;
+
+/// Convert a [`DynoxideError`] into a [`BackendError`].
+///
+/// Storage's sync surface returns `Result<T, DynoxideError>`; the trait surface
+/// returns `Result<T, BackendError>`. The conversion preserves rusqlite error
+/// codes via [`error::from_rusqlite`] and falls through any other variant
+/// (`InternalServerError`, `ValidationException`, etc.) into
+/// [`BackendError::Other`] carrying the original `Display` output.
+fn dyno_to_backend(err: DynoxideError) -> BackendError {
+    match err {
+        DynoxideError::SqliteError(e) => error::from_rusqlite(e),
+        other => BackendError::Other(other.to_string()),
+    }
+}
+
+impl StorageBackend for Storage {
+    async fn insert_table_metadata(&self, m: &CreateTableMetadata<'_>) -> Result<(), BackendError> {
+        Storage::insert_table_metadata(self, m).map_err(dyno_to_backend)
+    }
+
+    async fn get_table_metadata(
+        &self,
+        table_name: &str,
+    ) -> Result<Option<TableMetadata>, BackendError> {
+        Storage::get_table_metadata(self, table_name).map_err(dyno_to_backend)
+    }
+
+    async fn delete_table_metadata(&self, table_name: &str) -> Result<bool, BackendError> {
+        Storage::delete_table_metadata(self, table_name).map_err(dyno_to_backend)
+    }
+
+    async fn update_table_metadata(
+        &self,
+        table_name: &str,
+        attribute_definitions: &str,
+        gsi_definitions: Option<&str>,
+    ) -> Result<(), BackendError> {
+        Storage::update_table_metadata(self, table_name, attribute_definitions, gsi_definitions)
+            .map_err(dyno_to_backend)
+    }
+
+    async fn update_provisioned_throughput(
+        &self,
+        table_name: &str,
+        provisioned_throughput: &str,
+    ) -> Result<(), BackendError> {
+        Storage::update_provisioned_throughput(self, table_name, provisioned_throughput)
+            .map_err(dyno_to_backend)
+    }
+
+    async fn clear_provisioned_throughput(&self, table_name: &str) -> Result<(), BackendError> {
+        Storage::clear_provisioned_throughput(self, table_name).map_err(dyno_to_backend)
+    }
+
+    async fn update_billing_mode(
+        &self,
+        table_name: &str,
+        billing_mode: &str,
+    ) -> Result<(), BackendError> {
+        Storage::update_billing_mode(self, table_name, billing_mode).map_err(dyno_to_backend)
+    }
+
+    async fn get_tags(&self, table_name: &str) -> Result<Vec<Tag>, BackendError> {
+        Storage::get_tags(self, table_name).map_err(dyno_to_backend)
+    }
+
+    async fn set_tags(&self, table_name: &str, new_tags: &[Tag]) -> Result<(), BackendError> {
+        Storage::set_tags(self, table_name, new_tags).map_err(dyno_to_backend)
+    }
+
+    async fn update_deletion_protection(
+        &self,
+        table_name: &str,
+        enabled: bool,
+    ) -> Result<(), BackendError> {
+        Storage::update_deletion_protection(self, table_name, enabled).map_err(dyno_to_backend)
+    }
+
+    async fn remove_tags(&self, table_name: &str, keys: &[String]) -> Result<(), BackendError> {
+        Storage::remove_tags(self, table_name, keys).map_err(dyno_to_backend)
+    }
+
+    async fn list_table_names(&self) -> Result<Vec<String>, BackendError> {
+        Storage::list_table_names(self).map_err(dyno_to_backend)
+    }
+
+    async fn table_exists(&self, table_name: &str) -> Result<bool, BackendError> {
+        Storage::table_exists(self, table_name).map_err(dyno_to_backend)
+    }
+
+    async fn create_data_table(&self, table_name: &str) -> Result<(), BackendError> {
+        Storage::create_data_table(self, table_name).map_err(dyno_to_backend)
+    }
+
+    async fn drop_data_table(&self, table_name: &str) -> Result<(), BackendError> {
+        Storage::drop_data_table(self, table_name).map_err(dyno_to_backend)
+    }
+
+    async fn create_gsi_table(
+        &self,
+        table_name: &str,
+        index_name: &str,
+    ) -> Result<(), BackendError> {
+        Storage::create_gsi_table(self, table_name, index_name).map_err(dyno_to_backend)
+    }
+
+    async fn drop_gsi_table(&self, table_name: &str, index_name: &str) -> Result<(), BackendError> {
+        Storage::drop_gsi_table(self, table_name, index_name).map_err(dyno_to_backend)
+    }
+
+    async fn create_lsi_table(
+        &self,
+        table_name: &str,
+        index_name: &str,
+    ) -> Result<(), BackendError> {
+        Storage::create_lsi_table(self, table_name, index_name).map_err(dyno_to_backend)
+    }
+
+    async fn drop_lsi_table(&self, table_name: &str, index_name: &str) -> Result<(), BackendError> {
+        Storage::drop_lsi_table(self, table_name, index_name).map_err(dyno_to_backend)
+    }
+
+    async fn insert_gsi_item(
+        &self,
+        table_name: &str,
+        index_name: &str,
+        gsi_pk: &str,
+        gsi_sk: &str,
+        table_pk: &str,
+        table_sk: &str,
+        item_json: &str,
+    ) -> Result<(), BackendError> {
+        Storage::insert_gsi_item(
+            self, table_name, index_name, gsi_pk, gsi_sk, table_pk, table_sk, item_json,
+        )
+        .map_err(dyno_to_backend)
+    }
+
+    async fn delete_gsi_item(
+        &self,
+        table_name: &str,
+        index_name: &str,
+        table_pk: &str,
+        table_sk: &str,
+    ) -> Result<(), BackendError> {
+        Storage::delete_gsi_item(self, table_name, index_name, table_pk, table_sk)
+            .map_err(dyno_to_backend)
+    }
+
+    async fn query_gsi_items(
+        &self,
+        table_name: &str,
+        index_name: &str,
+        gsi_pk: &str,
+        params: &QueryParams<'_>,
+    ) -> Result<Vec<(String, String, String)>, BackendError> {
+        Storage::query_gsi_items(self, table_name, index_name, gsi_pk, params)
+            .map_err(dyno_to_backend)
+    }
+
+    async fn scan_gsi_items(
+        &self,
+        table_name: &str,
+        index_name: &str,
+        params: &ScanParams<'_>,
+    ) -> Result<Vec<(String, String, String)>, BackendError> {
+        Storage::scan_gsi_items(self, table_name, index_name, params).map_err(dyno_to_backend)
+    }
+
+    async fn insert_lsi_item(
+        &self,
+        table_name: &str,
+        index_name: &str,
+        pk: &str,
+        sk: &str,
+        base_pk: &str,
+        base_sk: &str,
+        item_json: &str,
+    ) -> Result<(), BackendError> {
+        Storage::insert_lsi_item(
+            self, table_name, index_name, pk, sk, base_pk, base_sk, item_json,
+        )
+        .map_err(dyno_to_backend)
+    }
+
+    async fn delete_lsi_item(
+        &self,
+        table_name: &str,
+        index_name: &str,
+        base_pk: &str,
+        base_sk: &str,
+    ) -> Result<(), BackendError> {
+        Storage::delete_lsi_item(self, table_name, index_name, base_pk, base_sk)
+            .map_err(dyno_to_backend)
+    }
+
+    async fn query_lsi_items(
+        &self,
+        table_name: &str,
+        index_name: &str,
+        pk: &str,
+        params: &QueryParams<'_>,
+    ) -> Result<Vec<(String, String, String)>, BackendError> {
+        Storage::query_lsi_items(self, table_name, index_name, pk, params).map_err(dyno_to_backend)
+    }
+
+    async fn scan_lsi_items(
+        &self,
+        table_name: &str,
+        index_name: &str,
+        params: &ScanParams<'_>,
+    ) -> Result<Vec<(String, String, String)>, BackendError> {
+        Storage::scan_lsi_items(self, table_name, index_name, params).map_err(dyno_to_backend)
+    }
+
+    async fn begin_transaction(&self) -> Result<(), BackendError> {
+        Storage::begin_transaction(self).map_err(dyno_to_backend)
+    }
+
+    async fn commit(&self) -> Result<(), BackendError> {
+        Storage::commit(self).map_err(dyno_to_backend)
+    }
+
+    async fn rollback(&self) -> Result<(), BackendError> {
+        Storage::rollback(self).map_err(dyno_to_backend)
+    }
+
+    async fn enable_bulk_loading(&self) -> Result<(), BackendError> {
+        Storage::enable_bulk_loading(self).map_err(dyno_to_backend)
+    }
+
+    async fn disable_bulk_loading(&self) -> Result<(), BackendError> {
+        Storage::disable_bulk_loading(self).map_err(dyno_to_backend)
+    }
+
+    async fn put_item(
+        &self,
+        table_name: &str,
+        pk: &str,
+        sk: &str,
+        item_json: &str,
+        item_size: usize,
+    ) -> Result<Option<String>, BackendError> {
+        Storage::put_item(self, table_name, pk, sk, item_json, item_size).map_err(dyno_to_backend)
+    }
+
+    async fn put_item_with_hash(
+        &self,
+        table_name: &str,
+        pk: &str,
+        sk: &str,
+        item_json: &str,
+        item_size: usize,
+        hash_prefix: &str,
+    ) -> Result<Option<String>, BackendError> {
+        Storage::put_item_with_hash(self, table_name, pk, sk, item_json, item_size, hash_prefix)
+            .map_err(dyno_to_backend)
+    }
+
+    async fn get_item(
+        &self,
+        table_name: &str,
+        pk: &str,
+        sk: &str,
+    ) -> Result<Option<String>, BackendError> {
+        Storage::get_item(self, table_name, pk, sk).map_err(dyno_to_backend)
+    }
+
+    async fn get_partition_size(&self, table_name: &str, pk: &str) -> Result<i64, BackendError> {
+        Storage::get_partition_size(self, table_name, pk).map_err(dyno_to_backend)
+    }
+
+    async fn get_lsi_partition_size(
+        &self,
+        table_name: &str,
+        index_name: &str,
+        pk: &str,
+    ) -> Result<i64, BackendError> {
+        Storage::get_lsi_partition_size(self, table_name, index_name, pk).map_err(dyno_to_backend)
+    }
+
+    async fn delete_item(
+        &self,
+        table_name: &str,
+        pk: &str,
+        sk: &str,
+    ) -> Result<Option<String>, BackendError> {
+        Storage::delete_item(self, table_name, pk, sk).map_err(dyno_to_backend)
+    }
+
+    async fn query_items(
+        &self,
+        table_name: &str,
+        pk: &str,
+        params: &QueryParams<'_>,
+    ) -> Result<Vec<(String, String, String)>, BackendError> {
+        Storage::query_items(self, table_name, pk, params).map_err(dyno_to_backend)
+    }
+
+    async fn scan_items(
+        &self,
+        table_name: &str,
+        params: &ScanParams<'_>,
+    ) -> Result<Vec<(String, String, String)>, BackendError> {
+        Storage::scan_items(self, table_name, params).map_err(dyno_to_backend)
+    }
+
+    async fn count_items(&self, table_name: &str) -> Result<i64, BackendError> {
+        Storage::count_items(self, table_name).map_err(dyno_to_backend)
+    }
+
+    async fn db_size_bytes(&self) -> Result<u64, BackendError> {
+        Storage::db_size_bytes(self).map_err(dyno_to_backend)
+    }
+
+    async fn table_count(&self) -> Result<usize, BackendError> {
+        Storage::table_count(self).map_err(dyno_to_backend)
+    }
+
+    async fn table_stats(&self) -> Result<Vec<TableStats>, BackendError> {
+        Storage::table_stats(self).map_err(dyno_to_backend)
+    }
+
+    async fn database_info(&self) -> Result<DatabaseInfo, BackendError> {
+        Storage::database_info(self).map_err(dyno_to_backend)
+    }
+
+    async fn vacuum(&self) -> Result<(), BackendError> {
+        Storage::vacuum(self).map_err(dyno_to_backend)
+    }
+
+    async fn enable_stream(
+        &self,
+        table_name: &str,
+        view_type: &str,
+        label: &str,
+    ) -> Result<(), BackendError> {
+        Storage::enable_stream(self, table_name, view_type, label).map_err(dyno_to_backend)
+    }
+
+    async fn disable_stream(&self, table_name: &str) -> Result<(), BackendError> {
+        Storage::disable_stream(self, table_name).map_err(dyno_to_backend)
+    }
+
+    async fn insert_stream_record(
+        &self,
+        table_name: &str,
+        event_name: &str,
+        keys_json: &str,
+        new_image: Option<&str>,
+        old_image: Option<&str>,
+        sequence_number: &str,
+        shard_id: &str,
+        created_at: i64,
+    ) -> Result<(), BackendError> {
+        Storage::insert_stream_record(
+            self,
+            table_name,
+            event_name,
+            keys_json,
+            new_image,
+            old_image,
+            sequence_number,
+            shard_id,
+            created_at,
+        )
+        .map_err(dyno_to_backend)
+    }
+
+    async fn insert_stream_record_with_identity(
+        &self,
+        table_name: &str,
+        event_name: &str,
+        keys_json: &str,
+        new_image: Option<&str>,
+        old_image: Option<&str>,
+        sequence_number: &str,
+        shard_id: &str,
+        created_at: i64,
+        user_identity: Option<&str>,
+    ) -> Result<(), BackendError> {
+        Storage::insert_stream_record_with_identity(
+            self,
+            table_name,
+            event_name,
+            keys_json,
+            new_image,
+            old_image,
+            sequence_number,
+            shard_id,
+            created_at,
+            user_identity,
+        )
+        .map_err(dyno_to_backend)
+    }
+
+    async fn next_stream_sequence_number(&self, table_name: &str) -> Result<i64, BackendError> {
+        Storage::next_stream_sequence_number(self, table_name).map_err(dyno_to_backend)
+    }
+
+    async fn get_stream_records(
+        &self,
+        table_name: &str,
+        shard_id: &str,
+        after_sequence: i64,
+        limit: usize,
+    ) -> Result<Vec<StreamRecord>, BackendError> {
+        Storage::get_stream_records(self, table_name, shard_id, after_sequence, limit)
+            .map_err(dyno_to_backend)
+    }
+
+    async fn list_stream_enabled_tables(&self) -> Result<Vec<TableMetadata>, BackendError> {
+        Storage::list_stream_enabled_tables(self).map_err(dyno_to_backend)
+    }
+
+    async fn update_ttl_config(
+        &self,
+        table_name: &str,
+        attribute_name: Option<&str>,
+        enabled: bool,
+    ) -> Result<(), BackendError> {
+        Storage::update_ttl_config(self, table_name, attribute_name, enabled)
+            .map_err(dyno_to_backend)
+    }
+
+    async fn list_ttl_enabled_tables(&self) -> Result<Vec<TableMetadata>, BackendError> {
+        Storage::list_ttl_enabled_tables(self).map_err(dyno_to_backend)
+    }
+
+    async fn get_shard_sequence_range(
+        &self,
+        table_name: &str,
+        shard_id: &str,
+    ) -> Result<(Option<String>, Option<String>), BackendError> {
+        Storage::get_shard_sequence_range(self, table_name, shard_id).map_err(dyno_to_backend)
+    }
+
+    async fn touch_cached_at(
+        &self,
+        table_name: &str,
+        pk: &str,
+        sk: &str,
+        timestamp: f64,
+    ) -> Result<(), BackendError> {
+        Storage::touch_cached_at(self, table_name, pk, sk, timestamp).map_err(dyno_to_backend)
+    }
+
+    async fn get_lru_items(
+        &self,
+        table_name: &str,
+        limit: usize,
+    ) -> Result<Vec<(String, String, i64)>, BackendError> {
+        Storage::get_lru_items(self, table_name, limit).map_err(dyno_to_backend)
+    }
+}

--- a/src/storage_backend/rusqlite_impl.rs
+++ b/src/storage_backend/rusqlite_impl.rs
@@ -3,8 +3,19 @@
 //!
 //! Each impl method is a thin async wrapper over the existing sync method on
 //! `Storage`: the body invokes the sync method synchronously and returns a
-//! ready future. No `spawn_blocking` is used — today's behaviour of running
+//! ready future. No `spawn_blocking` is used, so today's behaviour of running
 //! rusqlite calls on the active executor thread is preserved exactly.
+//!
+//! # Load-bearing invariant: native futures never suspend
+//!
+//! Every method here resolves on the first poll (it runs synchronous work and
+//! returns `Ready`). The synchronous `Database` facade depends on this: it
+//! drives these futures with `block_on`, which is only safe to call from inside
+//! the tokio-based HTTP and MCP servers because an always-ready future never
+//! parks the worker thread. Do not introduce a real `.await` on external async
+//! I/O (a socket, a timer, a task spawn, a channel) into any method here
+//! without first moving the facade off `block_on`; otherwise the server worker
+//! threads will stall.
 
 use crate::errors::DynoxideError;
 use crate::storage::{

--- a/src/storage_backend/rusqlite_impl.rs
+++ b/src/storage_backend/rusqlite_impl.rs
@@ -18,12 +18,15 @@ use crate::types::Tag;
 ///
 /// Storage's sync surface returns `Result<T, DynoxideError>`; the trait surface
 /// returns `Result<T, BackendError>`. The conversion preserves rusqlite error
-/// codes via [`error::from_rusqlite`] and falls through any other variant
-/// (`InternalServerError`, `ValidationException`, etc.) into
+/// codes via [`error::from_rusqlite`]. A client-facing `ValidationException`
+/// (a backend method such as `set_tags` enforces the tag-count limit) is
+/// preserved as [`BackendError::Validation`] so the reverse conversion can
+/// restore its 400 envelope; any other variant falls through to
 /// [`BackendError::Other`] carrying the original `Display` output.
 fn dyno_to_backend(err: DynoxideError) -> BackendError {
     match err {
         DynoxideError::SqliteError(e) => error::from_rusqlite(e),
+        DynoxideError::ValidationException(msg) => BackendError::Validation(msg),
         other => BackendError::Other(other.to_string()),
     }
 }

--- a/src/storage_backend/wasm_stub.rs
+++ b/src/storage_backend/wasm_stub.rs
@@ -12,7 +12,7 @@ use crate::storage::{
     CreateTableMetadata, DatabaseInfo, QueryParams, ScanParams, StreamRecord, TableMetadata,
     TableStats,
 };
-use crate::storage_backend::{BackendError, StorageBackend};
+use crate::storage_backend::{BackendError, BaseItemRow, Clock, GsiItemRow, StorageBackend};
 use crate::types::Tag;
 
 /// Placeholder backend. Constructible but not callable.
@@ -21,6 +21,27 @@ pub struct WaSqliteBackend;
 const STUB_NOT_IMPLEMENTED: &str = "wa-sqlite backend stub: no runtime support";
 
 impl StorageBackend for WaSqliteBackend {
+    fn clock(&self) -> &dyn Clock {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn insert_gsi_items(
+        &self,
+        _table_name: &str,
+        _index_name: &str,
+        _rows: &[GsiItemRow],
+    ) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn put_base_items(
+        &self,
+        _table_name: &str,
+        _rows: &[BaseItemRow],
+    ) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
     async fn insert_table_metadata(
         &self,
         _m: &CreateTableMetadata<'_>,

--- a/src/storage_backend/wasm_stub.rs
+++ b/src/storage_backend/wasm_stub.rs
@@ -1,0 +1,433 @@
+//! Compile-only wa-sqlite backend stub.
+//!
+//! `WaSqliteBackend` satisfies [`StorageBackend`] at the type level. Bodies
+//! are `unimplemented!()`; this is not a working backend.
+//!
+//! Its job is purely protective: when the trait surface drifts, the stub
+//! fails to compile and CI catches the regression before a real wa-sqlite
+//! backend has to absorb the change. A working wa-sqlite implementation
+//! lands later, alongside the broader WASM build.
+
+use crate::storage::{
+    CreateTableMetadata, DatabaseInfo, QueryParams, ScanParams, StreamRecord, TableMetadata,
+    TableStats,
+};
+use crate::storage_backend::{BackendError, StorageBackend};
+use crate::types::Tag;
+
+/// Placeholder backend. Constructible but not callable.
+pub struct WaSqliteBackend;
+
+const STUB_NOT_IMPLEMENTED: &str = "wa-sqlite backend stub: no runtime support";
+
+impl StorageBackend for WaSqliteBackend {
+    async fn insert_table_metadata(
+        &self,
+        _m: &CreateTableMetadata<'_>,
+    ) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn get_table_metadata(
+        &self,
+        _table_name: &str,
+    ) -> Result<Option<TableMetadata>, BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn delete_table_metadata(&self, _table_name: &str) -> Result<bool, BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn update_table_metadata(
+        &self,
+        _table_name: &str,
+        _attribute_definitions: &str,
+        _gsi_definitions: Option<&str>,
+    ) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn update_provisioned_throughput(
+        &self,
+        _table_name: &str,
+        _provisioned_throughput: &str,
+    ) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn clear_provisioned_throughput(&self, _table_name: &str) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn update_billing_mode(
+        &self,
+        _table_name: &str,
+        _billing_mode: &str,
+    ) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn get_tags(&self, _table_name: &str) -> Result<Vec<Tag>, BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn set_tags(&self, _table_name: &str, _new_tags: &[Tag]) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn update_deletion_protection(
+        &self,
+        _table_name: &str,
+        _enabled: bool,
+    ) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn remove_tags(&self, _table_name: &str, _keys: &[String]) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn list_table_names(&self) -> Result<Vec<String>, BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn table_exists(&self, _table_name: &str) -> Result<bool, BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn create_data_table(&self, _table_name: &str) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn drop_data_table(&self, _table_name: &str) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn create_gsi_table(
+        &self,
+        _table_name: &str,
+        _index_name: &str,
+    ) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn drop_gsi_table(
+        &self,
+        _table_name: &str,
+        _index_name: &str,
+    ) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn create_lsi_table(
+        &self,
+        _table_name: &str,
+        _index_name: &str,
+    ) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn drop_lsi_table(
+        &self,
+        _table_name: &str,
+        _index_name: &str,
+    ) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn insert_gsi_item(
+        &self,
+        _table_name: &str,
+        _index_name: &str,
+        _gsi_pk: &str,
+        _gsi_sk: &str,
+        _table_pk: &str,
+        _table_sk: &str,
+        _item_json: &str,
+    ) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn delete_gsi_item(
+        &self,
+        _table_name: &str,
+        _index_name: &str,
+        _table_pk: &str,
+        _table_sk: &str,
+    ) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn query_gsi_items(
+        &self,
+        _table_name: &str,
+        _index_name: &str,
+        _gsi_pk: &str,
+        _params: &QueryParams<'_>,
+    ) -> Result<Vec<(String, String, String)>, BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn scan_gsi_items(
+        &self,
+        _table_name: &str,
+        _index_name: &str,
+        _params: &ScanParams<'_>,
+    ) -> Result<Vec<(String, String, String)>, BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn insert_lsi_item(
+        &self,
+        _table_name: &str,
+        _index_name: &str,
+        _pk: &str,
+        _sk: &str,
+        _base_pk: &str,
+        _base_sk: &str,
+        _item_json: &str,
+    ) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn delete_lsi_item(
+        &self,
+        _table_name: &str,
+        _index_name: &str,
+        _base_pk: &str,
+        _base_sk: &str,
+    ) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn query_lsi_items(
+        &self,
+        _table_name: &str,
+        _index_name: &str,
+        _pk: &str,
+        _params: &QueryParams<'_>,
+    ) -> Result<Vec<(String, String, String)>, BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn scan_lsi_items(
+        &self,
+        _table_name: &str,
+        _index_name: &str,
+        _params: &ScanParams<'_>,
+    ) -> Result<Vec<(String, String, String)>, BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn begin_transaction(&self) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+    async fn commit(&self) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+    async fn rollback(&self) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn enable_bulk_loading(&self) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+    async fn disable_bulk_loading(&self) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn put_item(
+        &self,
+        _table_name: &str,
+        _pk: &str,
+        _sk: &str,
+        _item_json: &str,
+        _item_size: usize,
+    ) -> Result<Option<String>, BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn put_item_with_hash(
+        &self,
+        _table_name: &str,
+        _pk: &str,
+        _sk: &str,
+        _item_json: &str,
+        _item_size: usize,
+        _hash_prefix: &str,
+    ) -> Result<Option<String>, BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn get_item(
+        &self,
+        _table_name: &str,
+        _pk: &str,
+        _sk: &str,
+    ) -> Result<Option<String>, BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn get_partition_size(&self, _table_name: &str, _pk: &str) -> Result<i64, BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn get_lsi_partition_size(
+        &self,
+        _table_name: &str,
+        _index_name: &str,
+        _pk: &str,
+    ) -> Result<i64, BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn delete_item(
+        &self,
+        _table_name: &str,
+        _pk: &str,
+        _sk: &str,
+    ) -> Result<Option<String>, BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn query_items(
+        &self,
+        _table_name: &str,
+        _pk: &str,
+        _params: &QueryParams<'_>,
+    ) -> Result<Vec<(String, String, String)>, BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn scan_items(
+        &self,
+        _table_name: &str,
+        _params: &ScanParams<'_>,
+    ) -> Result<Vec<(String, String, String)>, BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn count_items(&self, _table_name: &str) -> Result<i64, BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn db_size_bytes(&self) -> Result<u64, BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn table_count(&self) -> Result<usize, BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn table_stats(&self) -> Result<Vec<TableStats>, BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn database_info(&self) -> Result<DatabaseInfo, BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn vacuum(&self) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn enable_stream(
+        &self,
+        _table_name: &str,
+        _view_type: &str,
+        _label: &str,
+    ) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn disable_stream(&self, _table_name: &str) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn insert_stream_record(
+        &self,
+        _table_name: &str,
+        _event_name: &str,
+        _keys_json: &str,
+        _new_image: Option<&str>,
+        _old_image: Option<&str>,
+        _sequence_number: &str,
+        _shard_id: &str,
+        _created_at: i64,
+    ) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn insert_stream_record_with_identity(
+        &self,
+        _table_name: &str,
+        _event_name: &str,
+        _keys_json: &str,
+        _new_image: Option<&str>,
+        _old_image: Option<&str>,
+        _sequence_number: &str,
+        _shard_id: &str,
+        _created_at: i64,
+        _user_identity: Option<&str>,
+    ) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn next_stream_sequence_number(&self, _table_name: &str) -> Result<i64, BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn get_stream_records(
+        &self,
+        _table_name: &str,
+        _shard_id: &str,
+        _after_sequence: i64,
+        _limit: usize,
+    ) -> Result<Vec<StreamRecord>, BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn list_stream_enabled_tables(&self) -> Result<Vec<TableMetadata>, BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn update_ttl_config(
+        &self,
+        _table_name: &str,
+        _attribute_name: Option<&str>,
+        _enabled: bool,
+    ) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn list_ttl_enabled_tables(&self) -> Result<Vec<TableMetadata>, BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn get_shard_sequence_range(
+        &self,
+        _table_name: &str,
+        _shard_id: &str,
+    ) -> Result<(Option<String>, Option<String>), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn touch_cached_at(
+        &self,
+        _table_name: &str,
+        _pk: &str,
+        _sk: &str,
+        _timestamp: f64,
+    ) -> Result<(), BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+
+    async fn get_lru_items(
+        &self,
+        _table_name: &str,
+        _limit: usize,
+    ) -> Result<Vec<(String, String, i64)>, BackendError> {
+        unimplemented!("{STUB_NOT_IMPLEMENTED}")
+    }
+}

--- a/src/streams.rs
+++ b/src/streams.rs
@@ -4,9 +4,9 @@
 
 use crate::errors::Result;
 use crate::storage::{Storage, TableMetadata};
+use crate::storage_backend::clock::Clock;
 use crate::types::{AttributeValue, Item};
 use std::collections::HashMap;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Region used in ARNs for the local emulator.
 pub const LOCAL_REGION: &str = "dynoxide";
@@ -34,11 +34,15 @@ pub fn shard_id(table_name: &str) -> String {
 }
 
 /// Generate a stream label from the current timestamp.
-pub fn generate_stream_label() -> String {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default();
-    format!("{}.{:09}", now.as_secs(), now.subsec_nanos())
+///
+/// The label format preserves the historical `<secs>.<nanos>` shape. The
+/// caller supplies the clock so production callers route through
+/// `Storage::clock()` while tests can pin time via `ManualClock`.
+pub fn generate_stream_label(clock: &dyn Clock) -> String {
+    let now_f64 = clock.now_unix_secs_f64();
+    let secs = now_f64.trunc() as u64;
+    let nanos = ((now_f64 - secs as f64) * 1_000_000_000.0) as u32;
+    format!("{secs}.{nanos:09}")
 }
 
 /// Extract only key attributes from an item given the key schema JSON.
@@ -104,10 +108,7 @@ pub fn record_stream_event(
 
     let seq_num = storage.next_stream_sequence_number(&meta.table_name)?;
     let sid = shard_id(&meta.table_name);
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs() as i64;
+    let now = storage.clock().now_unix_secs() as i64;
 
     storage.insert_stream_record(
         &meta.table_name,

--- a/src/streams.rs
+++ b/src/streams.rs
@@ -3,7 +3,8 @@
 //! Generates stream records on write operations when streams are enabled on a table.
 
 use crate::errors::Result;
-use crate::storage::{Storage, TableMetadata};
+use crate::storage::TableMetadata;
+use crate::storage_backend::StorageBackend;
 use crate::storage_backend::clock::Clock;
 use crate::types::{AttributeValue, Item};
 use std::collections::HashMap;
@@ -65,8 +66,8 @@ pub fn extract_keys(item: &Item, key_schema_json: &str) -> HashMap<String, Attri
 /// For MODIFY: both are Some.
 /// For REMOVE: old_item is Some, new_item is None.
 #[allow(clippy::too_many_arguments)]
-pub fn record_stream_event(
-    storage: &Storage,
+pub async fn record_stream_event<S: StorageBackend>(
+    storage: &S,
     meta: &TableMetadata,
     old_item: Option<&Item>,
     new_item: Option<&Item>,
@@ -106,20 +107,24 @@ pub fn record_stream_event(
         _ => None,
     };
 
-    let seq_num = storage.next_stream_sequence_number(&meta.table_name)?;
+    let seq_num = storage
+        .next_stream_sequence_number(&meta.table_name)
+        .await?;
     let sid = shard_id(&meta.table_name);
     let now = storage.clock().now_unix_secs() as i64;
 
-    storage.insert_stream_record(
-        &meta.table_name,
-        event_name,
-        &keys_json,
-        new_image_json.as_deref(),
-        old_image_json.as_deref(),
-        &seq_num.to_string(),
-        &sid,
-        now,
-    )?;
+    storage
+        .insert_stream_record(
+            &meta.table_name,
+            event_name,
+            &keys_json,
+            new_image_json.as_deref(),
+            old_image_json.as_deref(),
+            &seq_num.to_string(),
+            &sid,
+            now,
+        )
+        .await?;
 
     Ok(())
 }

--- a/src/ttl.rs
+++ b/src/ttl.rs
@@ -54,24 +54,24 @@ pub async fn sweep_expired_items<S: StorageBackend>(storage: &S) -> Result<usize
                 };
 
                 if is_expired(&item, &ttl_attr, now) {
-                    // Delete the item
-                    let old_json = storage.delete_item(&meta.table_name, pk, sk).await?;
-
-                    // Maintain GSI tables
-                    let _ =
+                    // Each TTL deletion is atomic with its own index fan-out: a
+                    // mid-fan-out failure rolls that item's delete back rather
+                    // than leaving a torn index. Items are independent, so this
+                    // is one transaction per deleted item.
+                    crate::actions::helpers::with_write_transaction(storage, async {
+                        storage.delete_item(&meta.table_name, pk, sk).await?;
                         gsi::maintain_gsis_after_delete(storage, &meta.table_name, meta, pk, sk)
                             .await?;
+                        lsi::maintain_lsis_after_delete(storage, &meta.table_name, meta, pk, sk)
+                            .await?;
+                        // Generate stream REMOVE record with TTL service identity
+                        if meta.stream_enabled {
+                            record_ttl_stream_event(storage, meta, &item).await?;
+                        }
+                        Ok(())
+                    })
+                    .await?;
 
-                    // Maintain LSI tables
-                    lsi::maintain_lsis_after_delete(storage, &meta.table_name, meta, pk, sk)
-                        .await?;
-
-                    // Generate stream REMOVE record with TTL service identity
-                    if meta.stream_enabled {
-                        record_ttl_stream_event(storage, meta, &item).await?;
-                    }
-
-                    let _ = old_json; // consumed by delete_item
                     total_deleted += 1;
                 }
             }

--- a/src/ttl.rs
+++ b/src/ttl.rs
@@ -4,7 +4,7 @@
 
 use crate::actions::{gsi, lsi};
 use crate::errors::Result;
-use crate::storage::Storage;
+use crate::storage_backend::StorageBackend;
 use crate::streams;
 use crate::types::{AttributeValue, Item};
 
@@ -14,10 +14,10 @@ const TTL_USER_IDENTITY: &str = r#"{"type":"Service","principalId":"dynamodb.ama
 /// Sweep all TTL-enabled tables and delete expired items.
 ///
 /// Returns the total number of items deleted across all tables.
-pub fn sweep_expired_items(storage: &Storage) -> Result<usize> {
+pub async fn sweep_expired_items<S: StorageBackend>(storage: &S) -> Result<usize> {
     let now = storage.clock().now_unix_secs();
 
-    let tables = storage.list_ttl_enabled_tables()?;
+    let tables = storage.list_ttl_enabled_tables().await?;
     let mut total_deleted = 0;
 
     for meta in &tables {
@@ -31,15 +31,17 @@ pub fn sweep_expired_items(storage: &Storage) -> Result<usize> {
         let mut exclusive_start_sk: Option<String> = None;
 
         loop {
-            let rows = storage.scan_items(
-                &meta.table_name,
-                &crate::storage::ScanParams {
-                    limit: Some(100),
-                    exclusive_start_pk: exclusive_start_pk.as_deref(),
-                    exclusive_start_sk: exclusive_start_sk.as_deref(),
-                    ..Default::default()
-                },
-            )?;
+            let rows = storage
+                .scan_items(
+                    &meta.table_name,
+                    &crate::storage::ScanParams {
+                        limit: Some(100),
+                        exclusive_start_pk: exclusive_start_pk.as_deref(),
+                        exclusive_start_sk: exclusive_start_sk.as_deref(),
+                        ..Default::default()
+                    },
+                )
+                .await?;
 
             if rows.is_empty() {
                 break;
@@ -53,18 +55,20 @@ pub fn sweep_expired_items(storage: &Storage) -> Result<usize> {
 
                 if is_expired(&item, &ttl_attr, now) {
                     // Delete the item
-                    let old_json = storage.delete_item(&meta.table_name, pk, sk)?;
+                    let old_json = storage.delete_item(&meta.table_name, pk, sk).await?;
 
                     // Maintain GSI tables
                     let _ =
-                        gsi::maintain_gsis_after_delete(storage, &meta.table_name, meta, pk, sk)?;
+                        gsi::maintain_gsis_after_delete(storage, &meta.table_name, meta, pk, sk)
+                            .await?;
 
                     // Maintain LSI tables
-                    lsi::maintain_lsis_after_delete(storage, &meta.table_name, meta, pk, sk)?;
+                    lsi::maintain_lsis_after_delete(storage, &meta.table_name, meta, pk, sk)
+                        .await?;
 
                     // Generate stream REMOVE record with TTL service identity
                     if meta.stream_enabled {
-                        record_ttl_stream_event(storage, meta, &item)?;
+                        record_ttl_stream_event(storage, meta, &item).await?;
                     }
 
                     let _ = old_json; // consumed by delete_item
@@ -103,8 +107,8 @@ fn is_expired(item: &Item, ttl_attr: &str, now_epoch_secs: u64) -> bool {
 
 /// Record a stream REMOVE event for a TTL deletion, with the DynamoDB service
 /// user identity to distinguish from manual deletes.
-fn record_ttl_stream_event(
-    storage: &Storage,
+async fn record_ttl_stream_event<S: StorageBackend>(
+    storage: &S,
     meta: &crate::storage::TableMetadata,
     old_item: &Item,
 ) -> Result<()> {
@@ -123,21 +127,25 @@ fn record_ttl_stream_event(
         _ => None,
     };
 
-    let seq_num = storage.next_stream_sequence_number(&meta.table_name)?;
+    let seq_num = storage
+        .next_stream_sequence_number(&meta.table_name)
+        .await?;
     let sid = streams::shard_id(&meta.table_name);
     let now = storage.clock().now_unix_secs() as i64;
 
-    storage.insert_stream_record_with_identity(
-        &meta.table_name,
-        "REMOVE",
-        &keys_json,
-        None,
-        old_image_json.as_deref(),
-        &seq_num.to_string(),
-        &sid,
-        now,
-        Some(TTL_USER_IDENTITY),
-    )?;
+    storage
+        .insert_stream_record_with_identity(
+            &meta.table_name,
+            "REMOVE",
+            &keys_json,
+            None,
+            old_image_json.as_deref(),
+            &seq_num.to_string(),
+            &sid,
+            now,
+            Some(TTL_USER_IDENTITY),
+        )
+        .await?;
 
     Ok(())
 }

--- a/src/ttl.rs
+++ b/src/ttl.rs
@@ -7,7 +7,6 @@ use crate::errors::Result;
 use crate::storage::Storage;
 use crate::streams;
 use crate::types::{AttributeValue, Item};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 /// JSON representation of the TTL service identity for stream records.
 const TTL_USER_IDENTITY: &str = r#"{"type":"Service","principalId":"dynamodb.amazonaws.com"}"#;
@@ -16,10 +15,7 @@ const TTL_USER_IDENTITY: &str = r#"{"type":"Service","principalId":"dynamodb.ama
 ///
 /// Returns the total number of items deleted across all tables.
 pub fn sweep_expired_items(storage: &Storage) -> Result<usize> {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
+    let now = storage.clock().now_unix_secs();
 
     let tables = storage.list_ttl_enabled_tables()?;
     let mut total_deleted = 0;
@@ -129,10 +125,7 @@ fn record_ttl_stream_event(
 
     let seq_num = storage.next_stream_sequence_number(&meta.table_name)?;
     let sid = streams::shard_id(&meta.table_name);
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs() as i64;
+    let now = storage.clock().now_unix_secs() as i64;
 
     storage.insert_stream_record_with_identity(
         &meta.table_name,

--- a/tests/backend_error.rs
+++ b/tests/backend_error.rs
@@ -1,0 +1,115 @@
+//! Coverage for `BackendError` and the `rusqlite::Error -> BackendError` mapping.
+
+use dynoxide::BackendError;
+use dynoxide::storage_backend::error::from_rusqlite;
+use rusqlite::ErrorCode;
+use rusqlite::ffi;
+
+fn sqlite_failure(extended_code: i32, msg: Option<&str>) -> rusqlite::Error {
+    rusqlite::Error::SqliteFailure(ffi::Error::new(extended_code), msg.map(str::to_owned))
+}
+
+#[test]
+fn display_is_non_empty_for_every_variant() {
+    let variants = [
+        BackendError::NotADatabase,
+        BackendError::Locked,
+        BackendError::Constraint("violated".into()),
+        BackendError::Io("disk full".into()),
+        BackendError::Other("anything".into()),
+    ];
+    for v in variants {
+        let s = v.to_string();
+        assert!(!s.is_empty(), "Display for {v:?} produced empty string");
+    }
+}
+
+#[test]
+fn other_carries_a_non_empty_message() {
+    let msg = "disk full";
+    let err = BackendError::Other(msg.into());
+    assert!(err.to_string().contains(msg));
+}
+
+#[test]
+fn maps_not_a_database_code() {
+    let err = sqlite_failure(ffi::SQLITE_NOTADB, None);
+    assert_eq!(err.sqlite_error_code(), Some(ErrorCode::NotADatabase));
+    let mapped = from_rusqlite(err);
+    assert!(matches!(mapped, BackendError::NotADatabase));
+}
+
+#[test]
+fn maps_database_busy_to_locked() {
+    let err = sqlite_failure(ffi::SQLITE_BUSY, None);
+    assert_eq!(err.sqlite_error_code(), Some(ErrorCode::DatabaseBusy));
+    let mapped = from_rusqlite(err);
+    assert!(matches!(mapped, BackendError::Locked));
+}
+
+#[test]
+fn maps_database_locked_to_locked() {
+    let err = sqlite_failure(ffi::SQLITE_LOCKED, None);
+    assert_eq!(err.sqlite_error_code(), Some(ErrorCode::DatabaseLocked));
+    let mapped = from_rusqlite(err);
+    assert!(matches!(mapped, BackendError::Locked));
+}
+
+#[test]
+fn maps_constraint_violation_with_message() {
+    let err = sqlite_failure(ffi::SQLITE_CONSTRAINT, Some("UNIQUE constraint failed"));
+    assert_eq!(
+        err.sqlite_error_code(),
+        Some(ErrorCode::ConstraintViolation)
+    );
+    let mapped = from_rusqlite(err);
+    match mapped {
+        BackendError::Constraint(msg) => assert_eq!(msg, "UNIQUE constraint failed"),
+        other => panic!("expected Constraint, got {other:?}"),
+    }
+}
+
+#[test]
+fn maps_constraint_violation_without_message() {
+    let err = sqlite_failure(ffi::SQLITE_CONSTRAINT, None);
+    let mapped = from_rusqlite(err);
+    match mapped {
+        BackendError::Constraint(msg) => assert!(msg.is_empty()),
+        other => panic!("expected Constraint, got {other:?}"),
+    }
+}
+
+#[test]
+fn maps_io_failure_with_message() {
+    let err = sqlite_failure(ffi::SQLITE_IOERR, Some("disk full"));
+    assert_eq!(err.sqlite_error_code(), Some(ErrorCode::SystemIoFailure));
+    let mapped = from_rusqlite(err);
+    match mapped {
+        BackendError::Io(msg) => assert_eq!(msg, "disk full"),
+        other => panic!("expected Io, got {other:?}"),
+    }
+}
+
+#[test]
+fn unmapped_rusqlite_variant_falls_through_to_other() {
+    let err = rusqlite::Error::QueryReturnedNoRows;
+    let original = err.to_string();
+    let mapped = from_rusqlite(err);
+    match mapped {
+        BackendError::Other(msg) => {
+            assert!(!msg.is_empty(), "Other carried empty message");
+            assert_eq!(msg, original);
+        }
+        other => panic!("expected Other, got {other:?}"),
+    }
+}
+
+#[test]
+fn unmapped_sqlite_failure_code_falls_through_to_other() {
+    let err = sqlite_failure(ffi::SQLITE_FULL, Some("database or disk is full"));
+    let mapped = from_rusqlite(err);
+    match mapped {
+        BackendError::Other(msg) => assert!(!msg.is_empty()),
+        other => panic!("expected Other for SQLITE_FULL, got {other:?}"),
+    }
+}

--- a/tests/clock.rs
+++ b/tests/clock.rs
@@ -1,0 +1,69 @@
+//! Coverage for the `Clock` capability and the streams/TTL surface that
+//! consumes it.
+
+use dynoxide::Database;
+use dynoxide::storage_backend::{Clock, ManualClock, SystemClock};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+#[test]
+fn system_clock_returns_value_close_to_wall_clock() {
+    let clock = SystemClock;
+    let from_clock = clock.now_unix_secs();
+    let from_std = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let delta = from_clock.abs_diff(from_std);
+    assert!(
+        delta <= 1,
+        "SystemClock drifted from wall clock by {delta}s"
+    );
+}
+
+#[test]
+fn manual_clock_returns_pinned_value() {
+    let clock = ManualClock::new(1_700_000_000);
+    assert_eq!(clock.now_unix_secs(), 1_700_000_000);
+    assert!((clock.now_unix_secs_f64() - 1_700_000_000.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn manual_clock_advances_via_tick() {
+    let clock = ManualClock::new(1_700_000_000);
+    clock.tick(Duration::from_secs(5));
+    assert_eq!(clock.now_unix_secs(), 1_700_000_005);
+}
+
+#[test]
+fn manual_clock_set_overrides_value() {
+    let clock = ManualClock::new(0);
+    clock.set(42);
+    assert_eq!(clock.now_unix_secs(), 42);
+}
+
+#[test]
+fn manual_clock_handles_subsecond_ticks() {
+    let clock = ManualClock::new(1_700_000_000);
+    clock.tick(Duration::from_millis(500));
+    let v = clock.now_unix_secs_f64();
+    assert!(
+        (v - 1_700_000_000.5).abs() < 0.001,
+        "expected ~1_700_000_000.5, got {v}"
+    );
+}
+
+#[test]
+fn arc_clock_handles_share_state() {
+    let clock = ManualClock::new(100);
+    let handle: Arc<dyn Clock> = clock.arc();
+    clock.set(200);
+    assert_eq!(handle.now_unix_secs(), 200);
+}
+
+#[test]
+fn database_default_uses_system_clock() {
+    // Smoke test: Database::memory() boots with the SystemClock default.
+    // No assertion on the exact time — just that nothing panics on the path.
+    let _db = Database::memory().expect("Database::memory should succeed");
+}

--- a/tests/storage_backend_native.rs
+++ b/tests/storage_backend_native.rs
@@ -17,8 +17,8 @@
 //! [`StorageBackend`]: dynoxide::storage_backend::StorageBackend
 //! [`Storage`]: dynoxide::storage::Storage
 
-use dynoxide::storage::{CreateTableMetadata, Storage};
-use dynoxide::storage_backend::StorageBackend;
+use dynoxide::storage::{CreateTableMetadata, QueryParams, Storage};
+use dynoxide::storage_backend::{BaseItemRow, GsiItemRow, StorageBackend};
 
 fn make_metadata<'a>(table_name: &'a str, key_schema: &'a str) -> CreateTableMetadata<'a> {
     CreateTableMetadata {
@@ -179,4 +179,122 @@ async fn count_items_matches_inserted_count_via_trait() {
         .await
         .unwrap();
     assert_eq!(count, 5);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn put_base_items_bulk_insert_via_trait() {
+    let storage = Storage::memory().expect("Storage::memory");
+    seed_table(&storage, "bulk").await;
+
+    let rows: Vec<BaseItemRow> = (0..3)
+        .map(|i| {
+            let pk = format!("k{i}");
+            let item_json = format!(r#"{{"pk":{{"S":"{pk}"}}}}"#);
+            BaseItemRow {
+                pk,
+                sk: String::new(),
+                item_size: item_json.len(),
+                item_json,
+                // First row carries a cache timestamp; the rest leave it NULL.
+                cached_at: if i == 0 { Some(123.0) } else { None },
+                hash_prefix: String::new(),
+            }
+        })
+        .collect();
+
+    <Storage as StorageBackend>::put_base_items(&storage, "bulk", &rows)
+        .await
+        .expect("put_base_items via trait");
+
+    // Every row is retrievable.
+    for i in 0..3 {
+        let got = <Storage as StorageBackend>::get_item(&storage, "bulk", &format!("k{i}"), "")
+            .await
+            .unwrap();
+        assert_eq!(
+            got.as_deref(),
+            Some(format!(r#"{{"pk":{{"S":"k{i}"}}}}"#).as_str())
+        );
+    }
+
+    // cached_at is written verbatim: only the row that set it shows up in the
+    // LRU view (which excludes NULL cached_at).
+    let lru = <Storage as StorageBackend>::get_lru_items(&storage, "bulk", 10)
+        .await
+        .unwrap();
+    assert_eq!(lru.len(), 1, "only the row with a cached_at should appear");
+    assert_eq!(lru[0].0, "k0");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn insert_gsi_items_bulk_insert_via_trait() {
+    let storage = Storage::memory().expect("Storage::memory");
+    seed_table(&storage, "orders").await;
+    <Storage as StorageBackend>::create_gsi_table(&storage, "orders", "by-status")
+        .await
+        .expect("create_gsi_table via trait");
+
+    let rows = vec![
+        GsiItemRow {
+            gsi_pk: "shipped".to_string(),
+            gsi_sk: "o1".to_string(),
+            table_pk: "o1".to_string(),
+            table_sk: String::new(),
+            item_json: r#"{"pk":{"S":"o1"},"status":{"S":"shipped"}}"#.to_string(),
+        },
+        GsiItemRow {
+            gsi_pk: "shipped".to_string(),
+            gsi_sk: "o2".to_string(),
+            table_pk: "o2".to_string(),
+            table_sk: String::new(),
+            item_json: r#"{"pk":{"S":"o2"},"status":{"S":"shipped"}}"#.to_string(),
+        },
+    ];
+
+    <Storage as StorageBackend>::insert_gsi_items(&storage, "orders", "by-status", &rows)
+        .await
+        .expect("insert_gsi_items via trait");
+
+    let found = <Storage as StorageBackend>::query_gsi_items(
+        &storage,
+        "orders",
+        "by-status",
+        "shipped",
+        &QueryParams::default(),
+    )
+    .await
+    .expect("query_gsi_items via trait");
+    assert_eq!(
+        found.len(),
+        2,
+        "both bulk-inserted GSI rows should be queryable"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn put_base_items_to_missing_table_is_backend_error() {
+    let storage = Storage::memory().expect("Storage::memory");
+    let rows = vec![BaseItemRow {
+        pk: "x".to_string(),
+        sk: String::new(),
+        item_json: r#"{"pk":{"S":"x"}}"#.to_string(),
+        item_size: 1,
+        cached_at: None,
+        hash_prefix: String::new(),
+    }];
+
+    let err = <Storage as StorageBackend>::put_base_items(&storage, "does-not-exist", &rows)
+        .await
+        .expect_err("bulk insert into a missing table must fail");
+
+    // From<BackendError> for DynoxideError keeps storage faults as 500s.
+    let dyno: dynoxide::DynoxideError = err.into();
+    assert_eq!(dyno.status_code(), 500);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn clock_via_trait_returns_wall_clock() {
+    let storage = Storage::memory().expect("Storage::memory");
+    let now = <Storage as StorageBackend>::clock(&storage).now_unix_secs();
+    assert!(now > 0, "system clock should report a positive epoch");
 }

--- a/tests/storage_backend_native.rs
+++ b/tests/storage_backend_native.rs
@@ -1,0 +1,182 @@
+//! End-to-end coverage that exercises the [`StorageBackend`] trait through
+//! the native [`Storage`] impl.
+//!
+//! Most of dynoxide's tests reach `Storage` via the sync `Database` wrapper.
+//! These tests bypass that wrapper to call trait methods directly with `await`,
+//! confirming the native impl's futures are actually drivable and that the
+//! trait surface produces the same observable state as the sync surface.
+//!
+//! Tests use `#[tokio::test(flavor = "current_thread")]` because `Storage`
+//! holds a `RefCell` and is `!Sync`; a multi-thread runtime would refuse the
+//! futures unless `Storage` were Send and Sync.
+//!
+//! Inherent methods on `Storage` shadow the trait methods of the same name, so
+//! these tests use fully-qualified `<Storage as StorageBackend>::method(...)`
+//! syntax to call through the trait surface explicitly.
+//!
+//! [`StorageBackend`]: dynoxide::storage_backend::StorageBackend
+//! [`Storage`]: dynoxide::storage::Storage
+
+use dynoxide::storage::{CreateTableMetadata, Storage};
+use dynoxide::storage_backend::StorageBackend;
+
+fn make_metadata<'a>(table_name: &'a str, key_schema: &'a str) -> CreateTableMetadata<'a> {
+    CreateTableMetadata {
+        table_name,
+        key_schema,
+        attribute_definitions: r#"[{"AttributeName":"pk","AttributeType":"S"}]"#,
+        gsi_definitions: None,
+        lsi_definitions: None,
+        provisioned_throughput: None,
+        created_at: 0,
+        sse_specification: None,
+        table_class: None,
+        deletion_protection_enabled: false,
+        billing_mode: None,
+    }
+}
+
+async fn seed_table(storage: &Storage, name: &str) {
+    let key_schema = r#"[{"AttributeName":"pk","KeyType":"HASH"}]"#;
+    <Storage as StorageBackend>::insert_table_metadata(storage, &make_metadata(name, key_schema))
+        .await
+        .expect("insert_table_metadata via trait");
+    <Storage as StorageBackend>::create_data_table(storage, name)
+        .await
+        .expect("create_data_table via trait");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn put_and_get_round_trip_via_trait() {
+    let storage = Storage::memory().expect("Storage::memory");
+    seed_table(&storage, "users").await;
+
+    let item = r#"{"pk":{"S":"alice"},"name":{"S":"Alice"}}"#;
+    let prior =
+        <Storage as StorageBackend>::put_item(&storage, "users", "alice", "", item, item.len())
+            .await
+            .expect("put_item via trait");
+    assert!(prior.is_none(), "first put should not return a prior item");
+
+    let fetched = <Storage as StorageBackend>::get_item(&storage, "users", "alice", "")
+        .await
+        .expect("get_item via trait");
+    assert_eq!(fetched.as_deref(), Some(item));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn delete_via_trait_returns_old_value() {
+    let storage = Storage::memory().expect("Storage::memory");
+    seed_table(&storage, "users").await;
+
+    let item = r#"{"pk":{"S":"bob"}}"#;
+    <Storage as StorageBackend>::put_item(&storage, "users", "bob", "", item, item.len())
+        .await
+        .unwrap();
+
+    let removed = <Storage as StorageBackend>::delete_item(&storage, "users", "bob", "")
+        .await
+        .expect("delete_item via trait");
+    assert_eq!(removed.as_deref(), Some(item));
+
+    let after = <Storage as StorageBackend>::get_item(&storage, "users", "bob", "")
+        .await
+        .unwrap();
+    assert!(after.is_none(), "item should be gone after delete");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn transaction_roundtrip_via_trait_commits() {
+    let storage = Storage::memory().expect("Storage::memory");
+    seed_table(&storage, "users").await;
+
+    <Storage as StorageBackend>::begin_transaction(&storage)
+        .await
+        .expect("begin_transaction");
+    let item = r#"{"pk":{"S":"carol"}}"#;
+    <Storage as StorageBackend>::put_item(&storage, "users", "carol", "", item, item.len())
+        .await
+        .unwrap();
+    <Storage as StorageBackend>::commit(&storage)
+        .await
+        .expect("commit");
+
+    let got = <Storage as StorageBackend>::get_item(&storage, "users", "carol", "")
+        .await
+        .unwrap();
+    assert_eq!(got.as_deref(), Some(item));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn transaction_rollback_via_trait_discards_writes() {
+    let storage = Storage::memory().expect("Storage::memory");
+    seed_table(&storage, "users").await;
+
+    <Storage as StorageBackend>::begin_transaction(&storage)
+        .await
+        .expect("begin_transaction");
+    let item = r#"{"pk":{"S":"dave"}}"#;
+    <Storage as StorageBackend>::put_item(&storage, "users", "dave", "", item, item.len())
+        .await
+        .unwrap();
+    <Storage as StorageBackend>::rollback(&storage)
+        .await
+        .expect("rollback");
+
+    let got = <Storage as StorageBackend>::get_item(&storage, "users", "dave", "")
+        .await
+        .unwrap();
+    assert!(
+        got.is_none(),
+        "rolled-back put should leave no item visible"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn metadata_roundtrip_via_trait() {
+    let storage = Storage::memory().expect("Storage::memory");
+    let key_schema = r#"[{"AttributeName":"pk","KeyType":"HASH"}]"#;
+    <Storage as StorageBackend>::insert_table_metadata(
+        &storage,
+        &make_metadata("orders", key_schema),
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        <Storage as StorageBackend>::table_exists(&storage, "orders")
+            .await
+            .unwrap(),
+        "table_exists via trait should reflect metadata insert"
+    );
+
+    let names = <Storage as StorageBackend>::list_table_names(&storage)
+        .await
+        .unwrap();
+    assert!(names.iter().any(|n| n == "orders"));
+
+    let meta = <Storage as StorageBackend>::get_table_metadata(&storage, "orders")
+        .await
+        .unwrap()
+        .expect("metadata should exist after insert");
+    assert_eq!(meta.table_name, "orders");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn count_items_matches_inserted_count_via_trait() {
+    let storage = Storage::memory().expect("Storage::memory");
+    seed_table(&storage, "events").await;
+
+    for i in 0..5 {
+        let pk = format!("evt-{i}");
+        let item = format!(r#"{{"pk":{{"S":"{pk}"}}}}"#);
+        <Storage as StorageBackend>::put_item(&storage, "events", &pk, "", &item, item.len())
+            .await
+            .unwrap();
+    }
+
+    let count = <Storage as StorageBackend>::count_items(&storage, "events")
+        .await
+        .unwrap();
+    assert_eq!(count, 5);
+}

--- a/tests/storage_backend_trait_compile.rs
+++ b/tests/storage_backend_trait_compile.rs
@@ -11,7 +11,7 @@ use dynoxide::storage::{
     CreateTableMetadata, DatabaseInfo, QueryParams, ScanParams, StreamRecord, TableMetadata,
     TableStats,
 };
-use dynoxide::storage_backend::{BackendError, StorageBackend};
+use dynoxide::storage_backend::{BackendError, BaseItemRow, Clock, GsiItemRow, StorageBackend};
 use dynoxide::types::Tag;
 
 /// A type that satisfies [`StorageBackend`] with `unimplemented!()` bodies.
@@ -20,6 +20,27 @@ use dynoxide::types::Tag;
 pub struct TestBackend;
 
 impl StorageBackend for TestBackend {
+    fn clock(&self) -> &dyn Clock {
+        unimplemented!()
+    }
+
+    async fn insert_gsi_items(
+        &self,
+        _table_name: &str,
+        _index_name: &str,
+        _rows: &[GsiItemRow],
+    ) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+
+    async fn put_base_items(
+        &self,
+        _table_name: &str,
+        _rows: &[BaseItemRow],
+    ) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+
     async fn insert_table_metadata(
         &self,
         _m: &CreateTableMetadata<'_>,

--- a/tests/storage_backend_trait_compile.rs
+++ b/tests/storage_backend_trait_compile.rs
@@ -1,0 +1,440 @@
+//! Compile-only sanity check for the [`StorageBackend`] trait.
+//!
+//! This test does not exercise behaviour; it confirms the trait can be
+//! satisfied natively by a hand-rolled stub, catching signature drift between
+//! the trait and any future impls. A companion `wasm32-unknown-unknown`
+//! `cargo check` job is the cross-platform sibling.
+//!
+//! [`StorageBackend`]: dynoxide::storage_backend::StorageBackend
+
+use dynoxide::storage::{
+    CreateTableMetadata, DatabaseInfo, QueryParams, ScanParams, StreamRecord, TableMetadata,
+    TableStats,
+};
+use dynoxide::storage_backend::{BackendError, StorageBackend};
+use dynoxide::types::Tag;
+
+/// A type that satisfies [`StorageBackend`] with `unimplemented!()` bodies.
+///
+/// Catches missing methods, signature drift, and basic type-fit issues.
+pub struct TestBackend;
+
+impl StorageBackend for TestBackend {
+    async fn insert_table_metadata(
+        &self,
+        _m: &CreateTableMetadata<'_>,
+    ) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+
+    async fn get_table_metadata(
+        &self,
+        _table_name: &str,
+    ) -> Result<Option<TableMetadata>, BackendError> {
+        unimplemented!()
+    }
+
+    async fn delete_table_metadata(&self, _table_name: &str) -> Result<bool, BackendError> {
+        unimplemented!()
+    }
+
+    async fn update_table_metadata(
+        &self,
+        _table_name: &str,
+        _attribute_definitions: &str,
+        _gsi_definitions: Option<&str>,
+    ) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+
+    async fn update_provisioned_throughput(
+        &self,
+        _table_name: &str,
+        _provisioned_throughput: &str,
+    ) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+
+    async fn clear_provisioned_throughput(&self, _table_name: &str) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+
+    async fn update_billing_mode(
+        &self,
+        _table_name: &str,
+        _billing_mode: &str,
+    ) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+
+    async fn get_tags(&self, _table_name: &str) -> Result<Vec<Tag>, BackendError> {
+        unimplemented!()
+    }
+
+    async fn set_tags(&self, _table_name: &str, _new_tags: &[Tag]) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+
+    async fn update_deletion_protection(
+        &self,
+        _table_name: &str,
+        _enabled: bool,
+    ) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+
+    async fn remove_tags(&self, _table_name: &str, _keys: &[String]) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+
+    async fn list_table_names(&self) -> Result<Vec<String>, BackendError> {
+        unimplemented!()
+    }
+
+    async fn table_exists(&self, _table_name: &str) -> Result<bool, BackendError> {
+        unimplemented!()
+    }
+
+    async fn create_data_table(&self, _table_name: &str) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+
+    async fn drop_data_table(&self, _table_name: &str) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+
+    async fn create_gsi_table(
+        &self,
+        _table_name: &str,
+        _index_name: &str,
+    ) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+
+    async fn drop_gsi_table(
+        &self,
+        _table_name: &str,
+        _index_name: &str,
+    ) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+
+    async fn create_lsi_table(
+        &self,
+        _table_name: &str,
+        _index_name: &str,
+    ) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+
+    async fn drop_lsi_table(
+        &self,
+        _table_name: &str,
+        _index_name: &str,
+    ) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+
+    async fn insert_gsi_item(
+        &self,
+        _table_name: &str,
+        _index_name: &str,
+        _gsi_pk: &str,
+        _gsi_sk: &str,
+        _table_pk: &str,
+        _table_sk: &str,
+        _item_json: &str,
+    ) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+
+    async fn delete_gsi_item(
+        &self,
+        _table_name: &str,
+        _index_name: &str,
+        _table_pk: &str,
+        _table_sk: &str,
+    ) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+
+    async fn query_gsi_items(
+        &self,
+        _table_name: &str,
+        _index_name: &str,
+        _gsi_pk: &str,
+        _params: &QueryParams<'_>,
+    ) -> Result<Vec<(String, String, String)>, BackendError> {
+        unimplemented!()
+    }
+
+    async fn scan_gsi_items(
+        &self,
+        _table_name: &str,
+        _index_name: &str,
+        _params: &ScanParams<'_>,
+    ) -> Result<Vec<(String, String, String)>, BackendError> {
+        unimplemented!()
+    }
+
+    async fn insert_lsi_item(
+        &self,
+        _table_name: &str,
+        _index_name: &str,
+        _pk: &str,
+        _sk: &str,
+        _base_pk: &str,
+        _base_sk: &str,
+        _item_json: &str,
+    ) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+
+    async fn delete_lsi_item(
+        &self,
+        _table_name: &str,
+        _index_name: &str,
+        _base_pk: &str,
+        _base_sk: &str,
+    ) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+
+    async fn query_lsi_items(
+        &self,
+        _table_name: &str,
+        _index_name: &str,
+        _pk: &str,
+        _params: &QueryParams<'_>,
+    ) -> Result<Vec<(String, String, String)>, BackendError> {
+        unimplemented!()
+    }
+
+    async fn scan_lsi_items(
+        &self,
+        _table_name: &str,
+        _index_name: &str,
+        _params: &ScanParams<'_>,
+    ) -> Result<Vec<(String, String, String)>, BackendError> {
+        unimplemented!()
+    }
+
+    async fn begin_transaction(&self) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+    async fn commit(&self) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+    async fn rollback(&self) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+
+    async fn enable_bulk_loading(&self) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+    async fn disable_bulk_loading(&self) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+
+    async fn put_item(
+        &self,
+        _table_name: &str,
+        _pk: &str,
+        _sk: &str,
+        _item_json: &str,
+        _item_size: usize,
+    ) -> Result<Option<String>, BackendError> {
+        unimplemented!()
+    }
+
+    async fn put_item_with_hash(
+        &self,
+        _table_name: &str,
+        _pk: &str,
+        _sk: &str,
+        _item_json: &str,
+        _item_size: usize,
+        _hash_prefix: &str,
+    ) -> Result<Option<String>, BackendError> {
+        unimplemented!()
+    }
+
+    async fn get_item(
+        &self,
+        _table_name: &str,
+        _pk: &str,
+        _sk: &str,
+    ) -> Result<Option<String>, BackendError> {
+        unimplemented!()
+    }
+
+    async fn get_partition_size(&self, _table_name: &str, _pk: &str) -> Result<i64, BackendError> {
+        unimplemented!()
+    }
+
+    async fn get_lsi_partition_size(
+        &self,
+        _table_name: &str,
+        _index_name: &str,
+        _pk: &str,
+    ) -> Result<i64, BackendError> {
+        unimplemented!()
+    }
+
+    async fn delete_item(
+        &self,
+        _table_name: &str,
+        _pk: &str,
+        _sk: &str,
+    ) -> Result<Option<String>, BackendError> {
+        unimplemented!()
+    }
+
+    async fn query_items(
+        &self,
+        _table_name: &str,
+        _pk: &str,
+        _params: &QueryParams<'_>,
+    ) -> Result<Vec<(String, String, String)>, BackendError> {
+        unimplemented!()
+    }
+
+    async fn scan_items(
+        &self,
+        _table_name: &str,
+        _params: &ScanParams<'_>,
+    ) -> Result<Vec<(String, String, String)>, BackendError> {
+        unimplemented!()
+    }
+
+    async fn count_items(&self, _table_name: &str) -> Result<i64, BackendError> {
+        unimplemented!()
+    }
+
+    async fn db_size_bytes(&self) -> Result<u64, BackendError> {
+        unimplemented!()
+    }
+
+    async fn table_count(&self) -> Result<usize, BackendError> {
+        unimplemented!()
+    }
+
+    async fn table_stats(&self) -> Result<Vec<TableStats>, BackendError> {
+        unimplemented!()
+    }
+
+    async fn database_info(&self) -> Result<DatabaseInfo, BackendError> {
+        unimplemented!()
+    }
+
+    async fn vacuum(&self) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+
+    async fn enable_stream(
+        &self,
+        _table_name: &str,
+        _view_type: &str,
+        _label: &str,
+    ) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+
+    async fn disable_stream(&self, _table_name: &str) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+
+    async fn insert_stream_record(
+        &self,
+        _table_name: &str,
+        _event_name: &str,
+        _keys_json: &str,
+        _new_image: Option<&str>,
+        _old_image: Option<&str>,
+        _sequence_number: &str,
+        _shard_id: &str,
+        _created_at: i64,
+    ) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+
+    async fn insert_stream_record_with_identity(
+        &self,
+        _table_name: &str,
+        _event_name: &str,
+        _keys_json: &str,
+        _new_image: Option<&str>,
+        _old_image: Option<&str>,
+        _sequence_number: &str,
+        _shard_id: &str,
+        _created_at: i64,
+        _user_identity: Option<&str>,
+    ) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+
+    async fn next_stream_sequence_number(&self, _table_name: &str) -> Result<i64, BackendError> {
+        unimplemented!()
+    }
+
+    async fn get_stream_records(
+        &self,
+        _table_name: &str,
+        _shard_id: &str,
+        _after_sequence: i64,
+        _limit: usize,
+    ) -> Result<Vec<StreamRecord>, BackendError> {
+        unimplemented!()
+    }
+
+    async fn list_stream_enabled_tables(&self) -> Result<Vec<TableMetadata>, BackendError> {
+        unimplemented!()
+    }
+
+    async fn update_ttl_config(
+        &self,
+        _table_name: &str,
+        _attribute_name: Option<&str>,
+        _enabled: bool,
+    ) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+
+    async fn list_ttl_enabled_tables(&self) -> Result<Vec<TableMetadata>, BackendError> {
+        unimplemented!()
+    }
+
+    async fn get_shard_sequence_range(
+        &self,
+        _table_name: &str,
+        _shard_id: &str,
+    ) -> Result<(Option<String>, Option<String>), BackendError> {
+        unimplemented!()
+    }
+
+    async fn touch_cached_at(
+        &self,
+        _table_name: &str,
+        _pk: &str,
+        _sk: &str,
+        _timestamp: f64,
+    ) -> Result<(), BackendError> {
+        unimplemented!()
+    }
+
+    async fn get_lru_items(
+        &self,
+        _table_name: &str,
+        _limit: usize,
+    ) -> Result<Vec<(String, String, i64)>, BackendError> {
+        unimplemented!()
+    }
+}
+
+#[test]
+fn trait_is_satisfiable_natively() {
+    // No assertion: the test passes by the file compiling. If a method's
+    // signature drifts between the trait and TestBackend, this test fails to
+    // compile and the regression is caught.
+    let _backend = TestBackend;
+}

--- a/tests/tag_operations.rs
+++ b/tests/tag_operations.rs
@@ -1,4 +1,5 @@
 use dynoxide::Database;
+use dynoxide::DynoxideError;
 use dynoxide::actions::create_table::CreateTableRequest;
 use dynoxide::actions::list_tags_of_resource::ListTagsOfResourceRequest;
 use dynoxide::actions::tag_resource::TagResourceRequest;
@@ -188,6 +189,11 @@ fn test_tag_resource_max_50() {
         })
         .unwrap_err();
     assert!(err.to_string().contains("tag limit is 50"));
+    // The tag-limit breach is a client-facing ValidationException (HTTP 400),
+    // not a 500. set_tags raises it inside the backend, so it must survive the
+    // StorageBackend trait boundary rather than collapsing to InternalServerError.
+    assert_eq!(err.status_code(), 400);
+    assert!(matches!(err, DynoxideError::ValidationException(_)));
 }
 
 #[test]


### PR DESCRIPTION
## What this changes

The `StorageBackend` trait landed in late April but nothing consumed it - the engine still ran against `Storage`'s inherent sync methods directly. This wires it up for real, and makes `Database` generic over the backend so a non-native one can slot in later. Native-only, behaviour-preserving bar one deliberate, more-correct change (index fan-out atomicity).

- The action handlers are now `async` and go through the trait. The last two raw `Storage::conn()` escape hatches - the bulk insert in import and the GSI backfill in `UpdateTable` - are gone, replaced by batch-shaped typed trait methods (`put_base_items`, `insert_gsi_items`).
- `Database` is now `Database<S = RusqliteBackend>`: monomorphic, no `dyn`. The default parameter means existing `Database` / `Database::memory()` code is untouched, and a `NativeDatabase` alias names that default. The synchronous public API is preserved by a `block_on` facade (via `pollster`); because the native backend's futures never suspend, that `block_on` never parks a thread, so it stays safe inside the tokio-based HTTP and MCP servers.
- A single-item write (`PutItem`, `DeleteItem`, `UpdateItem`) and its GSI/LSI index fan-out now commit or roll back as one transaction, so a failure partway through the fan-out can no longer leave a base row with a half-applied (torn) index. The same per-item atomicity extends to `BatchWriteItem` and the TTL sweep.
- Every write path shares one transaction helper that rolls back on a failed commit and surfaces a failed rollback, rather than leaving the connection stuck mid-transaction (which would break the next write).
- `BackendError` and `DynoxideError` are now `#[non_exhaustive]`, so adding variants later is not itself a breaking change. Done now while 0.10.0 is already breaking, so it is free.

The trait commits sit at the base of the branch (late April) with the consumption on top, so the history reads in the order the work happened.

Conformance: **643/655** against [dynamodb-conformance](https://github.com/nubo-db/dynamodb-conformance), up from 630/655 at 0.9.13, with no regressions from this branch (the gains come from the validation fixes already on `main`; the async and atomicity work is conformance-neutral).

## Checklist

- [x] Tests added or updated
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` pass locally
- [x] `CHANGELOG.md` updated if this is a user-visible change
- [ ] If AI tools drafted or materially shaped this change, disclosed in the description above
- [x] Linked issue, discussion, or a short note explaining the motivation

## DynamoDB compatibility note

The one behavioural change is more compatible, not less: a single-item write and its index fan-out are now atomic, matching DynamoDB, where a write does not half-apply to its indexes. Everything else is observable-behaviour-identical (the conformance suite confirms it).

Breaking changes, which is why this is the 0.10.0 minor bump (pre-1.0, so a minor bump is the SemVer signal for a break):

- `Database` gains a defaulted generic parameter. Source-compatible for normal `Database` / `Database::memory()` usage; only exotic cases (turbofish, `impl Trait for Database`) would need a tweak.
- `DynoxideError` and `BackendError` are now `#[non_exhaustive]`. Downstream `match` arms over either must include a wildcard.
