### PR TITLE
fix: paginate GSI scan over a hash-only base table with tied index keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Paginating a `Scan` over a GSI no longer drops items when several entries share the same index key and the base table has only a partition key. On a hash-only base table the continuation cursor lost its base-key component and stalled after the first page; it now carries the base partition key, so every tied item is returned across the paged walk ([#38](https://github.com/nubo-db/dynoxide/issues/38)).
 - A single-item write (`PutItem`, `DeleteItem`, `UpdateItem`) and its GSI/LSI index fan-out now run in a single transaction. A failure partway through the fan-out rolls the whole write back rather than leaving a base row with a half-applied (torn) index. The same per-item atomicity now also covers `BatchWriteItem` (each write request) and the TTL sweep (each expired-item delete). This matches DynamoDB, where a single-item write does not half-apply to its indexes.
 - Write paths now roll back on a failed `COMMIT` and surface a failed `ROLLBACK` rather than leaving the connection stuck mid-transaction, which would make the next write fail. Every write path shares one transaction helper for this.
 - A client-facing `ValidationException` raised inside a backend method (the 50-tag limit in `set_tags`) keeps its 400 status across the `StorageBackend` boundary instead of collapsing to a 500.

--- a/src/actions/scan.rs
+++ b/src/actions/scan.rs
@@ -459,11 +459,18 @@ pub async fn execute<S: StorageBackend>(
             let base_pk = esk
                 .get(&table_key_schema.partition_key)
                 .and_then(|v| v.to_key_string());
-            let base_sk = table_key_schema
-                .sort_key
-                .as_ref()
-                .and_then(|sk_name| esk.get(sk_name))
-                .and_then(|v| v.to_key_string());
+            // When the base table is hash-only there is no base sort key, but
+            // the GSI/LSI row stores the empty-string default in its table_sk
+            // column. Default base_sk to "" (mirroring start_sk above) so the
+            // composite cursor keeps its full width and disambiguates tied
+            // index keys by table_pk. Leaving it None collapses scan_gsi_items
+            // to the 2-column (gsi_pk, gsi_sk) cursor, which cannot advance past
+            // rows that share the same index key and silently drops them.
+            let base_sk = if let Some(sk_name) = table_key_schema.sort_key.as_ref() {
+                esk.get(sk_name).and_then(|v| v.to_key_string())
+            } else {
+                Some(String::new())
+            };
             (base_pk, base_sk)
         } else {
             (None, None)

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1335,7 +1335,13 @@ impl Storage {
             sql.push_str(&where_clauses.join(" AND "));
         }
 
-        sql.push_str(" ORDER BY pk ASC, sk ASC");
+        // Order by the full composite key so the scan order matches the
+        // `(pk, sk, base_pk, base_sk)` pagination cursor above. Without the
+        // base-key columns here, rows tied on (pk, sk) would only be ordered
+        // deterministically by the primary-key b-tree as an implementation
+        // accident; making it explicit mirrors `scan_gsi_items` and keeps the
+        // cursor/order invariant from depending on the query planner.
+        sql.push_str(" ORDER BY pk ASC, sk ASC, base_pk ASC, base_sk ASC");
 
         if let Some(lim) = params.limit {
             sql.push_str(&format!(" LIMIT {lim}"));

--- a/tests/gsi.rs
+++ b/tests/gsi.rs
@@ -2,6 +2,7 @@
 
 use dynoxide::Database;
 use dynoxide::types::AttributeValue;
+use std::collections::HashMap;
 
 /// Helper: create a table with a GSI.
 /// Table: pk=UserId(S), sk=Timestamp(S)
@@ -827,5 +828,96 @@ fn test_gsi_scan_pagination_with_filter() {
         20,
         "expected 20 special items out of 100, got {}",
         all_items.len()
+    );
+}
+
+/// Regression (#38): paginating a Scan over a GSI whose items share the same
+/// index partition + sort key must visit every tied item exactly once. This
+/// uses a **hash-only base table**, which is the case that actually breaks:
+/// with no base sort key, the GSI rows carry the empty-string default in their
+/// table_sk column, so the cursor must still disambiguate tied index keys by
+/// the base partition key. The earlier defect collapsed the cursor to
+/// `(gsi_pk, gsi_sk)` and stopped after the first page.
+#[test]
+fn test_scan_gsi_pagination_visits_all_tied_sort_keys() {
+    let db = Database::memory().unwrap();
+
+    // Hash-only base table (ID); GSI TieIndex (GType hash, GSort range).
+    let create_req = serde_json::json!({
+        "TableName": "TieScan",
+        "KeySchema": [{"AttributeName": "ID", "KeyType": "HASH"}],
+        "AttributeDefinitions": [
+            {"AttributeName": "ID", "AttributeType": "S"},
+            {"AttributeName": "GType", "AttributeType": "S"},
+            {"AttributeName": "GSort", "AttributeType": "S"}
+        ],
+        "GlobalSecondaryIndexes": [{
+            "IndexName": "TieIndex",
+            "KeySchema": [
+                {"AttributeName": "GType", "KeyType": "HASH"},
+                {"AttributeName": "GSort", "KeyType": "RANGE"}
+            ],
+            "Projection": {"ProjectionType": "ALL"}
+        }],
+        "BillingMode": "PAY_PER_REQUEST"
+    });
+    db.create_table(serde_json::from_value(create_req).unwrap())
+        .unwrap();
+
+    // All five items share the GSI key (GType="tie", GSort="same") and differ
+    // only by the base partition key (ID).
+    let ids = ["id-0", "id-1", "id-2", "id-3", "id-4"];
+    for id in ids {
+        let put = serde_json::json!({
+            "TableName": "TieScan",
+            "Item": {
+                "ID": {"S": id},
+                "GType": {"S": "tie"},
+                "GSort": {"S": "same"}
+            }
+        });
+        db.put_item(serde_json::from_value(put).unwrap()).unwrap();
+    }
+
+    // Page through the GSI one item at a time, following LastEvaluatedKey.
+    let mut seen: Vec<String> = Vec::new();
+    let mut exclusive_start_key: Option<HashMap<String, AttributeValue>> = None;
+    let mut pages = 0;
+    loop {
+        pages += 1;
+        assert!(
+            pages <= ids.len() + 1,
+            "paged GSI scan did not terminate (looping or stalling on tied keys)"
+        );
+
+        let mut req = serde_json::json!({
+            "TableName": "TieScan",
+            "IndexName": "TieIndex",
+            "Limit": 1
+        });
+        if let Some(ref lek) = exclusive_start_key {
+            req["ExclusiveStartKey"] = serde_json::to_value(lek).unwrap();
+        }
+        let resp = db.scan(serde_json::from_value(req).unwrap()).unwrap();
+
+        if let Some(items) = resp.items {
+            for item in items {
+                if let Some(AttributeValue::S(id)) = item.get("ID") {
+                    seen.push(id.clone());
+                }
+            }
+        }
+
+        match resp.last_evaluated_key {
+            Some(lek) => exclusive_start_key = Some(lek),
+            None => break,
+        }
+    }
+
+    seen.sort();
+    assert_eq!(
+        seen,
+        vec!["id-0", "id-1", "id-2", "id-3", "id-4"],
+        "every tied GSI item should be visited exactly once across the paged scan"
     );
 }

--- a/tests/lsi.rs
+++ b/tests/lsi.rs
@@ -2,6 +2,7 @@
 
 use dynoxide::Database;
 use dynoxide::types::AttributeValue;
+use std::collections::HashMap;
 
 /// Helper: create a table with an LSI.
 /// Table: pk=UserId(S), sk=Timestamp(S)
@@ -609,5 +610,68 @@ fn test_put_item_overwrite_changes_lsi_sk() {
     assert_eq!(
         items[0].get("Status"),
         Some(&AttributeValue::S("B".to_string()))
+    );
+}
+
+/// Regression (#38): paginating a Scan over an LSI whose items share the same
+/// index sort-key value must visit every tied item exactly once. The LSI scan
+/// cursor is `(pk, sk, base_pk, base_sk)`; if the storage ORDER BY omits the
+/// base-table columns, rows tied on `(pk, sk)` come back in an order that
+/// disagrees with the cursor tuple and the paged walk silently drops items.
+#[test]
+fn test_scan_lsi_pagination_visits_all_tied_sort_keys() {
+    let db = Database::memory().unwrap();
+    create_table_with_lsi(&db);
+
+    // All five orders share UserId + Status, so they tie on the LSI key
+    // (UserId, Status) and differ only by the base sort key (Timestamp). Insert
+    // in an order whose rowid sequence disagrees with Timestamp order, so a
+    // missing ORDER BY on the base key surfaces as dropped pages rather than
+    // being masked by an accidental rowid/sort-key agreement.
+    let timestamps = ["03", "01", "04", "00", "02"];
+    for ts in timestamps {
+        put_order(&db, "user1", ts, "OPEN", "100");
+    }
+
+    // Page through the LSI one item at a time, following LastEvaluatedKey.
+    let mut seen: Vec<String> = Vec::new();
+    let mut exclusive_start_key: Option<HashMap<String, AttributeValue>> = None;
+    let mut pages = 0;
+    loop {
+        pages += 1;
+        assert!(
+            pages <= timestamps.len() + 1,
+            "paged LSI scan did not terminate (looping on tied sort keys)"
+        );
+
+        let mut req = serde_json::json!({
+            "TableName": "Orders",
+            "IndexName": "StatusIndex",
+            "Limit": 1
+        });
+        if let Some(ref lek) = exclusive_start_key {
+            req["ExclusiveStartKey"] = serde_json::to_value(lek).unwrap();
+        }
+        let resp = db.scan(serde_json::from_value(req).unwrap()).unwrap();
+
+        if let Some(items) = resp.items {
+            for item in items {
+                if let Some(AttributeValue::S(ts)) = item.get("Timestamp") {
+                    seen.push(ts.clone());
+                }
+            }
+        }
+
+        match resp.last_evaluated_key {
+            Some(lek) => exclusive_start_key = Some(lek),
+            None => break,
+        }
+    }
+
+    seen.sort();
+    assert_eq!(
+        seen,
+        vec!["00", "01", "02", "03", "04"],
+        "every tied LSI item should be visited exactly once across the paged scan"
     );
 }


### PR DESCRIPTION
## What this changes

Fixes a data-loss bug in `Scan` pagination over a GSI. When several items share the same index key and the base table has only a partition key (no sort key), a paged scan returned the first item and then stopped. On a hash-only base table the continuation cursor lost its base-key component, so `scan_gsi_items` fell back to a two-column `(gsi_pk, gsi_sk)` cursor that cannot advance past rows sharing the same index key. The cursor now keeps the base partition key, so the walk visits every tied item. `scan_lsi_items` also gets its `ORDER BY` aligned to its composite cursor, so its correctness no longer leans on the planner reaching for the primary-key b-tree.

Closes #38.

## Checklist

- [x] Tests added or updated
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` pass locally
- [x] `CHANGELOG.md` updated if this is a user-visible change
- [x] Linked issue, discussion, or a short note explaining the motivation

- ~~If AI tools drafted or materially shaped this change, disclosed in the description above~~ (N/A)

## DynamoDB compatibility note

This moves Dynoxide towards AWS behaviour, not away from it: real DynamoDB returns every item across a paged index scan, including entries tied on the index key. Verified against the conformance suite (`tests/tier1/scan/`, 44 tests including the GSI and LSI pagination cases, where the GSI case failed before this change), which records the AWS-observed behaviour as ground truth.
