### PR TITLE
ci: lint the test targets with clippy and fix what it turns up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Clippy (default)
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
 
       - name: Clippy (encryption)
         run: cargo clippy --no-default-features --features encryption --lib -- -D warnings

--- a/tests/consumed_capacity.rs
+++ b/tests/consumed_capacity.rs
@@ -145,16 +145,18 @@ fn test_query_consumed_capacity() {
     })
     .unwrap();
 
-    let mut qr = dynoxide::actions::query::QueryRequest::default();
-    qr.table_name = "TestTable".to_string();
-    qr.key_condition_expression = Some("pk = :pk".to_string());
-    qr.expression_attribute_values = Some({
-        let mut m = HashMap::new();
-        m.insert(":pk".to_string(), AttributeValue::S("u1".to_string()));
-        m
-    });
-    qr.scan_index_forward = true;
-    qr.return_consumed_capacity = Some("TOTAL".to_string());
+    let qr = dynoxide::actions::query::QueryRequest {
+        table_name: "TestTable".to_string(),
+        key_condition_expression: Some("pk = :pk".to_string()),
+        expression_attribute_values: Some({
+            let mut m = HashMap::new();
+            m.insert(":pk".to_string(), AttributeValue::S("u1".to_string()));
+            m
+        }),
+        scan_index_forward: true,
+        return_consumed_capacity: Some("TOTAL".to_string()),
+        ..Default::default()
+    };
     let resp = db.query(qr).unwrap();
 
     let cc = resp.consumed_capacity.unwrap();

