### PR TITLE
fix: accept {"NULL": false} and read it back as {"NULL": true}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The wasm engine gained an operation-level `execute` API, and a new npm package, `@nubo-db/dynoxide-engine`, that ships it. The Worker answers a small versioned RPC - `open`, `execute`, `capabilities`, `contractVersion` - with `{id, op, payload}` in and `{id, ok, result|error}` out, and a bundled `EngineClient` owns the round trip so you deal in objects instead of hand-building postMessage envelopes. `npm run build:wasm` assembles the package: the Worker, the two `.wasm`, the `EngineClient`, and a `manifest.json` stamped with the engine and contract versions. Depend on that built package, not this repo's source. The client checks its `CONTRACT_VERSION` against the engine on boot and fails loudly if they differ, so a stale embed can't quietly mis-read a newer one. Still a preview: the wasm path isn't run against the conformance suite.
 
+### Fixed
+
+- `PutItem` and the other write paths now accept a `{"NULL": false}` attribute value and read it back as `{"NULL": true}`, where before they rejected it with `One or more parameter values were invalid: Null attribute value types must have the value of true`. The NULL member is typed as a plain boolean in the model, so `false` was valid input all along; AWS has dropped the server-side true-only rule and normalises `false` to `true` on read, and dynoxide now matches. A non-boolean NULL such as `{"NULL": "no"}` is still rejected as a type error ([#62](https://github.com/nubo-db/dynoxide/issues/62)).
+
 ## [0.10.0] - 2026-05-29
 
 ### Added

--- a/src/types.rs
+++ b/src/types.rs
@@ -268,10 +268,17 @@ impl<'de> Deserialize<'de> for AttributeValue {
                 Ok(AttributeValue::BOOL(b))
             }
             "NULL" => {
-                // DynamoDB treats non-boolean NULL values (e.g. {"NULL": "no"}) as
-                // NULL(false) and rejects them during validation, not serialisation.
-                let n = val.as_bool().unwrap_or(false);
-                Ok(AttributeValue::NULL(n))
+                // The NULL member is a plain boolean in the model. AWS accepts both
+                // {"NULL": true} and {"NULL": false} and reads either back as
+                // {"NULL": true}, so normalise false to true here. A non-boolean
+                // value (e.g. {"NULL": "no"}) is a type error.
+                if val.as_bool().is_none() {
+                    return Err(de::Error::custom(
+                        "VALIDATION:One or more parameter values were invalid: \
+                         Null attribute value types must have the value of true",
+                    ));
+                }
+                Ok(AttributeValue::NULL(true))
             }
             "SS" => {
                 let arr = val
@@ -1370,6 +1377,31 @@ mod tests {
         let val = AttributeValue::NULL(true);
         let json = serde_json::to_string(&val).unwrap();
         assert_eq!(json, r#"{"NULL":true}"#);
+    }
+
+    #[test]
+    fn test_deserialize_null_true() {
+        let val: AttributeValue = serde_json::from_str(r#"{"NULL":true}"#).unwrap();
+        assert_eq!(val, AttributeValue::NULL(true));
+    }
+
+    #[test]
+    fn test_deserialize_null_false_normalises_to_true() {
+        // The NULL member is a plain boolean in the model, so {"NULL": false} is
+        // valid input. AWS accepts it and reads it back as {"NULL": true}, so
+        // normalise false to true on the way in.
+        let val: AttributeValue = serde_json::from_str(r#"{"NULL":false}"#).unwrap();
+        assert_eq!(val, AttributeValue::NULL(true));
+    }
+
+    #[test]
+    fn test_deserialize_null_non_boolean_rejected() {
+        // A non-boolean NULL (e.g. {"NULL": "no"}) is a type error, not a value.
+        let err = serde_json::from_str::<AttributeValue>(r#"{"NULL":"no"}"#).unwrap_err();
+        assert!(
+            err.to_string().contains("must have the value of true"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -341,11 +341,6 @@ fn validate_attribute_value(value: &AttributeValue, depth: usize) -> Result<()> 
         ));
     }
     match value {
-        AttributeValue::NULL(b) if !b => Err(DynoxideError::ValidationException(
-            "One or more parameter values were invalid: \
-             Null attribute value types must have the value of true"
-                .to_string(),
-        )),
         AttributeValue::SS(set) if set.is_empty() => Err(DynoxideError::ValidationException(
             "One or more parameter values were invalid: An string set  may not be empty"
                 .to_string(),
@@ -429,7 +424,6 @@ fn validate_attribute_value(value: &AttributeValue, depth: usize) -> Result<()> 
 /// This validates the attribute values in a Key map for:
 /// - Invalid/empty numbers
 /// - Empty sets, duplicate sets
-/// - NULL attribute with non-true value
 /// - Multiple datatypes
 ///
 /// These errors are returned with "One or more parameter values were invalid: " prefix.
@@ -442,13 +436,6 @@ pub fn validate_key_attribute_values(key: &Item) -> Result<()> {
 
 fn validate_key_attr_value(value: &AttributeValue) -> Result<()> {
     match value {
-        AttributeValue::NULL(b) if !b => {
-            return Err(DynoxideError::ValidationException(
-                "One or more parameter values were invalid: \
-                 Null attribute value types must have the value of true"
-                    .to_string(),
-            ));
-        }
         AttributeValue::SS(set) if set.is_empty() => {
             return Err(DynoxideError::ValidationException(
                 "One or more parameter values were invalid: An string set  may not be empty"

--- a/tests/item_operations.rs
+++ b/tests/item_operations.rs
@@ -471,3 +471,35 @@ fn test_put_item_from_json() {
     let item = resp.item.unwrap();
     assert_eq!(item["data"], AttributeValue::N("42".into()));
 }
+
+#[test]
+fn test_put_item_accepts_null_false() {
+    // AWS accepts {"NULL": false} on PutItem and reads it back as
+    // {"NULL": true}. Regression guard for that round-trip.
+    let db = make_db();
+    create_hash_only_table(&db, "Items");
+
+    let json = r#"{
+        "TableName": "Items",
+        "Item": {
+            "pk": {"S": "null-false"},
+            "flag": {"NULL": false}
+        }
+    }"#;
+
+    let request: PutItemRequest = serde_json::from_str(json).unwrap();
+    db.put_item(request).unwrap();
+
+    let resp = db
+        .get_item(GetItemRequest {
+            table_name: "Items".to_string(),
+            key: key_map(&[("pk", AttributeValue::S("null-false".into()))]),
+            consistent_read: None,
+            projection_expression: None,
+            ..Default::default()
+        })
+        .unwrap();
+
+    let item = resp.item.unwrap();
+    assert_eq!(item["flag"], AttributeValue::NULL(true));
+}


### PR DESCRIPTION
## What this changes

`PutItem` and the other write paths now accept a `{"NULL": false}` attribute value and read it back as `{"NULL": true}`, instead of rejecting it with `One or more parameter values were invalid: Null attribute value types must have the value of true`.

The NULL member is typed as a plain boolean in the model - the JS SDK and botocore both have `NULL: boolean` with no true-only constraint - so `false` was valid input all along. The old rejection was a server-side rule sitting on top of the model, and AWS has dropped it: `false` is accepted and normalised to `true` on read. dynoxide now matches.

Under the hood, `false` is normalised to `true` at the deserialisation boundary, which brings the serde parser into line with the import and PartiQL parsers - both already produce `NULL(true)` unconditionally. The two validation arms that rejected `NULL(false)` are gone. A genuinely non-boolean NULL such as `{"NULL": "no"}` is still rejected as a type error, with the same message as before.

## Checklist

- [x] Tests added or updated
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` pass locally
- [x] `CHANGELOG.md` updated if this is a user-visible change
- [x] Linked issue, discussion, or a short note explaining the motivation

## DynamoDB compatibility note

This brings dynoxide back in line with AWS. AWS now accepts `{"NULL": false}` on writes and hands back `{"NULL": true}` on read, having dropped the older server-side rule that rejected any NULL whose value was not `true`. The change is backed by the model, where the NULL member is a plain boolean, so it isn't expected to swing back.

Refs #62, which also tracks two validation-ordering differences left for later. Those are deliberately out of scope here - the conformance capture found them split across regions, so they may yet settle either way.
