### PR TITLE
Strip harness-only ops from the shipping wasm Worker

### DIFF
--- a/harness/engine-harness.html
+++ b/harness/engine-harness.html
@@ -50,6 +50,8 @@
             open: (name, ephemeral = false) =>
               call("open", { name, ephemeral }).then(JSON.parse),
             execute: (op, request) => call("execute", { op, request }).then(JSON.parse),
+            // Raw op dispatch, for specs that need to send an arbitrary worker op.
+            call,
             terminate: () => worker.terminate(),
           };
         },

--- a/js/dynoxide-worker.js
+++ b/js/dynoxide-worker.js
@@ -14,17 +14,18 @@
  * | `open`         | `{ name, ephemeral? }`   | contract descriptor JSON string     |
  * | `execute`      | `{ op, request }`        | response JSON string (rejects with  |
  * |                |                          | an error-envelope string on failure)|
- * | `capabilities` | —                        | JSON array of supported op names    |
- * | `contractVersion` | —                     | the engine contract version (number)|
+ * | `capabilities` | (none)                   | JSON array of supported op names    |
+ * | `contractVersion` | (none)                | the engine contract version (number)|
  *
  * `ephemeral: true` on `open` forces an in-memory session. Every failure - the
  * engine's own errors and the Worker's (contract mismatch, unknown op) - is an
  * error-envelope string `{ __type, message }`, so the client always parses it
  * the same way. `request` is a plain object; the Worker serialises it for the
- * engine, so a caller never hand-builds JSON. The smoke ops (`smoke`/`index`/`errors`) exist
- * only in `wasm-harness` builds and are absent from the shipping `wasm-sqlite`
- * bundle — a namespace import leaves them `undefined` there rather than failing
- * to load.
+ * engine, so a caller never hand-builds JSON. The smoke ops (`smoke`/`index`/
+ * `errors`) exist only in `wasm-harness` builds; the shipping `wasm-sqlite`
+ * bundle strips them at build time via the `__DYNOXIDE_HARNESS__` esbuild define
+ * (see scripts/build-wasm.sh), so they are not dead weight in what consumers
+ * download.
  *
  * ## Contract version
  *
