### PR TITLE
docs: README limitations, conformance links, and trademark notice

### DIFF
--- a/.kos
+++ b/.kos
@@ -1,0 +1,1 @@
+product: dynoxide

--- a/NOTICE
+++ b/NOTICE
@@ -3,3 +3,8 @@ Copyright 2025-2026 Martin Hicks (https://martinhicks.dev)
 
 Licensed under the Apache License, Version 2.0 and the MIT License.
 See LICENSE-APACHE and LICENSE-MIT for details.
+
+DynamoDB and AWS are trademarks of Amazon.com, Inc. or its affiliates. This
+software is an independent project and is not affiliated with, endorsed by, or
+sponsored by Amazon. The licence does not grant permission to use those trade
+names, trademarks, service marks, or product names.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,20 @@ Point any AWS SDK or DynamoDB client at `http://localhost:8000`. For Homebrew, C
 
 Dynoxide implements the DynamoDB API across tables, items, query and scan, batches, transactions, PartiQL, streams, TTL, and tags, with GSI and LSI support, the full expression syntax, and DynamoDB-compatible pagination, validation, and error codes. For the operation-by-operation breakdown and a comparison with DynamoDB Local, see the [compatibility summary](https://github.com/nubo-db/dynoxide/blob/main/docs/compatibility-summary.md).
 
+## Limitations
+
+Dynoxide is built for local development, testing, and CI, not as a production DynamoDB replacement, so two classes of thing are missing on purpose.
+
+Cloud-only operations with no local equivalent aren't implemented: backups and point-in-time restore, global tables, Kinesis streaming, resource policies, and capacity management. Call one and you get an `UnknownOperationException`.
+
+A few behavioural differences are also worth knowing when you test against it:
+
+- `ConsistentRead` is accepted but changes nothing. SQLite is strongly consistent, so every read already is - you can't reproduce eventually-consistent reads.
+- Streams expose a single shard. `DescribeStream` returns one shard, and its `ExclusiveStartShardId` and `Limit` paging parameters are accepted but ignored.
+- Transaction-contention errors (`TransactionConflictException`, `TransactionInProgressException`) aren't emulated - there's no concurrent contention in a single process.
+
+For the live, per-feature support matrix across every emulator see [paritysuite.org/capabilities](https://paritysuite.org/capabilities), and the full operation-by-operation breakdown is in the [compatibility summary](https://github.com/nubo-db/dynoxide/blob/main/docs/compatibility-summary.md).
+
 ## Acknowledgements
 
 Dynoxide's DynamoDB API semantics and validation logic were informed by [dynalite](https://github.com/architect/dynalite), the excellent DynamoDB emulator built on LevelDB by Michael Hart and now maintained by the Architect team.

--- a/README.md
+++ b/README.md
@@ -120,3 +120,7 @@ Dynoxide uses SQLite as its storage layer. (AWS's [DynamoDB Local](https://docs.
 ## License
 
 Dual-licensed under MIT and Apache 2.0. See [LICENSE-MIT](LICENSE-MIT) and [LICENSE-APACHE](LICENSE-APACHE).
+
+## Trademarks
+
+Amazon DynamoDB, DynamoDB, and AWS are trademarks of Amazon.com, Inc. or its affiliates. Dynoxide is an independent project and is not affiliated with, endorsed by, or sponsored by Amazon, and nothing here grants any right to use those names or marks.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Point any AWS SDK or DynamoDB client at `http://localhost:8000`. For Homebrew, C
 
 ## Supported Operations
 
-Dynoxide implements the DynamoDB API across tables, items, query and scan, batches, transactions, PartiQL, streams, TTL, and tags, with GSI and LSI support, the full expression syntax, and DynamoDB-compatible pagination, validation, and error codes. For the operation-by-operation breakdown and a comparison with DynamoDB Local, see the [compatibility summary](https://github.com/nubo-db/dynoxide/blob/main/docs/compatibility-summary.md).
+Dynoxide implements the DynamoDB API across tables, items, query and scan, batches, transactions, PartiQL, streams, TTL, and tags, with GSI and LSI support, the full expression syntax, and DynamoDB-compatible pagination, validation, and error codes. For the operation-by-operation breakdown and a comparison, see the [compatibility summary](https://github.com/nubo-db/dynoxide/blob/main/docs/compatibility-summary.md).
 
 ## Limitations
 
@@ -107,7 +107,7 @@ A few behavioural differences are also worth knowing when you test against it:
 - Streams expose a single shard. `DescribeStream` returns one shard, and its `ExclusiveStartShardId` and `Limit` paging parameters are accepted but ignored.
 - Transaction-contention errors (`TransactionConflictException`, `TransactionInProgressException`) aren't emulated - there's no concurrent contention in a single process.
 
-For the live, per-feature support matrix across every emulator see [paritysuite.org/capabilities](https://paritysuite.org/capabilities), and the full operation-by-operation breakdown is in the [compatibility summary](https://github.com/nubo-db/dynoxide/blob/main/docs/compatibility-summary.md).
+For the live, per-feature support matrix see [paritysuite.org/capabilities](https://paritysuite.org/capabilities), and the full operation-by-operation breakdown is in the [compatibility summary](https://github.com/nubo-db/dynoxide/blob/main/docs/compatibility-summary.md).
 
 ## Acknowledgements
 

--- a/docs/compatibility-summary.md
+++ b/docs/compatibility-summary.md
@@ -6,35 +6,33 @@ Dynoxide is an embeddable DynamoDB emulator backed by SQLite. It is designed for
 
 **Consistency model:** SQLite provides strong consistency. `ConsistentRead` is accepted but has no effect - all reads are strongly consistent.
 
-> **Updated:** 2026-03-24 · Reflects current behaviour, validated by the conformance suite.
+> Behaviour validated by the [conformance suite](https://github.com/nubo-db/dynamodb-conformance). Pass rates move as the suite grows, so this page links to the [live results](https://paritysuite.org) rather than pinning a snapshot.
 
 ---
 
 ## Conformance
 
 Dynoxide's DynamoDB compatibility is independently verified by the
-[dynamodb-conformance](https://github.com/nubo-db/dynamodb-conformance) test
-suite - 526 tests across 3 tiers, validated against real DynamoDB ground truth.
+[dynamodb-conformance](https://github.com/nubo-db/dynamodb-conformance) suite,
+which runs one test matrix against real DynamoDB and every major emulator across
+three tiers:
 
-| Target | Tier 1 (Core) | Tier 2 (Complete) | Tier 3 (Strict) | Total |
-|---|---|---|---|---|
-| DynamoDB | 100% | 100% | 100% | 100% (526/526) |
-| **Dynoxide** | **100%** | **100%** | **100%** | **100% (526/526)** |
-| DynamoDB Local | 98.9% (264/267) | 90.3% (84/93) | 81.9% (136/166) | 92.0% (484/526) |
+- **Tier 1 (Core)** - CRUD, queries, scans, batch operations, GSIs, and UpdateTable
+- **Tier 2 (Complete)** - transactions, PartiQL, LSIs, streams, TTL, and tags
+- **Tier 3 (Strict)** - validation ordering, error-message fidelity, reserved
+  words, legacy-API handling, and edge cases
 
-Tier 1 covers core CRUD, queries, scans, batch operations, and GSIs. Tier 2
-adds transactions, PartiQL, streams, TTL, tags, and UpdateTable. Tier 3 covers
-validation ordering, error message fidelity, reserved words, and edge cases.
+Pass rates move as the suite grows and each engine changes, so rather than pin a
+snapshot that goes stale, the current standings are published live:
 
-"100% conformance on 526 tests" means Dynoxide matches real DynamoDB behaviour
-for every test in the suite. It does not mean "100% DynamoDB compatible" - there
-are aspects of DynamoDB the suite does not yet cover.
+- **[paritysuite.org](https://paritysuite.org)** - pass rates for every engine, broken down by tier
+- **[paritysuite.org/capabilities](https://paritysuite.org/capabilities)** - the feature-by-feature support matrix
+- **[nubo-db/dynamodb-conformance](https://github.com/nubo-db/dynamodb-conformance#results)** - the suite, the raw results, and how each target is run
 
-**How Dynoxide compares to DynamoDB Local:** DynamoDB Local is itself a subset of
-the full DynamoDB API - it fails 42 of the 526 conformance tests that real
-DynamoDB passes. Where a feature is unsupported in both, it is marked as such.
-Where Dynoxide supports something DynamoDB Local does not, this is noted
-explicitly.
+A high conformance score means Dynoxide matches real DynamoDB behaviour for the
+tests in the suite. It does not mean "100% DynamoDB compatible" - there are
+aspects of DynamoDB the suite does not yet cover, and the limitations below are
+the ones worth knowing.
 
 ---
 
@@ -144,7 +142,7 @@ Parameter placeholders (`?`) supported in all positions including nested list/ma
 
 ### Conformance advantages
 
-DynamoDB Local fails 42 of 526 conformance tests. Grouped by category:
+DynamoDB Local fails a sizeable share of the suite that real DynamoDB passes; the current count is on the [live results](https://paritysuite.org). The gaps cluster in a few categories (figures from a representative run):
 
 | Category | Failures | Details |
 |---|---|---|


### PR DESCRIPTION
Adds a Limitations section and live conformance links to the README, and records the DynamoDB trademark and non-affiliation notice in both NOTICE and the README.