### PR TITLE
chore: bump indicatif and add a cargo-deny supply-chain gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,16 @@ jobs:
       - name: Format
         run: cargo fmt --check
 
+  cargo-deny:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check
+
   feature-guards:
     name: Feature guard checks
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,15 +743,14 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1722,14 +1721,14 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console",
- "number_prefix",
  "portable-atomic",
  "unicode-width",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -1968,12 +1967,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
@@ -3307,6 +3300,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3604,15 +3603,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ toml = { version = "0.8", optional = true }
 fake = { version = "3", features = ["derive"], optional = true }
 sha2 = { version = "0.10", optional = true }
 flate2 = { version = "1", optional = true }
-indicatif = { version = "0.17", optional = true }
+indicatif = { version = "0.18", optional = true }
 zstd = { version = "0.13", optional = true }
 tempfile = { version = "3", optional = true }
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,56 @@
+# cargo-deny configuration. Run with `cargo deny check`.
+# https://embarkstudios.github.io/cargo-deny/
+
+[advisories]
+# Advisories are denied by default. Each ignore below is a dev-dependency-only
+# finding, pinned by the AWS SDK's legacy default TLS stack (hyper 0.14 +
+# rustls 0.21 + rustls-webpki 0.101), which `aws-config` / `aws-sdk-dynamodb`
+# pull in transitively for the integration and conformance tests. None of these
+# crates are compiled into the published crate or the installed binary
+# (confirmed with `cargo tree -e no-dev`). There is no fix by version bump: the
+# latest AWS SDK 1.x still ships this stack by default. The proper fix is to
+# migrate the AWS dev-deps to the modern `default-https-client` (hyper 1.x +
+# rustls 0.23 + aws-lc) under a 2025+ BehaviorVersion. Revisit and remove these
+# entries when that migration lands.
+ignore = [
+    { id = "RUSTSEC-2026-0098", reason = "rustls-webpki 0.101: URI name constraints incorrectly accepted. Dev-only via the AWS SDK legacy default TLS; not in the published crate or binary. Revisit on the AWS default-https-client / rustls 0.23 migration." },
+    { id = "RUSTSEC-2026-0099", reason = "rustls-webpki 0.101: wildcard name constraints accepted. Dev-only via the AWS SDK legacy default TLS; not in the published crate or binary. Revisit on the AWS default-https-client / rustls 0.23 migration." },
+    { id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.101: reachable panic in CRL parsing. Dev-only via the AWS SDK legacy default TLS; not in the published crate or binary. Revisit on the AWS default-https-client / rustls 0.23 migration." },
+    { id = "RUSTSEC-2026-0009", reason = "rustls-webpki 0.101: denial of service via stack exhaustion. Dev-only via the AWS SDK legacy default TLS; not in the published crate or binary. Revisit on the AWS default-https-client / rustls 0.23 migration." },
+    { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile 1.0 unmaintained. Dev-only via the AWS SDK legacy default TLS; not in the published crate or binary. Revisit on the AWS default-https-client / rustls 0.23 migration." },
+]
+
+[licenses]
+# Mirrors about.toml's accepted set, plus MPL-2.0 for option-ext (a normal
+# transitive dep via the dirs / directories family). MPL-2.0 is weak copyleft
+# and standard to allow for a permissively-licensed binary.
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "ISC",
+    "OpenSSL",
+    "Unicode-3.0",
+    "Zlib",
+    "0BSD",
+    "MIT-0",
+    "CC0-1.0",
+    "Unlicense",
+    "MPL-2.0",
+]
+# A few allowed licences (ISC, OpenSSL, MIT-0, CC0-1.0) are only reachable under
+# certain feature combinations; keep them for about.toml parity without warning
+# when the current graph does not use them.
+unused-allowed-license = "allow"
+
+[bans]
+# The TLS transition leaves duplicate major versions in the tree (rustls 0.21
+# and 0.23, rustls-webpki 0.101 and 0.103); allow duplicates rather than fail.
+multiple-versions = "allow"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"


### PR DESCRIPTION
## What this changes

Supply-chain cleanup and a cargo-deny gate, in two parts.

- **`indicatif` 0.17 -> 0.18.** Drops the unmaintained `number_prefix` crate, the only advisory that reached a shipped artefact (the import CLI progress bar, behind the `import` feature). No API changes; the import path and the full test suite pass.
- **cargo-deny gate.** Adds `deny.toml` and a `cargo-deny` CI job. The licence allow-list mirrors `about.toml` plus `MPL-2.0` (`option-ext`, a normal transitive dep via the `dirs` family). The advisory ignores are scoped to specific IDs, each with a reason: the four `rustls-webpki 0.101` advisories and `rustls-pemfile 1.0` are dev-dependency-only, pinned by the AWS SDK's legacy default TLS stack and confirmed absent from the published crate and binary (`cargo tree -e no-dev`), with no fix available by version bump. They carry a revisit trigger (the AWS dev-deps moving to the modern `default-https-client` / rustls 0.23), and cargo-deny still notes them on every run, so the findings stay visible rather than silenced.

`cargo deny check` passes: advisories ok, bans ok, licenses ok, sources ok.

## Checklist

- ~~Tests added or updated~~ - dependency bump and CI config; the existing suite passes, no behavioural change
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` pass locally
- ~~`CHANGELOG.md` updated if this is a user-visible change~~ - no user-facing behaviour change (dependency and CI hygiene)
- [x] Linked issue, discussion, or a short note explaining the motivation

## DynamoDB compatibility note

None. This PR changes no observable behaviour relative to AWS DynamoDB.