@@ -49,15 +50,6 @@ function ensureInit() {
 function envelope(type, message) {
   return JSON.stringify({ __type: type, message });
 }
-
-// Bracket access (not `engine.smoke_test`) so the bundler does not flag these
-// as missing exports: they are present only in `wasm-harness` builds and are
-// deliberately `undefined` in the shipping `wasm-sqlite` bundle.
-const SMOKE_OPS = {
-  smoke: () => engine["smoke_test"]?.(),
-  index: () => engine["index_scan_test"]?.(),
-  errors: () => engine["error_fidelity_test"]?.(),
-};
 
 self.onmessage = async (event) => {
   const { id, op, payload, contractVersion } = event.data ?? {};
@@ -104,18 +96,33 @@ self.onmessage = async (event) => {
       case "contractVersion":
         result = engineVersion;
         break;
-      case "smoke":
-      case "index":
-      case "errors": {
-        const run = SMOKE_OPS[op]();
-        if (run === undefined) {
-          throw envelope("com.dynoxide.wasm#UnsupportedOperation", `op "${op}" needs a wasm-harness build`);
+      default: {
+        // The smoke/index/errors harness ops exist only in `--harness` builds.
+        // esbuild replaces __DYNOXIDE_HARNESS__ with a literal, so for the
+        // shipping build this whole block (and the SMOKE_OPS table) is
+        // dead-code-eliminated (#69); build-wasm.sh asserts it is gone.
+        if (__DYNOXIDE_HARNESS__) {
+          // Bracket access (not `engine.smoke_test`) so the bundler does not
+          // flag these as missing exports in a non-harness compile. Adding an op
+          // here means updating the strip assertion in scripts/build-wasm.sh.
+          const SMOKE_OPS = {
+            smoke: () => engine["smoke_test"]?.(),
+            index: () => engine["index_scan_test"]?.(),
+            errors: () => engine["error_fidelity_test"]?.(),
+          };
+          if (op in SMOKE_OPS) {
+            const run = SMOKE_OPS[op]();
+            if (run === undefined) {
+              throw envelope("com.dynoxide.wasm#UnsupportedOperation", `op "${op}" needs a wasm-harness build`);
+            }
+            result = await run;
+            break;
+          }
         }
-        result = await run;
-        break;
-      }
-      default:
+        // Reached for any op not handled above: a genuine unknown op, or (in the
+        // shipping build, where the block above is stripped) a harness op.
         throw envelope("com.dynoxide.wasm#UnsupportedOperation", `unknown op: ${op}`);
+      }
     }
     self.postMessage({ id, ok: true, result });
   } catch (err) {

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -30,6 +30,10 @@ for arg in "$@"; do
   esac
 done
 
+# Harness builds keep the smoke/index/errors ops; the shipping build strips them
+# via this define so esbuild dead-code-eliminates the guarded block (#69).
+if [ "$feature" = "wasm-harness" ]; then harness_define="true"; else harness_define="false"; fi
+
 # 1. Compile the wasm-bindgen artefact into pkg/. The default `wasm-sqlite`
 #    feature exposes the operation-level engine API (open/execute/capabilities/
 #    contract_version); `--harness` adds the smoke ops on top.
@@ -58,15 +62,39 @@ done
 #    resolves wa-sqlite's bare specifiers from node_modules. The two
 #    `new URL("*.wasm", import.meta.url)` references stay as runtime URLs that
 #    resolve next to the bundle, so the .wasm files ship as siblings.
-#    The smoke ops are present only in `--harness` builds, so in the default
-#    `wasm-sqlite` build esbuild correctly sees them as undefined; that is by
-#    design (the Worker guards them at runtime), so silence that one warning.
+#    The --define folds __DYNOXIDE_HARNESS__ to a literal and --minify-syntax
+#    dead-code-eliminates the resulting `if (false)` block, so the shipping build
+#    drops the smoke/index/errors ops while the harness build keeps them. The
+#    define alone substitutes but does not remove the dead branch; --minify-syntax
+#    leaves identifiers and whitespace intact, so it is not a full minify.
+#    log-override silences the import-is-undefined note from the bracket access to
+#    the harness-only exports.
 rm -rf dist
 npx esbuild js/dynoxide-worker.js \
   --bundle \
   --format=esm \
+  "--define:__DYNOXIDE_HARNESS__=$harness_define" \
+  --minify-syntax \
   --log-override:import-is-undefined=silent \
   --outfile=dist/dynoxide-worker.js
+
+# 2b. Guard (#69). For the shipping build, assert the harness-only ops are gone;
+#     for the harness build, assert they are still present, so the strip is a
+#     proven toggle rather than a vacuous pass. `SMOKE_OPS` is the load-bearing
+#     sentinel for the negative check - it is the local const inside the stripped
+#     block; the export names usually fold to `void 0` in a non-harness compile.
+#     If a new harness op is added, mirror it here and in dynoxide-worker.js.
+if [ "$feature" != "wasm-harness" ]; then
+  if grep -qE 'SMOKE_OPS|smoke_test|index_scan_test|error_fidelity_test' dist/dynoxide-worker.js; then
+    echo "error: harness-only ops leaked into the shipping worker bundle (#69)" >&2
+    exit 1
+  fi
+else
+  if ! grep -qE 'smoke_test|index_scan_test|error_fidelity_test' dist/dynoxide-worker.js; then
+    echo "error: harness ops missing from the --harness worker bundle (#69)" >&2
+    exit 1
+  fi
+fi
 
 # 3. Copy the two .wasm next to the bundle. wa-sqlite.wasm is the synchronous
 #    (non-async) build, paired with the Worker-only AccessHandlePoolVFS; it is

--- a/tests/browser/engine.browser.spec.js
+++ b/tests/browser/engine.browser.spec.js
@@ -237,3 +237,28 @@ test("re-open keeps same-name data and frees the old database when switching nam
   expect(out.aReopen.mode).toBe("opfs");
   expect(out.aReopen.count).toBe(1); // nameA's data persisted across the switch
 });
+
+test("the shipping worker rejects a stripped harness op as unknown (#69)", async ({ page }) => {
+  // The shipping build strips the smoke/index/errors handling, so a harness op
+  // sent to it falls through to the unknown-op envelope - the runtime proof that
+  // the build-time strip is real, complementing build-wasm.sh's grep assertion.
+  const err = await page.evaluate(async () => {
+    const w = globalThis.dynoxide.makeRawWorker();
+    let parsed = null;
+    try {
+      await w.call("smoke", {});
+    } catch (e) {
+      try {
+        parsed = JSON.parse(e.message);
+      } catch {
+        parsed = { message: e.message };
+      }
+    }
+    w.terminate();
+    return parsed;
+  });
+
+  expect(err).not.toBeNull();
+  expect(err.__type).toBe("com.dynoxide.wasm#UnsupportedOperation");
+  expect(err.message).toMatch(/unknown op/);
+});


### PR DESCRIPTION
## What this changes

Keeps the harness-only worker ops (`smoke`/`index`/`errors` + the `SMOKE_OPS` table) out of the shipping `@nubo-db/dynoxide-engine` bundle, so consumers don't download dead code. They now sit behind a `__DYNOXIDE_HARNESS__` build flag; `build-wasm.sh` passes the esbuild `--define` plus `--minify-syntax` to dead-code-eliminate the block for the shipping build. No change to the production op set or to the harness's behaviour.

Closes #69.

- The strip is self-checking: the shipping build asserts the harness ops are gone, and the `--harness` build asserts they are still present, so the toggle can't pass vacuously.
- A browser test confirms the shipping worker rejects a stripped op (`smoke`) with the `unknown op` envelope.

## Checklist

- [x] Tests added or updated (browser rejection test + build-time strip/positive-control assertions)
- ~~`cargo fmt --check` and `cargo clippy -- -D warnings` pass locally~~ - N/A: no Rust changed
- ~~`CHANGELOG.md` updated if this is a user-visible change~~ - N/A: build-internal strip, no user-facing behaviour or API change (the dead ops always threw in production), and the engine package is unpublished
- [x] Linked issue, discussion, or a short note explaining the motivation (Closes #69)