--- a/tests/core_important_fixes.rs
+++ b/tests/core_important_fixes.rs
@@ -250,13 +250,15 @@ fn test_put_item_condition_failure_leaves_no_partial_state() {
     assert!(result.is_err());
 
     // Verify original item is still there, unchanged
-    let mut qr = QueryRequest::default();
-    qr.table_name = "TestTbl".to_string();
-    qr.key_condition_expression = Some("pk = :pk AND sk = :sk".to_string());
-    qr.expression_attribute_values = Some(item(&[
-        (":pk", AttributeValue::S("a".into())),
-        (":sk", AttributeValue::S("b".into())),
-    ]));
+    let qr = QueryRequest {
+        table_name: "TestTbl".to_string(),
+        key_condition_expression: Some("pk = :pk AND sk = :sk".to_string()),
+        expression_attribute_values: Some(item(&[
+            (":pk", AttributeValue::S("a".into())),
+            (":sk", AttributeValue::S("b".into())),
+        ])),
+        ..Default::default()
+    };
     let query_resp = db.query(qr).unwrap();
 
     let items = query_resp.items.unwrap();
@@ -287,14 +289,16 @@ fn test_size_on_number_type_returns_no_match() {
     );
 
     // Query with filter: size(num) > 0 — should NOT match since N doesn't support size()
-    let mut qr = QueryRequest::default();
-    qr.table_name = "TestTbl".to_string();
-    qr.key_condition_expression = Some("pk = :pk".to_string());
-    qr.filter_expression = Some("size(num) > :zero".to_string());
-    qr.expression_attribute_values = Some(item(&[
-        (":pk", AttributeValue::S("a".into())),
-        (":zero", AttributeValue::N("0".into())),
-    ]));
+    let qr = QueryRequest {
+        table_name: "TestTbl".to_string(),
+        key_condition_expression: Some("pk = :pk".to_string()),
+        filter_expression: Some("size(num) > :zero".to_string()),
+        expression_attribute_values: Some(item(&[
+            (":pk", AttributeValue::S("a".into())),
+            (":zero", AttributeValue::N("0".into())),
+        ])),
+        ..Default::default()
+    };
     let resp = db.query(qr).unwrap();
 
     // The item should not pass the filter since size() on N returns no match
@@ -318,15 +322,17 @@ fn test_size_on_string_type_still_works() {
     );
 
     // size(#n) = 5, so size(#n) > :three should pass (name is a reserved word)
-    let mut qr = QueryRequest::default();
-    qr.table_name = "TestTbl".to_string();
-    qr.key_condition_expression = Some("pk = :pk".to_string());
-    qr.filter_expression = Some("size(#n) > :three".to_string());
-    qr.expression_attribute_names = Some(HashMap::from([("#n".to_string(), "name".to_string())]));
-    qr.expression_attribute_values = Some(item(&[
-        (":pk", AttributeValue::S("a".into())),
-        (":three", AttributeValue::N("3".into())),
-    ]));
+    let qr = QueryRequest {
+        table_name: "TestTbl".to_string(),
+        key_condition_expression: Some("pk = :pk".to_string()),
+        filter_expression: Some("size(#n) > :three".to_string()),
+        expression_attribute_names: Some(HashMap::from([("#n".to_string(), "name".to_string())])),
+        expression_attribute_values: Some(item(&[
+            (":pk", AttributeValue::S("a".into())),
+            (":three", AttributeValue::N("3".into())),
+        ])),
+        ..Default::default()
+    };
     let resp = db.query(qr).unwrap();
 
     assert_eq!(resp.count, 1);

--- a/tests/correctness_fixes.rs
+++ b/tests/correctness_fixes.rs
@@ -138,15 +138,16 @@ fn test_c1_number_comparison_38_digit_precision() {
     // Query with FilterExpression checking val < big_b  -- should match
     let resp = db
         .query({
-            let mut req = QueryRequest::default();
-            req.table_name = "Tbl".to_string();
-            req.key_condition_expression = Some("pk = :pk".to_string());
-            req.filter_expression = Some("val < :limit".to_string());
-            req.expression_attribute_values = Some(HashMap::from([
-                (":pk".to_string(), AttributeValue::S("a".into())),
-                (":limit".to_string(), AttributeValue::N(big_b.to_string())),
-            ]));
-            req
+            QueryRequest {
+                table_name: "Tbl".to_string(),
+                key_condition_expression: Some("pk = :pk".to_string()),
+                filter_expression: Some("val < :limit".to_string()),
+                expression_attribute_values: Some(HashMap::from([
+                    (":pk".to_string(), AttributeValue::S("a".into())),
+                    (":limit".to_string(), AttributeValue::N(big_b.to_string())),
+                ])),
+                ..Default::default()
+            }
         })
         .unwrap();
     assert_eq!(
@@ -157,15 +158,16 @@ fn test_c1_number_comparison_38_digit_precision() {
     // Now check val < big_a -- should NOT match (equal, not less)
     let resp2 = db
         .query({
-            let mut req = QueryRequest::default();
-            req.table_name = "Tbl".to_string();
-            req.key_condition_expression = Some("pk = :pk".to_string());
-            req.filter_expression = Some("val < :limit".to_string());
-            req.expression_attribute_values = Some(HashMap::from([
-                (":pk".to_string(), AttributeValue::S("a".into())),
-                (":limit".to_string(), AttributeValue::N(big_a.to_string())),
-            ]));
-            req
+            QueryRequest {
+                table_name: "Tbl".to_string(),
+                key_condition_expression: Some("pk = :pk".to_string()),
+                filter_expression: Some("val < :limit".to_string()),
+                expression_attribute_values: Some(HashMap::from([
+                    (":pk".to_string(), AttributeValue::S("a".into())),
+                    (":limit".to_string(), AttributeValue::N(big_a.to_string())),
+                ])),
+                ..Default::default()
+            }
         })
         .unwrap();
     assert_eq!(
@@ -209,14 +211,15 @@ fn test_c2_number_arithmetic_preserves_precision() {
     // Verify: should be 100000000000000000000000000000000000000 (39 digits)
     let resp = db
         .query({
-            let mut req = QueryRequest::default();
-            req.table_name = "Tbl".to_string();
-            req.key_condition_expression = Some("pk = :pk".to_string());
-            req.expression_attribute_values = Some(HashMap::from([(
-                ":pk".to_string(),
-                AttributeValue::S("a".into()),
-            )]));
-            req
+            QueryRequest {
+                table_name: "Tbl".to_string(),
+                key_condition_expression: Some("pk = :pk".to_string()),
+                expression_attribute_values: Some(HashMap::from([(
+                    ":pk".to_string(),
+                    AttributeValue::S("a".into()),
+                )])),
+                ..Default::default()
+            }
         })
         .unwrap();
     let items = resp.items.unwrap();
@@ -261,14 +264,15 @@ fn test_c2_set_plus_minus_high_precision() {
 
     let resp = db
         .query({
-            let mut req = QueryRequest::default();
-            req.table_name = "Tbl".to_string();
-            req.key_condition_expression = Some("pk = :pk".to_string());
-            req.expression_attribute_values = Some(HashMap::from([(
-                ":pk".to_string(),
-                AttributeValue::S("a".into()),
-            )]));
-            req
+            QueryRequest {
+                table_name: "Tbl".to_string(),
+                key_condition_expression: Some("pk = :pk".to_string()),
+                expression_attribute_values: Some(HashMap::from([(
+                    ":pk".to_string(),
+                    AttributeValue::S("a".into()),
+                )])),
+                ..Default::default()
+            }
         })
         .unwrap();
     let items = resp.items.unwrap();
@@ -310,15 +314,15 @@ fn test_c4_begins_with_percent_in_sort_key() {
     // begins_with(sk, "100%") should match only the first item
     let resp = db
         .query({
-            let mut req = QueryRequest::default();
-            req.table_name = "Tbl".to_string();
-            req.key_condition_expression =
-                Some("pk = :pk AND begins_with(sk, :prefix)".to_string());
-            req.expression_attribute_values = Some(HashMap::from([
-                (":pk".to_string(), AttributeValue::S("p".into())),
-                (":prefix".to_string(), AttributeValue::S("100%".into())),
-            ]));
-            req
+            QueryRequest {
+                table_name: "Tbl".to_string(),
+                key_condition_expression: Some("pk = :pk AND begins_with(sk, :prefix)".to_string()),
+                expression_attribute_values: Some(HashMap::from([
+                    (":pk".to_string(), AttributeValue::S("p".into())),
+                    (":prefix".to_string(), AttributeValue::S("100%".into())),
+                ])),
+                ..Default::default()
+            }
         })
         .unwrap();
     assert_eq!(
@@ -357,15 +361,15 @@ fn test_c4_begins_with_underscore_in_sort_key() {
     // begins_with(sk, "a_") should match only "a_b", not "aXb"
     let resp = db
         .query({
-            let mut req = QueryRequest::default();
-            req.table_name = "Tbl".to_string();
-            req.key_condition_expression =
-                Some("pk = :pk AND begins_with(sk, :prefix)".to_string());
-            req.expression_attribute_values = Some(HashMap::from([
-                (":pk".to_string(), AttributeValue::S("p".into())),
-                (":prefix".to_string(), AttributeValue::S("a_".into())),
-            ]));
-            req
+            QueryRequest {
+                table_name: "Tbl".to_string(),
+                key_condition_expression: Some("pk = :pk AND begins_with(sk, :prefix)".to_string()),
+                expression_attribute_values: Some(HashMap::from([
+                    (":pk".to_string(), AttributeValue::S("p".into())),
+                    (":prefix".to_string(), AttributeValue::S("a_".into())),
+                ])),
+                ..Default::default()
+            }
         })
         .unwrap();
     assert_eq!(
@@ -399,16 +403,17 @@ fn test_c5_query_count_with_filter_expression() {
     // SELECT COUNT with filter: score >= 30 (items 3,4 = 2 items)
     let resp = db
         .query({
-            let mut req = QueryRequest::default();
-            req.table_name = "Tbl".to_string();
-            req.key_condition_expression = Some("pk = :pk".to_string());
-            req.filter_expression = Some("score >= :min".to_string());
-            req.expression_attribute_values = Some(HashMap::from([
-                (":pk".to_string(), AttributeValue::S("p".into())),
-                (":min".to_string(), AttributeValue::N("30".to_string())),
-            ]));
-            req.select = Some("COUNT".to_string());
-            req
+            QueryRequest {
+                table_name: "Tbl".to_string(),
+                key_condition_expression: Some("pk = :pk".to_string()),
+                filter_expression: Some("score >= :min".to_string()),
+                expression_attribute_values: Some(HashMap::from([
+                    (":pk".to_string(), AttributeValue::S("p".into())),
+                    (":min".to_string(), AttributeValue::N("30".to_string())),
+                ])),
+                select: Some("COUNT".to_string()),
+                ..Default::default()
+            }
         })
         .unwrap();
 
@@ -438,15 +443,16 @@ fn test_c5_scan_count_with_filter_expression() {
     // Scan with COUNT + filter: score >= 30 (items 3,4 = 2 items)
     let resp = db
         .scan({
-            let mut req = ScanRequest::default();
-            req.table_name = "Tbl".to_string();
-            req.filter_expression = Some("score >= :min".to_string());
-            req.expression_attribute_values = Some(HashMap::from([(
-                ":min".to_string(),
-                AttributeValue::N("30".to_string()),
-            )]));
-            req.select = Some("COUNT".to_string());
-            req
+            ScanRequest {
+                table_name: "Tbl".to_string(),
+                filter_expression: Some("score >= :min".to_string()),
+                expression_attribute_values: Some(HashMap::from([(
+                    ":min".to_string(),
+                    AttributeValue::N("30".to_string()),
+                )])),
+                select: Some("COUNT".to_string()),
+                ..Default::default()
+            }
         })
         .unwrap();
 

--- a/tests/create_fixtures.rs
+++ b/tests/create_fixtures.rs
@@ -14,6 +14,7 @@ use dynoxide::Database;
 use std::path::Path;
 
 const FIXTURE_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
+#[cfg(feature = "encryption")]
 const TEST_KEY: &str = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
 
 fn create_table_and_insert(db: &Database) {

--- a/tests/import_items.rs
+++ b/tests/import_items.rs
@@ -196,13 +196,15 @@ fn import_maintains_gsi() {
     use dynoxide::actions::query::QueryRequest;
     let resp = db
         .query({
-            let mut req = QueryRequest::default();
-            req.table_name = "Users".to_string();
-            req.index_name = Some("email-index".to_string());
-            req.key_condition_expression = Some("email = :email".to_string());
-            req.expression_attribute_values =
-                Some(dynoxide::item! { ":email" => "alice@example.com" });
-            req
+            QueryRequest {
+                table_name: "Users".to_string(),
+                index_name: Some("email-index".to_string()),
+                key_condition_expression: Some("email = :email".to_string()),
+                expression_attribute_values: Some(
+                    dynoxide::item! { ":email" => "alice@example.com" },
+                ),
+                ..Default::default()
+            }
         })
         .unwrap();
 
@@ -233,10 +235,11 @@ fn import_sparse_gsi_skips_items_without_gsi_key() {
     use dynoxide::actions::scan::ScanRequest;
     let resp = db
         .scan({
-            let mut req = ScanRequest::default();
-            req.table_name = "Users".to_string();
-            req.index_name = Some("email-index".to_string());
-            req
+            ScanRequest {
+                table_name: "Users".to_string(),
+                index_name: Some("email-index".to_string()),
+                ..Default::default()
+            }
         })
         .unwrap();
     let gsi_items = resp.items.unwrap_or_default();

--- a/tests/item_collection_metrics.rs
+++ b/tests/item_collection_metrics.rs
@@ -355,21 +355,22 @@ fn test_query_gsi_with_indexes_mode_attributes_capacity_to_gsi() {
     // Query the GSI with INDEXES
     let resp = db
         .query({
-            let mut req = dynoxide::actions::query::QueryRequest::default();
-            req.table_name = "Products".to_string();
-            req.key_condition_expression = Some("category = :cat".to_string());
-            req.expression_attribute_values = Some({
-                let mut m = HashMap::new();
-                m.insert(
-                    ":cat".to_string(),
-                    AttributeValue::S("electronics".to_string()),
-                );
-                m
-            });
-            req.scan_index_forward = true;
-            req.index_name = Some("CategoryIndex".to_string());
-            req.return_consumed_capacity = Some("INDEXES".to_string());
-            req
+            dynoxide::actions::query::QueryRequest {
+                table_name: "Products".to_string(),
+                key_condition_expression: Some("category = :cat".to_string()),
+                expression_attribute_values: Some({
+                    let mut m = HashMap::new();
+                    m.insert(
+                        ":cat".to_string(),
+                        AttributeValue::S("electronics".to_string()),
+                    );
+                    m
+                }),
+                scan_index_forward: true,
+                index_name: Some("CategoryIndex".to_string()),
+                return_consumed_capacity: Some("INDEXES".to_string()),
+                ..Default::default()
+            }
         })
         .unwrap();
 

--- a/tests/parallel_scan.rs
+++ b/tests/parallel_scan.rs
@@ -41,11 +41,12 @@ fn make_db_with_items(count: usize) -> Database {
 }
 
 fn scan_req(table: &str, segment: Option<u32>, total: Option<u32>) -> ScanRequest {
-    let mut req = ScanRequest::default();
-    req.table_name = table.to_string();
-    req.segment = segment;
-    req.total_segments = total;
-    req
+    ScanRequest {
+        table_name: table.to_string(),
+        segment,
+        total_segments: total,
+        ..Default::default()
+    }
 }
 
 #[test]
@@ -124,12 +125,14 @@ fn test_paginated_parallel_scan() {
     for segment in 0..total_segments {
         let mut start_key: Option<HashMap<String, AttributeValue>> = None;
         loop {
-            let mut req = ScanRequest::default();
-            req.table_name = "Tbl".to_string();
-            req.segment = Some(segment);
-            req.total_segments = Some(total_segments);
-            req.limit = Some(5);
-            req.exclusive_start_key = start_key.clone();
+            let req = ScanRequest {
+                table_name: "Tbl".to_string(),
+                segment: Some(segment),
+                total_segments: Some(total_segments),
+                limit: Some(5),
+                exclusive_start_key: start_key.clone(),
+                ..Default::default()
+            };
             let resp = db.scan(req).unwrap();
 
             for item in resp.items.unwrap_or_default() {

--- a/tests/partiql.rs
+++ b/tests/partiql.rs
@@ -914,7 +914,7 @@ fn test_select_nested_map_path() {
     );
     // Should NOT have the parent map key
     assert!(
-        items[0].get("mymap").is_none(),
+        !items[0].contains_key("mymap"),
         "should not have parent 'mymap' key in result"
     );
 }
@@ -981,7 +981,7 @@ fn test_select_nested_path_missing_returns_empty() {
     let items = resp.items.unwrap();
     assert_eq!(items.len(), 1);
     // Non-existent nested path should be absent, not error
-    assert!(items[0].get("nonexistent").is_none());
+    assert!(!items[0].contains_key("nonexistent"));
 }
 
 // ── Issue #40: bracket IN lists and negated predicates ────────────────────

--- a/tests/partiql_important_fixes.rs
+++ b/tests/partiql_important_fixes.rs
@@ -62,19 +62,6 @@ fn exec(db: &Database, statement: &str) -> ExecuteStatementResponse {
     .unwrap()
 }
 
-fn exec_with_params(
-    db: &Database,
-    statement: &str,
-    params: Vec<AttributeValue>,
-) -> ExecuteStatementResponse {
-    db.execute_statement(ExecuteStatementRequest {
-        statement: statement.to_string(),
-        parameters: Some(params),
-        ..Default::default()
-    })
-    .unwrap()
-}
-
 fn exec_with_limit(db: &Database, statement: &str, limit: usize) -> ExecuteStatementResponse {
     db.execute_statement(ExecuteStatementRequest {
         statement: statement.to_string(),
@@ -136,8 +123,8 @@ fn test_update_remove_clause() {
         items[0].get("name"),
         Some(&AttributeValue::S("Alicia".to_string()))
     );
-    assert!(items[0].get("age").is_none(), "age should be removed");
-    assert!(items[0].get("email").is_none(), "email should be removed");
+    assert!(!items[0].contains_key("age"), "age should be removed");
+    assert!(!items[0].contains_key("email"), "email should be removed");
 }
 
 #[test]
@@ -155,7 +142,7 @@ fn test_update_remove_only() {
     let sel = exec(&db, "SELECT * FROM \"Tbl\" WHERE pk = 'k1'");
     let items = sel.items.unwrap();
     assert_eq!(items.len(), 1);
-    assert!(items[0].get("temp").is_none(), "temp should be removed");
+    assert!(!items[0].contains_key("temp"), "temp should be removed");
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/streams.rs
+++ b/tests/streams.rs
@@ -359,7 +359,7 @@ fn test_get_shard_iterator_latest() {
     put_item(&db, "Table1", "b", "2");
 
     // Use the next iterator to read new records
-    let resp2 = get_records(&db, &resp.next_shard_iterator.as_ref().unwrap());
+    let resp2 = get_records(&db, resp.next_shard_iterator.as_ref().unwrap());
     assert_eq!(resp2.records.len(), 1);
     assert_eq!(resp2.records[0].event_name, "INSERT");
 }

--- a/tests/ttl.rs
+++ b/tests/ttl.rs
@@ -90,10 +90,12 @@ fn disable_ttl(db: &Database, table_name: &str, attribute_name: &str) {
 }
 
 fn item_count(db: &Database, table_name: &str) -> usize {
-    let mut req = dynoxide::actions::scan::ScanRequest::default();
-    req.table_name = table_name.to_string();
+    let req = dynoxide::actions::scan::ScanRequest {
+        table_name: table_name.to_string(),
+        ..Default::default()
+    };
     let resp = db.scan(req).unwrap();
-    resp.count as usize
+    resp.count
 }
 
 // -----------------------------------------------------------------------
@@ -291,7 +293,7 @@ fn test_ttl_deletion_generates_stream_remove_record() {
     let iter_resp = db
         .get_shard_iterator(GetShardIteratorRequest {
             stream_arn: stream_arn.clone(),
-            shard_id: format!("shardId-00000001-TestTable"),
+            shard_id: "shardId-00000001-TestTable".to_string(),
             shard_iterator_type: "TRIM_HORIZON".to_string(),
             sequence_number: None,
         })
@@ -427,9 +429,11 @@ fn test_ttl_deletion_removes_from_gsi() {
     .unwrap();
 
     // Verify item exists in GSI
-    let mut gsi_req = dynoxide::actions::scan::ScanRequest::default();
-    gsi_req.table_name = "TestTable".to_string();
-    gsi_req.index_name = Some("ByGsiPk".to_string());
+    let gsi_req = dynoxide::actions::scan::ScanRequest {
+        table_name: "TestTable".to_string(),
+        index_name: Some("ByGsiPk".to_string()),
+        ..Default::default()
+    };
     let gsi_scan = db.scan(gsi_req).unwrap();
     assert_eq!(gsi_scan.count, 1);
 
@@ -441,9 +445,11 @@ fn test_ttl_deletion_removes_from_gsi() {
     assert_eq!(item_count(&db, "TestTable"), 0);
 
     // Verify item removed from GSI
-    let mut gsi_req2 = dynoxide::actions::scan::ScanRequest::default();
-    gsi_req2.table_name = "TestTable".to_string();
-    gsi_req2.index_name = Some("ByGsiPk".to_string());
+    let gsi_req2 = dynoxide::actions::scan::ScanRequest {
+        table_name: "TestTable".to_string(),
+        index_name: Some("ByGsiPk".to_string()),
+        ..Default::default()
+    };
     let gsi_scan = db.scan(gsi_req2).unwrap();
     assert_eq!(gsi_scan.count, 0);
 }

--- a/tests/type_conversions.rs
+++ b/tests/type_conversions.rs
@@ -125,8 +125,8 @@ fn from_btreeset_string() {
 
 #[test]
 fn try_from_f64_valid() {
-    let av = AttributeValue::try_from(3.14f64).unwrap();
-    assert_eq!(av, AttributeValue::N("3.14".to_string()));
+    let av = AttributeValue::try_from(3.5f64).unwrap();
+    assert_eq!(av, AttributeValue::N("3.5".to_string()));
 }
 
 #[test]
@@ -238,9 +238,9 @@ fn av_to_i64_wrong_type() {
 
 #[test]
 fn av_to_f64() {
-    let av = AttributeValue::N("3.14".to_string());
+    let av = AttributeValue::N("3.5".to_string());
     let n: f64 = av.try_into().unwrap();
-    assert!((n - 3.14).abs() < f64::EPSILON);
+    assert!((n - 3.5).abs() < f64::EPSILON);
 }
 
 #[test]

--- a/tests/unused_expression_attrs.rs
+++ b/tests/unused_expression_attrs.rs
@@ -124,22 +124,23 @@ fn test_query_name_used_across_expressions_is_valid() {
     put_item(&db, "TestTable", "user#1", "2024-01-01");
 
     let result = db.query({
-        let mut req = QueryRequest::default();
-        req.table_name = "TestTable".to_string();
-        req.key_condition_expression = Some("#pk = :pk".to_string());
-        req.filter_expression = Some("#s = :status".to_string());
-        req.expression_attribute_names = Some(HashMap::from([
-            ("#pk".to_string(), "pk".to_string()),
-            ("#s".to_string(), "status".to_string()),
-        ]));
-        req.expression_attribute_values = Some(HashMap::from([
-            (":pk".to_string(), AttributeValue::S("user#1".to_string())),
-            (
-                ":status".to_string(),
-                AttributeValue::S("active".to_string()),
-            ),
-        ]));
-        req
+        QueryRequest {
+            table_name: "TestTable".to_string(),
+            key_condition_expression: Some("#pk = :pk".to_string()),
+            filter_expression: Some("#s = :status".to_string()),
+            expression_attribute_names: Some(HashMap::from([
+                ("#pk".to_string(), "pk".to_string()),
+                ("#s".to_string(), "status".to_string()),
+            ])),
+            expression_attribute_values: Some(HashMap::from([
+                (":pk".to_string(), AttributeValue::S("user#1".to_string())),
+                (
+                    ":status".to_string(),
+                    AttributeValue::S("active".to_string()),
+                ),
+            ])),
+            ..Default::default()
+        }
     });
 
     assert!(result.is_ok(), "Expected success, got: {:?}", result.err());
@@ -152,17 +153,20 @@ fn test_query_name_used_only_in_projection_is_valid() {
     put_item(&db, "TestTable", "user#1", "2024-01-01");
 
     let result = db.query({
-        let mut req = QueryRequest::default();
-        req.table_name = "TestTable".to_string();
-        req.key_condition_expression = Some("pk = :pk".to_string());
-        req.projection_expression = Some("#s".to_string());
-        req.expression_attribute_names =
-            Some(HashMap::from([("#s".to_string(), "status".to_string())]));
-        req.expression_attribute_values = Some(HashMap::from([(
-            ":pk".to_string(),
-            AttributeValue::S("user#1".to_string()),
-        )]));
-        req
+        QueryRequest {
+            table_name: "TestTable".to_string(),
+            key_condition_expression: Some("pk = :pk".to_string()),
+            projection_expression: Some("#s".to_string()),
+            expression_attribute_names: Some(HashMap::from([(
+                "#s".to_string(),
+                "status".to_string(),
+            )])),
+            expression_attribute_values: Some(HashMap::from([(
+                ":pk".to_string(),
+                AttributeValue::S("user#1".to_string()),
+            )])),
+            ..Default::default()
+        }
     });
 
     assert!(result.is_ok(), "Expected success, got: {:?}", result.err());


### PR DESCRIPTION
Closes #81.

`cargo clippy --all-targets` has been red on `main` while CI stayed green: the clippy jobs only lint the lib and bins, so nothing in the test crates was ever checked. The default job now runs `--all-targets -- -D warnings`, the same bar the lib already meets.

Reproducing it surfaced more than the issue listed - two deny-by-default `approx_constant` errors plus ~30 warnings across 13 test files. The cleanup:

- `field_reassign_with_default` rewritten as struct literals (the request structs aren't `#[non_exhaustive]`, so this is the real fix, not a workaround)
- two `3.14` floats clippy reads as pi swapped for `3.5` (arbitrary test data, no suppression)
- `get(k).is_none()` to `!contains_key(k)`
- a genuinely-unused helper removed; an encryption-only fixture key `#[cfg]`-gated rather than deleted
- plus the auto-fixable needless borrow, redundant cast, and argless `format!`

The encryption clippy job stays `--lib` on purpose: integration tests are built under the native backend (the matrix runs them only there), so linting test targets belongs on the default job, not the encryption one.

Verified locally: `cargo clippy --all-targets -- -D warnings`, the encryption `--lib` job, `cargo test`, and `cargo fmt --check` all clean.