### PR TITLE
perf(wasm): batch the per-write/delete index fan-out into one bridge crossing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- On the wasm backend, the per-write and per-delete secondary-index fan-out now crosses the JS bridge once per index type rather than once per index operation. Keeping a table's GSIs and LSIs in step with a write is a delete and a re-insert per index, each previously its own bridge crossing; a new `exec_script` primitive carries the whole ordered batch over in a single crossing, so an indexed `PutItem` or `DeleteItem` on a table with K GSIs and L LSIs drops from order K+L crossings to a constant two. Index contents and native behaviour are unchanged ([#85](https://github.com/nubo-db/dynoxide/issues/85)).
 - The browser backend moved from `wa-sqlite` to the official [`@sqlite.org/sqlite-wasm`](https://github.com/sqlite/sqlite-wasm) engine, maintained by the SQLite team and versioned to track SQLite releases. The bridge now runs through the `sqlite3.oo1` API over the OPFS SAHPool VFS, which keeps the no-COOP/COEP guarantee that motivated the original VFS choice (it needs no `SharedArrayBuffer`). The `open`/`exec`/`query`/`close` contract is unchanged, so consumers of `@nubo-db/dynoxide-engine` need no code change. A busy database now recovers once the holder releases it rather than staying busy until reload, and the full 64-bit integer round-trip and the `fnv1a_hash` scalar are re-proven on the new engine ([#61](https://github.com/nubo-db/dynoxide/issues/61)). The shipped SQLite `.wasm` is larger than before (~845 KB against wa-sqlite's ~545 KB).
 
 ### Fixed

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -14,6 +14,8 @@ One fidelity note on what *is* supported: adding a GSI is synchronous. The new i
 
 The engine runs in a Web Worker (OPFS's synchronous file handles are Worker-only), and the page talks to it over a message channel. It needs no special server headers (no COOP/COEP cross-origin isolation), so it works on ordinary static hosting.
 
+Keeping secondary indexes in step with a write means a delete and a re-insert per GSI and per LSI, and on wasm each of those statements is a bridge crossing. The maintenance for one write (or one delete) is issued as a single ordered batch through the `exec_script` bridge primitive - one crossing for the whole GSI fan-out and one for the LSI fan-out - rather than one crossing per index operation. A table with no indexes crosses zero extra times. Native runs the same fan-out in-process, so it has no crossings to save.
+
 ## Persistence and durability
 
 The database lives in OPFS, reached through the official OPFS SAHPool VFS - a pool of synchronous access handles. Where a browser can't provide those handles - a Firefox private window, an older Safari - the engine falls back to an in-memory database that works for the session but doesn't survive a reload, and `open` reports which mode you got as `persistenceMode` so you can warn the user.

--- a/js/sqlite-wasm-bridge.js
+++ b/js/sqlite-wasm-bridge.js
@@ -345,6 +345,45 @@ export async function exec_batch(handle, sql, paramRows) {
 }
 
 /**
+ * Run several distinct statements in order in a single bridge crossing. Unlike
+ * `exec_batch` (one statement reused over many parameter rows), each entry
+ * carries its own `sql` and positional `params`, so a statement is prepared,
+ * stepped to completion, and finalised before the next runs. This is the shape
+ * the per-write and per-delete index fan-out needs: a delete and an insert per
+ * GSI/LSI - several different statements, one binding each - collapsed from one
+ * crossing per operation into one crossing for the whole list.
+ *
+ * It owns no transaction - it runs inside whatever the caller has open - so a
+ * mid-script failure is rolled back by the caller's transaction, not here. Any
+ * failure (prepare, bind, or step) throws an Error naming the failing statement
+ * index, so a mid-script failure is diagnosable. An empty list makes no work.
+ *
+ * Each statement's `params` bind its placeholders in order. The builders that
+ * produce these pairs always match arity, so there is no per-statement arity
+ * guard like `exec_batch`'s: a too-long array throws at `bind` (the only
+ * mismatch the builders cannot produce), and that throw is reported with its
+ * statement index like any other.
+ */
+export async function exec_script(handle, statements) {
+  if (!statements || !statements.length) return;
+  for (let i = 0; i < statements.length; i += 1) {
+    const { sql, params } = statements[i];
+    let stmt;
+    try {
+      stmt = handle.db.prepare(sql);
+      if (params && params.length) stmt.bind(params);
+      while (stmt.step()) {
+        // a row-less write; drain any result rows without collecting them
+      }
+    } catch (e) {
+      throw new Error(`exec_script statement ${i}: ${e.message}`);
+    } finally {
+      if (stmt) stmt.finalize();
+    }
+  }
+}
+
+/**
  * Close a database handle, releasing its connection so a re-open does not leak
  * the old one. When the last connection on a persistent pool closes, the pool
  * is paused: its OPFS sync access handles are relinquished (so another tab can

--- a/js/sqlite-wasm-bridge.test.js
+++ b/js/sqlite-wasm-bridge.test.js
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { open, exec, query, close, exec_batch } from "./sqlite-wasm-bridge.js";
+import { open, exec, query, close, exec_batch, exec_script } from "./sqlite-wasm-bridge.js";
 import { fnv1aHash } from "./fnv1a.js";
 
 // Off-browser proof of the bridge's SQL contract against the official
@@ -23,10 +23,10 @@ async function withMemoryDb(fn) {
   }
 }
 
-test("the bridge exports exactly the open/exec/query/close contract", () => {
-  // The Rust extern block binds these four names by js_name; the migration must
-  // not rename or drop any of them.
-  for (const fn of [open, exec, query, close]) {
+test("the bridge exports the open/exec/query/close/exec_batch/exec_script contract", () => {
+  // The Rust extern block binds these names by js_name; none may be renamed or
+  // dropped without updating the matching wasm-bindgen extern.
+  for (const fn of [open, exec, query, close, exec_batch, exec_script]) {
     assert.equal(typeof fn, "function");
   }
 });
@@ -237,5 +237,94 @@ test("a mid-batch failure names the row and the caller's rollback undoes the bat
     await exec(handle, "ROLLBACK", []);
     const [[count]] = await query(handle, "SELECT count(*) FROM t", []);
     assert.equal(Number(count), 0); // row 0 was rolled back with the outer transaction
+  });
+});
+
+// --- exec_script: the ordered-multi-statement primitive (issue #85) ---------
+
+// The per-write/per-delete index fan-out is a delete then an insert per index:
+// several different statements, one binding each, run in order. exec_script
+// carries that list across the bridge in a single crossing.
+const GSI_DELETE = "DELETE FROM g WHERE table_pk = ?1 AND table_sk = ?2";
+
+test("exec_script applies an ordered delete-then-insert in one call", async () => {
+  // The overwrite shape: an existing index entry for a base key is deleted, then
+  // the new projection is inserted. Ordering is load-bearing - the delete must
+  // land before the re-insert - so a stale row left behind would fail this.
+  await withMemoryDb(async (handle) => {
+    await exec(handle, GSI_DDL, []);
+    await exec(handle, GSI_INSERT, ["old", "s", "p1", "t1", '{"v":"old"}']);
+    await exec_script(handle, [
+      { sql: GSI_DELETE, params: ["p1", "t1"] },
+      { sql: GSI_INSERT, params: ["new", "s", "p1", "t1", '{"v":"new"}'] },
+    ]);
+    const rows = await query(handle, "SELECT gsi_pk, item_json FROM g", []);
+    assert.deepEqual(rows, [["new", '{"v":"new"}']]);
+  });
+});
+
+test("exec_script runs several distinct statements against different tables", async () => {
+  // GSI and LSI fan-outs target different index tables in the same call; prove
+  // the primitive is not tied to one statement shape the way exec_batch is.
+  await withMemoryDb(async (handle) => {
+    await exec(handle, GSI_DDL, []);
+    await exec(handle, "CREATE TABLE l (pk TEXT, sk TEXT, base_pk TEXT, base_sk TEXT, item_json TEXT)", []);
+    await exec_script(handle, [
+      { sql: GSI_INSERT, params: ["g", "s", "p", "t", "{}"] },
+      { sql: "INSERT INTO l (pk, sk, base_pk, base_sk, item_json) VALUES (?1, ?2, ?3, ?4, ?5)", params: ["p", "ls", "p", "t", "{}"] },
+    ]);
+    const [[g]] = await query(handle, "SELECT count(*) FROM g", []);
+    const [[l]] = await query(handle, "SELECT count(*) FROM l", []);
+    assert.equal(Number(g), 1);
+    assert.equal(Number(l), 1);
+  });
+});
+
+test("exec_script is a no-op on an empty list", async () => {
+  await withMemoryDb(async (handle) => {
+    await exec(handle, GSI_DDL, []);
+    await exec_script(handle, []);
+    const [[count]] = await query(handle, "SELECT count(*) FROM g", []);
+    assert.equal(Number(count), 0);
+  });
+});
+
+test("exec_script runs inside the caller's open transaction", async () => {
+  // The real usage shape: the fan-out runs between the BEGIN and COMMIT that the
+  // write owns. The primitive itself issues no BEGIN/COMMIT.
+  await withMemoryDb(async (handle) => {
+    await exec(handle, GSI_DDL, []);
+    await exec(handle, "BEGIN IMMEDIATE", []);
+    await exec_script(handle, [
+      { sql: GSI_INSERT, params: ["g0", "s0", "p0", "t0", "{}"] },
+      { sql: GSI_INSERT, params: ["g1", "s1", "p1", "t1", "{}"] },
+    ]);
+    await exec(handle, "COMMIT", []);
+    const [[count]] = await query(handle, "SELECT count(*) FROM g", []);
+    assert.equal(Number(count), 2);
+  });
+});
+
+test("a mid-script failure names the statement and the caller's rollback undoes it", async () => {
+  // Atomicity comes from the caller's transaction, not the primitive: a statement
+  // that violates a constraint mid-script throws with its index, and ROLLBACK
+  // undoes even the statements that applied before it.
+  await withMemoryDb(async (handle) => {
+    await exec(handle, "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT NOT NULL)", []);
+    await exec(handle, "BEGIN IMMEDIATE", []);
+    await assert.rejects(
+      () =>
+        exec_script(handle, [
+          { sql: "INSERT INTO t (id, v) VALUES (?1, ?2)", params: [1, "ok"] },
+          { sql: "INSERT INTO t (id, v) VALUES (?1, ?2)", params: [2, null] }, // NOT NULL violation
+        ]),
+      (e) => {
+        assert.match(e.message, /statement 1/);
+        return true;
+      },
+    );
+    await exec(handle, "ROLLBACK", []);
+    const [[count]] = await query(handle, "SELECT count(*) FROM t", []);
+    assert.equal(Number(count), 0); // statement 0 was rolled back with the outer transaction
   });
 });

--- a/src/actions/gsi.rs
+++ b/src/actions/gsi.rs
@@ -4,7 +4,7 @@
 
 use crate::errors::{DynoxideError, Result};
 use crate::storage::TableMetadata;
-use crate::storage_backend::StorageBackend;
+use crate::storage_backend::{IndexWriteOp, StorageBackend};
 use crate::types::{GlobalSecondaryIndex, Item, KeyType, ProjectionType};
 use std::collections::HashMap;
 
@@ -136,12 +136,16 @@ pub async fn maintain_gsis_after_write<S: StorageBackend>(
 ) -> Result<HashMap<String, f64>> {
     let gsi_defs = parse_gsi_defs(meta)?;
     let mut gsi_units: HashMap<String, f64> = HashMap::new();
+    let mut ops: Vec<IndexWriteOp> = Vec::new();
 
     for gsi in &gsi_defs {
         // First, remove any existing GSI entry for this base table key
-        storage
-            .delete_gsi_item(table_name, &gsi.index_name, table_pk_str, table_sk_str)
-            .await?;
+        ops.push(IndexWriteOp::DeleteGsi {
+            table_name: table_name.to_string(),
+            index_name: gsi.index_name.clone(),
+            table_pk: table_pk_str.to_string(),
+            table_sk: table_sk_str.to_string(),
+        });
 
         // If the item has the GSI pk attribute, insert into GSI
         if let Some(gsi_pk_val) = item.get(&gsi.pk_attr) {
@@ -158,17 +162,15 @@ pub async fn maintain_gsis_after_write<S: StorageBackend>(
             let item_json = serde_json::to_string(&projected)
                 .map_err(|e| DynoxideError::InternalServerError(e.to_string()))?;
 
-            storage
-                .insert_gsi_item(
-                    table_name,
-                    &gsi.index_name,
-                    &gsi_pk,
-                    &gsi_sk,
-                    table_pk_str,
-                    table_sk_str,
-                    &item_json,
-                )
-                .await?;
+            ops.push(IndexWriteOp::InsertGsi {
+                table_name: table_name.to_string(),
+                index_name: gsi.index_name.clone(),
+                gsi_pk,
+                gsi_sk,
+                table_pk: table_pk_str.to_string(),
+                table_sk: table_sk_str.to_string(),
+                item_json,
+            });
 
             gsi_units.insert(
                 gsi.index_name.clone(),
@@ -177,6 +179,11 @@ pub async fn maintain_gsis_after_write<S: StorageBackend>(
         }
     }
 
+    // One batched fan-out call: the per-op loop crossed the wasm bridge once per
+    // index operation; this hands the whole list over in a single crossing. The
+    // default impl replays it per-item, so native order and behaviour are
+    // unchanged.
+    storage.apply_index_writes(&ops).await?;
     Ok(gsi_units)
 }
 
@@ -191,15 +198,20 @@ pub async fn maintain_gsis_after_delete<S: StorageBackend>(
 ) -> Result<HashMap<String, f64>> {
     let gsi_defs = parse_gsi_defs(meta)?;
     let mut gsi_units: HashMap<String, f64> = HashMap::new();
+    let mut ops: Vec<IndexWriteOp> = Vec::new();
 
     for gsi in &gsi_defs {
-        storage
-            .delete_gsi_item(table_name, &gsi.index_name, table_pk_str, table_sk_str)
-            .await?;
+        ops.push(IndexWriteOp::DeleteGsi {
+            table_name: table_name.to_string(),
+            index_name: gsi.index_name.clone(),
+            table_pk: table_pk_str.to_string(),
+            table_sk: table_sk_str.to_string(),
+        });
         // Delete operations consume 1 WCU minimum per GSI affected
         gsi_units.insert(gsi.index_name.clone(), 1.0);
     }
 
+    storage.apply_index_writes(&ops).await?;
     Ok(gsi_units)
 }
 

--- a/src/actions/lsi.rs
+++ b/src/actions/lsi.rs
@@ -4,7 +4,7 @@
 
 use crate::errors::{DynoxideError, Result};
 use crate::storage::TableMetadata;
-use crate::storage_backend::StorageBackend;
+use crate::storage_backend::{IndexWriteOp, StorageBackend};
 use crate::types::{Item, KeyType, LocalSecondaryIndex};
 
 /// Type alias: LSI definitions reuse the shared IndexDef from gsi.
@@ -76,12 +76,16 @@ pub async fn maintain_lsis_after_write<S: StorageBackend>(
     table_sk_attr: Option<&str>,
 ) -> Result<()> {
     let lsi_defs = parse_lsi_defs(meta)?;
+    let mut ops: Vec<IndexWriteOp> = Vec::new();
 
     for lsi in &lsi_defs {
         // First, remove any existing LSI entry for this base table key
-        storage
-            .delete_lsi_item(table_name, &lsi.index_name, table_pk_str, table_sk_str)
-            .await?;
+        ops.push(IndexWriteOp::DeleteLsi {
+            table_name: table_name.to_string(),
+            index_name: lsi.index_name.clone(),
+            base_pk: table_pk_str.to_string(),
+            base_sk: table_sk_str.to_string(),
+        });
 
         // LSI pk is always the same as the table pk. Only insert if item
         // has the LSI sort key attribute (sparse index behaviour).
@@ -95,21 +99,20 @@ pub async fn maintain_lsis_after_write<S: StorageBackend>(
                 let item_json = serde_json::to_string(&projected)
                     .map_err(|e| DynoxideError::InternalServerError(e.to_string()))?;
 
-                storage
-                    .insert_lsi_item(
-                        table_name,
-                        &lsi.index_name,
-                        &lsi_pk,
-                        &lsi_sk,
-                        table_pk_str,
-                        table_sk_str,
-                        &item_json,
-                    )
-                    .await?;
+                ops.push(IndexWriteOp::InsertLsi {
+                    table_name: table_name.to_string(),
+                    index_name: lsi.index_name.clone(),
+                    pk: lsi_pk,
+                    sk: lsi_sk,
+                    base_pk: table_pk_str.to_string(),
+                    base_sk: table_sk_str.to_string(),
+                    item_json,
+                });
             }
         }
     }
 
+    storage.apply_index_writes(&ops).await?;
     Ok(())
 }
 
@@ -122,12 +125,17 @@ pub async fn maintain_lsis_after_delete<S: StorageBackend>(
     table_sk_str: &str,
 ) -> Result<()> {
     let lsi_defs = parse_lsi_defs(meta)?;
+    let mut ops: Vec<IndexWriteOp> = Vec::new();
 
     for lsi in &lsi_defs {
-        storage
-            .delete_lsi_item(table_name, &lsi.index_name, table_pk_str, table_sk_str)
-            .await?;
+        ops.push(IndexWriteOp::DeleteLsi {
+            table_name: table_name.to_string(),
+            index_name: lsi.index_name.clone(),
+            base_pk: table_pk_str.to_string(),
+            base_sk: table_sk_str.to_string(),
+        });
     }
 
+    storage.apply_index_writes(&ops).await?;
     Ok(())
 }

--- a/src/storage_backend/mod.rs
+++ b/src/storage_backend/mod.rs
@@ -93,6 +93,52 @@ pub struct GsiItemRow {
     pub item_json: String,
 }
 
+/// One index-table write operation, backend-neutral.
+///
+/// The per-write and per-delete GSI/LSI fan-out builds an ordered list of these
+/// and hands it to [`StorageBackend::apply_index_writes`] in a single call. The
+/// default impl replays each op through the matching per-item method, identical
+/// to the per-op loop it replaces; the wasm backend overrides it to collapse the
+/// list into one bridge crossing. Each variant's fields mirror the argument
+/// order of the per-item method it stands in for.
+#[derive(Debug, Clone)]
+pub enum IndexWriteOp {
+    /// Remove this base key's entry from a GSI table.
+    DeleteGsi {
+        table_name: String,
+        index_name: String,
+        table_pk: String,
+        table_sk: String,
+    },
+    /// Insert (or replace) this item's projected entry into a GSI table.
+    InsertGsi {
+        table_name: String,
+        index_name: String,
+        gsi_pk: String,
+        gsi_sk: String,
+        table_pk: String,
+        table_sk: String,
+        item_json: String,
+    },
+    /// Remove this base key's entry from an LSI table.
+    DeleteLsi {
+        table_name: String,
+        index_name: String,
+        base_pk: String,
+        base_sk: String,
+    },
+    /// Insert (or replace) this item's projected entry into an LSI table.
+    InsertLsi {
+        table_name: String,
+        index_name: String,
+        pk: String,
+        sk: String,
+        base_pk: String,
+        base_sk: String,
+        item_json: String,
+    },
+}
+
 /// Backend-neutral storage interface.
 ///
 /// Method signatures mirror [`Storage`](crate::storage::Storage)'s public
@@ -299,6 +345,76 @@ pub trait StorageBackend {
         index_name: &str,
         params: &ScanParams<'_>,
     ) -> Result<Vec<(String, String, String)>, BackendError>;
+
+    // -----------------------------------------------------------------------
+    // Index write fan-out
+    // -----------------------------------------------------------------------
+
+    /// Apply an ordered batch of GSI/LSI write operations.
+    ///
+    /// The GSI/LSI maintenance helpers build the list and call this once per
+    /// fan-out instead of invoking the per-item methods one at a time. The
+    /// default impl replays each op through the matching per-item method in
+    /// order, so a backend that does not override it behaves exactly as the
+    /// per-op loop did. The wasm backend overrides this to issue the whole list
+    /// in a single bridge crossing.
+    ///
+    /// Owns no transaction: the caller's open transaction supplies atomicity, so
+    /// a mid-batch failure is rolled back by that caller. An empty list does no
+    /// work.
+    async fn apply_index_writes(&self, ops: &[IndexWriteOp]) -> Result<(), BackendError> {
+        for op in ops {
+            match op {
+                IndexWriteOp::DeleteGsi {
+                    table_name,
+                    index_name,
+                    table_pk,
+                    table_sk,
+                } => {
+                    self.delete_gsi_item(table_name, index_name, table_pk, table_sk)
+                        .await?;
+                }
+                IndexWriteOp::InsertGsi {
+                    table_name,
+                    index_name,
+                    gsi_pk,
+                    gsi_sk,
+                    table_pk,
+                    table_sk,
+                    item_json,
+                } => {
+                    self.insert_gsi_item(
+                        table_name, index_name, gsi_pk, gsi_sk, table_pk, table_sk, item_json,
+                    )
+                    .await?;
+                }
+                IndexWriteOp::DeleteLsi {
+                    table_name,
+                    index_name,
+                    base_pk,
+                    base_sk,
+                } => {
+                    self.delete_lsi_item(table_name, index_name, base_pk, base_sk)
+                        .await?;
+                }
+                IndexWriteOp::InsertLsi {
+                    table_name,
+                    index_name,
+                    pk,
+                    sk,
+                    base_pk,
+                    base_sk,
+                    item_json,
+                } => {
+                    self.insert_lsi_item(
+                        table_name, index_name, pk, sk, base_pk, base_sk, item_json,
+                    )
+                    .await?;
+                }
+            }
+        }
+        Ok(())
+    }
 
     // -----------------------------------------------------------------------
     // Transactions

--- a/src/storage_backend/wasm_backend.rs
+++ b/src/storage_backend/wasm_backend.rs
@@ -37,7 +37,7 @@ use crate::storage::{
 };
 use crate::storage_backend::sql_builders::{self, SqlParam};
 use crate::storage_backend::{
-    BackendError, BaseItemRow, Clock, GsiItemRow, StorageBackend, SystemClock,
+    BackendError, BaseItemRow, Clock, GsiItemRow, IndexWriteOp, StorageBackend, SystemClock,
 };
 use crate::types::Tag;
 
@@ -65,6 +65,12 @@ extern "C" {
         handle: &JsValue,
         sql: &str,
         param_rows: js_sys::Array,
+    ) -> Result<JsValue, JsValue>;
+
+    #[wasm_bindgen(catch, js_name = "exec_script")]
+    async fn bridge_exec_script(
+        handle: &JsValue,
+        statements: js_sys::Array,
     ) -> Result<JsValue, JsValue>;
 
     #[wasm_bindgen(catch, js_name = "close")]
@@ -154,6 +160,20 @@ impl WasmBridgeBackend {
         Ok(())
     }
 
+    /// Run several distinct `(sql, params)` statements in order in a single
+    /// bridge crossing. Like [`exec_batch`](Self::exec_batch) it owns no
+    /// transaction: the caller's open transaction supplies atomicity, and a
+    /// mid-script failure (reported by the bridge with the failing statement
+    /// index) is rolled back by that caller. Collapses the per-index fan-out -
+    /// a delete and an insert per GSI/LSI - from one crossing per operation into
+    /// one crossing for the whole list.
+    async fn exec_script(&self, statements: js_sys::Array) -> Result<(), BackendError> {
+        bridge_exec_script(&self.handle, statements)
+            .await
+            .map_err(js_err)?;
+        Ok(())
+    }
+
     /// Run a query, returning rows as a JS array of column arrays.
     async fn query(
         &self,
@@ -201,6 +221,68 @@ fn params_rows_to_js(rows: &[Vec<SqlParam<'_>>]) -> js_sys::Array {
     let arr = js_sys::Array::new();
     for row in rows {
         arr.push(&params_to_js(row));
+    }
+    arr
+}
+
+/// Resolve one [`IndexWriteOp`] to the `(sql, params)` the wasm bridge runs for
+/// it, through the same shared [`sql_builders`] the per-item methods use. The
+/// returned `SqlParam`s borrow from `op`, so the value must outlive this pair.
+fn index_write_op_sql(op: &IndexWriteOp) -> (String, Vec<SqlParam<'_>>) {
+    match op {
+        IndexWriteOp::DeleteGsi {
+            table_name,
+            index_name,
+            table_pk,
+            table_sk,
+        } => sql_builders::delete_gsi_item(table_name, index_name, table_pk, table_sk),
+        IndexWriteOp::InsertGsi {
+            table_name,
+            index_name,
+            gsi_pk,
+            gsi_sk,
+            table_pk,
+            table_sk,
+            item_json,
+        } => (
+            sql_builders::gsi_insert_sql(table_name, index_name),
+            sql_builders::gsi_insert_params(gsi_pk, gsi_sk, table_pk, table_sk, item_json),
+        ),
+        IndexWriteOp::DeleteLsi {
+            table_name,
+            index_name,
+            base_pk,
+            base_sk,
+        } => sql_builders::delete_lsi_item(table_name, index_name, base_pk, base_sk),
+        IndexWriteOp::InsertLsi {
+            table_name,
+            index_name,
+            pk,
+            sk,
+            base_pk,
+            base_sk,
+            item_json,
+        } => (
+            sql_builders::lsi_insert_sql(table_name, index_name),
+            sql_builders::lsi_insert_params(pk, sk, base_pk, base_sk, item_json),
+        ),
+    }
+}
+
+/// Convert an index-write op list to the JS array of `{ sql, params }` objects
+/// `exec_script` runs in order. Unlike [`params_rows_to_js`] (positional arrays
+/// for one reused statement), each entry pairs its own SQL with its own params,
+/// since the fan-out is several different statements.
+fn params_scripts_to_js(ops: &[IndexWriteOp]) -> js_sys::Array {
+    let arr = js_sys::Array::new();
+    for op in ops {
+        let (sql, params) = index_write_op_sql(op);
+        let stmt = js_sys::Object::new();
+        js_sys::Reflect::set(&stmt, &JsValue::from_str("sql"), &JsValue::from_str(&sql))
+            .expect("Reflect::set on a fresh object cannot fail");
+        js_sys::Reflect::set(&stmt, &JsValue::from_str("params"), &params_to_js(&params))
+            .expect("Reflect::set on a fresh object cannot fail");
+        arr.push(&stmt);
     }
     arr
 }
@@ -641,6 +723,20 @@ impl StorageBackend for WasmBridgeBackend {
         let (sql, p) = sql_builders::scan_lsi_items(table_name, index_name, params);
         let rows = self.query(&sql, p).await?;
         Ok(rows_to_triples(&rows))
+    }
+
+    // --- Index write fan-out --------------------------------------------
+
+    /// Collapse the per-index fan-out into a single bridge crossing. The default
+    /// impl would replay each op through the per-item methods, one crossing
+    /// each; here the whole `(sql, params)` list crosses once as an ordered
+    /// `exec_script`. An empty list crosses zero times, exactly as the per-op
+    /// loop's empty iteration did, so a table with no indexes pays nothing.
+    async fn apply_index_writes(&self, ops: &[IndexWriteOp]) -> Result<(), BackendError> {
+        if ops.is_empty() {
+            return Ok(());
+        }
+        self.exec_script(params_scripts_to_js(ops)).await
     }
 
     // --- Transactions ----------------------------------------------------

--- a/tests/browser/engine.browser.spec.js
+++ b/tests/browser/engine.browser.spec.js
@@ -746,3 +746,106 @@ test("a GSI added to a populated table survives a reload (OPFS)", async ({ page 
   expect(reopened.mode).toBe("opfs");
   expect(reopened.count).toBe(1); // the backfilled index persisted across reload
 });
+
+test("an overwrite and a delete keep GSI and LSI in step with the fan-out batched over the bridge", async ({ page }) => {
+  // Each indexed write and delete maintains its GSI and LSI through one batched
+  // bridge crossing (apply_index_writes -> exec_script). This proves the batched
+  // delete-then-insert (overwrite) and the batched delete-only (delete) fan-outs
+  // are correct end to end on OPFS, not just in the Node bridge test.
+  const result = await page.evaluate(async () => {
+    const client = globalThis.dynoxide.makeClient({ name: `fanout-${crypto.randomUUID()}` });
+    await client.ready();
+    await client.execute("CreateTable", {
+      TableName: "Fanout",
+      KeySchema: [
+        { AttributeName: "pk", KeyType: "HASH" },
+        { AttributeName: "sk", KeyType: "RANGE" },
+      ],
+      AttributeDefinitions: [
+        { AttributeName: "pk", AttributeType: "S" },
+        { AttributeName: "sk", AttributeType: "S" },
+        { AttributeName: "gpk", AttributeType: "S" },
+        { AttributeName: "lsk", AttributeType: "S" },
+      ],
+      GlobalSecondaryIndexes: [
+        {
+          IndexName: "byG",
+          KeySchema: [{ AttributeName: "gpk", KeyType: "HASH" }],
+          Projection: { ProjectionType: "ALL" },
+        },
+      ],
+      LocalSecondaryIndexes: [
+        {
+          IndexName: "byL",
+          KeySchema: [
+            { AttributeName: "pk", KeyType: "HASH" },
+            { AttributeName: "lsk", KeyType: "RANGE" },
+          ],
+          Projection: { ProjectionType: "ALL" },
+        },
+      ],
+      BillingMode: "PAY_PER_REQUEST",
+    });
+
+    const put = (gpk, lsk) =>
+      client.execute("PutItem", {
+        TableName: "Fanout",
+        Item: { pk: { S: "p1" }, sk: { S: "s1" }, gpk: { S: gpk }, lsk: { S: lsk } },
+      });
+    const queryGsi = (gpk) =>
+      client.execute("Query", {
+        TableName: "Fanout",
+        IndexName: "byG",
+        KeyConditionExpression: "gpk = :g",
+        ExpressionAttributeValues: { ":g": { S: gpk } },
+      });
+    const queryLsi = () =>
+      client.execute("Query", {
+        TableName: "Fanout",
+        IndexName: "byL",
+        KeyConditionExpression: "pk = :p",
+        ExpressionAttributeValues: { ":p": { S: "p1" } },
+      });
+
+    await put("g1", "l1");
+    const g1Initial = (await queryGsi("g1")).Count;
+    const lsiInitial = (await queryLsi()).Items.map((i) => i.lsk.S);
+
+    // Overwrite with changed index keys: the batched delete-then-insert must
+    // drop the stale index entries and write the new ones in one crossing.
+    await put("g2", "l2");
+    const g1AfterOverwrite = (await queryGsi("g1")).Count;
+    const g2AfterOverwrite = (await queryGsi("g2")).Count;
+    const lsiAfterOverwrite = (await queryLsi()).Items.map((i) => i.lsk.S);
+
+    // Delete: the batched delete-only fan-out must clear both indexes.
+    await client.execute("DeleteItem", {
+      TableName: "Fanout",
+      Key: { pk: { S: "p1" }, sk: { S: "s1" } },
+    });
+    const g2AfterDelete = (await queryGsi("g2")).Count;
+    const lsiAfterDelete = (await queryLsi()).Count;
+
+    const out = {
+      mode: client.persistenceMode,
+      g1Initial,
+      lsiInitial,
+      g1AfterOverwrite,
+      g2AfterOverwrite,
+      lsiAfterOverwrite,
+      g2AfterDelete,
+      lsiAfterDelete,
+    };
+    client.terminate();
+    return out;
+  });
+
+  expect(result.mode).toBe("opfs");
+  expect(result.g1Initial).toBe(1); // the put landed in the GSI
+  expect(result.lsiInitial).toEqual(["l1"]); // and in the LSI
+  expect(result.g1AfterOverwrite).toBe(0); // stale GSI entry deleted in the batch
+  expect(result.g2AfterOverwrite).toBe(1); // new GSI entry inserted in the same batch
+  expect(result.lsiAfterOverwrite).toEqual(["l2"]); // LSI re-pointed, no stale row left
+  expect(result.g2AfterDelete).toBe(0); // delete-path fan-out cleared the GSI
+  expect(result.lsiAfterDelete).toBe(0); // and the LSI
+});


### PR DESCRIPTION
## What this changes

On the wasm backend, keeping a table's secondary indexes in step with a write is a delete and a re-insert per index, and each of those statements was its own crossing of the JS bridge - the dominant FFI cost on an indexed write. This batches the whole fan-out behind a new ordered-multi-statement bridge primitive, `exec_script`, so an indexed `PutItem` or `DeleteItem` on a table with K GSIs and L LSIs crosses the bridge a constant two times (one for the GSI batch, one for the LSI batch) instead of order K+L. A table with no indexes crosses zero extra times. Implements #85.

The change stays behind the storage abstraction rather than special-casing the wasm path. The maintenance helpers now build a backend-neutral ordered op list and hand it to one `StorageBackend::apply_index_writes` call; a default trait impl replays that list through the existing per-item methods, so native behaviour is byte-identical by construction, and only the wasm backend overrides it to issue the batch as a single `exec_script` crossing. Index contents are unchanged on both backends. Builds on the `exec_batch` backfill primitive from #71 and the official `@sqlite.org/sqlite-wasm` engine from #84.

## Checklist

- [x] Tests added or updated
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` pass locally
- [x] `CHANGELOG.md` updated if this is a user-visible change
- [x] Linked issue, discussion, or a short note explaining the motivation

## DynamoDB compatibility note

Not applicable. This is a performance change; index contents and observable behaviour relative to AWS DynamoDB are unchanged on both backends.
