### PR TITLE
Prepare 0.11.0 release: worker minify + engine preview-track publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,11 +156,16 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
-      # Build the same self-contained bundle a consumer installs. The dev
-      # profile is functionally identical to release - it just skips wasm-opt -
-      # so it gates behaviour without the optimiser's cost on every PR.
+      # Build the same self-contained bundle a consumer installs, on the release
+      # profile, so the full --minify path (renamed identifiers, the worker that
+      # actually ships) is exercised against real Chromium + OPFS on every PR -
+      # not only at publish time and in a manual run. This build also runs the
+      # harness-op strip guard (build-wasm.sh step 2b) against the minified
+      # output. The wasm-opt cost is the price of testing what ships; the dev
+      # profile (build:wasm:dev) only minifies syntax and would leave the
+      # identifier-renaming transform unverified.
       - name: Build the wasm bundle
-        run: npm run build:wasm:dev
+        run: npm run build:wasm
 
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -71,10 +71,16 @@ jobs:
             --release-url "https://github.com/nubo-db/dynoxide/releases/download/$PUBLISH_TAG"
 
   # The browser engine package (@nubo-db/dynoxide-engine) is built from source
-  # here, since wasm is architecture-independent. Published via OIDC trusted
-  # publishing (no token), so its trusted publisher must be configured on
-  # npmjs.com first; the very first publish is bootstrapped manually, and the
-  # idempotent guard below then skips that already-published version.
+  # here, since wasm is architecture-independent. It rides its own preview track:
+  # the wasm path is not conformance-tested, so it publishes as <crate>-preview to
+  # the `preview` dist-tag, decoupled from the crate's stable version, and never
+  # lands on `latest`. Published via OIDC trusted publishing (no token), so its
+  # trusted publisher must be configured on npmjs.com first; the very first publish
+  # is bootstrapped manually, and the idempotent guard below then skips that
+  # already-published version. This job runs independently of the native `publish`
+  # job (no `needs:`): the engine and CLI packages are separate artefacts, each
+  # guarded by its own idempotent skip, so one failing neither blocks nor rolls
+  # back the other - a re-dispatch re-publishes only what is still missing.
   publish-engine:
     name: Publish @nubo-db/dynoxide-engine
     runs-on: ubuntu-latest
@@ -118,17 +124,34 @@ jobs:
             echo "::error::Invalid tag format: $TAG (expected vX.Y.Z)"
             exit 1
           fi
-          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+          VERSION="${TAG#v}"
+          # The engine rides its own preview track, versioned independently of the
+          # crate: it always ships as <crate-base>-preview, never a plain stable
+          # version. BASE strips any prerelease suffix off the tag, so a stable
+          # v0.11.0 tag yields an engine version of 0.11.0-preview.
+          BASE="${VERSION%%-*}"
+          # Defence in depth: the tag regex above already guarantees a non-empty
+          # version, but assert it before these values reach the skip check and the
+          # publish. An empty engine version would make the `npm view ...@` probe
+          # match the whole package and silently skip the publish.
+          if [ -z "$VERSION" ] || [ -z "$BASE" ]; then
+            echo "::error::could not derive a version from tag '$TAG'"
+            exit 1
+          fi
+          {
+            echo "version=$VERSION"
+            echo "engine_version=${BASE}-preview"
+          } >> "$GITHUB_OUTPUT"
 
       # Idempotent: skip if this version is already on npm (the manual bootstrap
       # publish, or a re-run) rather than fail on a duplicate.
       - name: Skip if this version is already published
         id: published
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          ENGINE_VERSION: ${{ steps.version.outputs.engine_version }}
         run: |
-          if npm view "@nubo-db/dynoxide-engine@$VERSION" version >/dev/null 2>&1; then
-            echo "::notice::@nubo-db/dynoxide-engine@$VERSION already published; skipping."
+          if npm view "@nubo-db/dynoxide-engine@$ENGINE_VERSION" version >/dev/null 2>&1; then
+            echo "::notice::@nubo-db/dynoxide-engine@$ENGINE_VERSION already published; skipping."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
@@ -146,42 +169,41 @@ jobs:
         if: steps.published.outputs.skip == 'false'
         working-directory: npm/dynoxide-engine
         env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: npm version "$VERSION" --no-git-tag-version --allow-same-version
+          ENGINE_VERSION: ${{ steps.version.outputs.engine_version }}
+        run: npm version "$ENGINE_VERSION" --no-git-tag-version --allow-same-version
 
       - name: Verify the engine version matches the release
         if: steps.published.outputs.skip == 'false'
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          # build-wasm.sh stamps manifest.engineVersion from Cargo.toml, so a
-          # mismatch means Cargo.toml was not bumped to the release version.
+          # build-wasm.sh stamps manifest.engineVersion from Cargo.toml verbatim,
+          # which release.yml validate has already pinned to the full tag version,
+          # so the manifest must equal VERSION. A mismatch means Cargo.toml was not
+          # bumped to the release version. The published package layers the -preview
+          # suffix on top of this (see the stamp step); the manifest tracks the
+          # crate version, which is what this guards.
           MANIFEST_VERSION=$(node -p "require('./npm/dynoxide-engine/manifest.json').engineVersion")
           if [ "$MANIFEST_VERSION" != "$VERSION" ]; then
             echo "::error::engine manifest version ($MANIFEST_VERSION) != release version ($VERSION); is Cargo.toml bumped to $VERSION?"
             exit 1
           fi
 
-      - name: Choose dist-tag
-        if: steps.published.outputs.skip == 'false'
-        id: disttag
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          # A prerelease (e.g. 0.10.1-pre.1) goes to `next` so it never clobbers
-          # `latest`; a normal version goes to `latest`.
-          if [[ "$VERSION" == *-* ]]; then
-            echo "tag=next" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=latest" >> "$GITHUB_OUTPUT"
-          fi
-
+      # The engine always publishes to the `preview` dist-tag, never `latest`, so
+      # `npm install @nubo-db/dynoxide-engine` (which resolves `latest`) never
+      # picks up the preview build by default; consumers opt in with
+      # `@nubo-db/dynoxide-engine@preview`. When the wasm path graduates from
+      # preview (conformance-tested): drop the `-preview` suffix in "Determine
+      # version", switch `--tag preview` below to `--tag latest`, and once the
+      # stable version is on `latest`, run `npm deprecate
+      # @nubo-db/dynoxide-engine@"<x.y.z-preview>" "superseded by the stable release"`
+      # so pinned preview consumers get a deprecation nudge.
       - name: Publish (dry-run)
         if: steps.published.outputs.skip == 'false'
         working-directory: npm/dynoxide-engine
-        run: npm publish --dry-run --access public --provenance --tag "${{ steps.disttag.outputs.tag }}"
+        run: npm publish --dry-run --access public --provenance --tag preview
 
       - name: Publish to npm
         if: steps.published.outputs.skip == 'false'
         working-directory: npm/dynoxide-engine
-        run: npm publish --access public --provenance --tag "${{ steps.disttag.outputs.tag }}"
+        run: npm publish --access public --provenance --tag preview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-06-24
+
 ### Added
 
 - `UpdateTable` on the wasm preview engine: add or delete a global secondary index, with existing rows backfilled into a newly added index, and change the simple table settings (provisioned throughput, billing mode, table class, on-demand throughput, deletion protection). A stream-specification change through `UpdateTable` stays unsupported, since streams remain a preview gap, and a newly added GSI is reported immediately `ACTIVE` rather than transitioning through `CREATING`.
@@ -358,3 +360,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ReturnConsumedCapacity (TOTAL and INDEXES modes)
 - HTTP server (axum-based, DynamoDB JSON wire protocol)
 - 300+ tests
+
+[Unreleased]: https://github.com/nubo-db/dynoxide/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/nubo-db/dynoxide/compare/v0.10.0...v0.11.0
+[0.10.0]: https://github.com/nubo-db/dynoxide/compare/v0.9.13...v0.10.0
+[0.9.13]: https://github.com/nubo-db/dynoxide/compare/v0.9.12...v0.9.13
+[0.9.12]: https://github.com/nubo-db/dynoxide/compare/v0.9.11...v0.9.12
+[0.9.11]: https://github.com/nubo-db/dynoxide/compare/v0.9.10...v0.9.11
+[0.9.10]: https://github.com/nubo-db/dynoxide/compare/v0.9.9...v0.9.10
+[0.9.9]: https://github.com/nubo-db/dynoxide/compare/v0.9.8...v0.9.9
+[0.9.8]: https://github.com/nubo-db/dynoxide/compare/v0.9.7...v0.9.8
+[0.9.7]: https://github.com/nubo-db/dynoxide/compare/v0.9.6...v0.9.7
+[0.9.6]: https://github.com/nubo-db/dynoxide/compare/v0.9.5...v0.9.6
+[0.9.5]: https://github.com/nubo-db/dynoxide/releases/tag/v0.9.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,7 +974,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "dynoxide-rs"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-lock",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dynoxide-rs"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 description = "A lightweight, embeddable DynamoDB emulator backed by SQLite"
 license = "MIT OR Apache-2.0"

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -39,12 +39,12 @@ npm run build:wasm
 
 | File | Size | What |
 |---|---|---|
-| `dynoxide_bg.wasm` | ~960 KB | the engine (release, wasm-opt) |
+| `dynoxide_bg.wasm` | ~1.0 MB | the engine (release, wasm-opt) |
 | `sqlite3.wasm` | ~845 KB | SQLite (the official @sqlite.org/sqlite-wasm build) |
-| `dynoxide-worker.js` | ~415 KB | the bundled Web Worker (engine glue + bridge) |
+| `dynoxide-worker.js` | ~225 KB | the bundled Web Worker (engine glue + bridge, fully minified) |
 | `manifest.json` | <1 KB | engine version, contract version, file list |
 
-About 2.2 MB total. Not tiny, but the `.wasm` files are immutable and cache well, and the SAHPool VFS is synchronous, so the engine needs neither the larger Asyncify async build nor `SharedArrayBuffer`.
+About 2.1 MB raw, but that's not the number that reaches a browser. The `.wasm` and the Worker JS all compress well, so served with gzip it's around 860 KB over the wire, and brotli takes it lower again - turn one of them on at the host (most CDNs do by default). The `.wasm` files are immutable, so they cache hard after the first load, and the SAHPool VFS is synchronous, so the engine needs neither the larger Asyncify async build nor `SharedArrayBuffer`.
 
 Drop `dist/` on any origin that's a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) - HTTPS in production, or `localhost` for development. OPFS needs a secure context, but **no COOP/COEP headers and no cross-origin isolation**, so plain static hosting works. (SQLite in the browser usually needs cross-origin isolation, because the common technique makes an async storage API look synchronous via `SharedArrayBuffer`. Dynoxide avoids that by running the official synchronous OPFS SAHPool VFS inside a Worker, where synchronous file handles are available directly.) One header does matter: if you set a Content-Security-Policy it must allow `'wasm-unsafe-eval'`, or the engine won't instantiate. Serve the `.wasm` as `application/wasm` while you're at it.
 
@@ -92,5 +92,5 @@ const { Items } = await client.execute("Query", { /* ... */ });
 
 `new EngineClient()` with no arguments resolves the Worker next to the package, and the Worker resolves the `.wasm` next to itself, so a bundler that copies the package's files - or a plain static deploy of them - needs no configuration. Serving the assets from a CDN or another origin? Pass `assetBase` (the directory they sit in) or `workerUrl` (the exact Worker URL).
 
-The package also exports `EngineError` (the typed rejection, carrying the engine's `__type` on `.type`) and `CONTRACT_VERSION`. The client checks that version against the engine on boot and fails loudly on a mismatch, so a pinned consumer never mis-reads a newer engine. Hosting matches `dist/`: a secure context, no COOP/COEP, a CSP that allows `'wasm-unsafe-eval'`, and `.wasm` served as `application/wasm`. It's a preview, like the rest of the wasm build.
+The package also exports `EngineError` (the typed rejection, carrying the engine's `__type` on `.type`) and `CONTRACT_VERSION`. The client checks that version against the engine on boot and fails loudly on a mismatch, so a pinned consumer never mis-reads a newer engine. Hosting matches `dist/`: a secure context, no COOP/COEP, a CSP that allows `'wasm-unsafe-eval'`, and `.wasm` served as `application/wasm`. It's a preview, like the rest of the wasm build, so it's published only under the npm `preview` dist-tag: install it with `npm install @nubo-db/dynoxide-engine@preview` (a bare install resolves `latest`, which is intentionally unset).
 

--- a/npm/dynoxide-engine/README.md
+++ b/npm/dynoxide-engine/README.md
@@ -7,8 +7,10 @@ It's a preview. The wasm build is not run against the conformance suite that bac
 ## Install
 
 ```bash
-npm install @nubo-db/dynoxide-engine
+npm install @nubo-db/dynoxide-engine@preview
 ```
+
+The `@preview` is required. This is a preview build, published only under the `preview` dist-tag, so a bare `npm install @nubo-db/dynoxide-engine` resolves `latest`, which is intentionally unset, and a `^0.11.0-preview` range won't track it either. Pin the exact version or use the `@preview` tag.
 
 ## Quick start
 
@@ -78,11 +80,11 @@ Two clients on one page are fine: each gets its own storage pool, keyed on `name
 
 ## Hosting
 
-The engine needs a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) (HTTPS, or `localhost` for development) for OPFS, but **no COOP/COEP cross-origin isolation**. A Content-Security-Policy must allow `'wasm-unsafe-eval'`, or the engine won't instantiate. Serve the `.wasm` as `application/wasm`.
+The engine needs a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) (HTTPS, or `localhost` for development) for OPFS, but **no COOP/COEP cross-origin isolation**. A Content-Security-Policy must allow `'wasm-unsafe-eval'`, or the engine won't instantiate. Serve the `.wasm` as `application/wasm`, and serve the assets gzip- or brotli-encoded - the wasm and the Worker both more than halve over the wire.
 
 ## Versioning
 
-`CONTRACT_VERSION` stamps the message-envelope shape, not the engine version. Adding an operation leaves it alone; changing a request, response, or error envelope bumps it. The client validates it against the engine on boot and fails loudly on a mismatch, so a pinned consumer fails with a clear error rather than mis-reading a newer engine. The shipped engine and contract versions sit in `manifest.json`.
+`CONTRACT_VERSION` stamps the message-envelope shape, not the engine version. Adding an operation leaves it alone; changing a request, response, or error envelope bumps it. The client validates it against the engine on boot and fails loudly on a mismatch, so a pinned consumer fails with a clear error rather than mis-reading a newer engine. The shipped engine and contract versions sit in `manifest.json`. `manifest.engineVersion` is the dynoxide crate version (e.g. `0.11.0`); the npm package version layers a `-preview` suffix on top (e.g. `0.11.0-preview`), since the package is a preview distribution of that crate version.
 
 ## Persistence
 

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -63,19 +63,28 @@ done
 #    and resolves the official engine's bare specifier from node_modules. The two
 #    `new URL("*.wasm", import.meta.url)` references stay as runtime URLs that
 #    resolve next to the bundle, so the .wasm files ship as siblings.
-#    The --define folds __DYNOXIDE_HARNESS__ to a literal and --minify-syntax
-#    dead-code-eliminates the resulting `if (false)` block, so the shipping build
-#    drops the smoke/index/errors ops while the harness build keeps them. The
-#    define alone substitutes but does not remove the dead branch; --minify-syntax
-#    leaves identifiers and whitespace intact, so it is not a full minify.
+#    The --define folds __DYNOXIDE_HARNESS__ to a literal so the guarded block
+#    becomes `if (false)`; the minifier then dead-code-eliminates it, so the
+#    shipping build drops the smoke/index/errors ops while the harness build
+#    keeps them. The shipping build (release + wasm-sqlite) uses a full --minify:
+#    it renames local identifiers and strips whitespace, roughly halving the
+#    worker's raw size and trimming the gzipped transfer. Dev and any harness
+#    build stay on --minify-syntax, which still folds the dead branch but leaves
+#    identifiers intact, so those bundles stay readable and the harness-op guard
+#    below can still match op names by identifier.
 #    log-override silences the import-is-undefined note from the bracket access to
 #    the harness-only exports.
+if [ "$profile" = "release" ] && [ "$feature" = "wasm-sqlite" ]; then
+  minify_flag="--minify"
+else
+  minify_flag="--minify-syntax"
+fi
 rm -rf dist
 npx esbuild js/dynoxide-worker.js \
   --bundle \
   --format=esm \
   "--define:__DYNOXIDE_HARNESS__=$harness_define" \
-  --minify-syntax \
+  "$minify_flag" \
   --log-override:import-is-undefined=silent \
   --outfile=dist/dynoxide-worker.js
 


### PR DESCRIPTION
## What this changes

Release prep for 0.11.0, in three focused commits:

- **`perf(wasm)`** the shipping wasm Worker bundle is now fully minified (release build only); dev and harness builds stay on `--minify-syntax`. Roughly halves the Worker's raw size and trims the gzipped transfer.
- **`ci(wasm)`** `@nubo-db/dynoxide-engine` will publish as `<crate-base>-preview` on the `preview` npm dist-tag, decoupled from the stable crate version, since the wasm path is not run against the conformance suite yet. It never lands on `latest`; consumers opt in with `@preview`.
- **`chore`** version bumped to 0.11.0, changelog promoted.

No runtime behaviour change.

## Checklist

- [x] Tests added or updated. No new test cases, but the `browser-engine` CI job now builds the **release** bundle, so the existing Playwright suite exercises the minified, identifier-renamed Worker that actually ships on every PR (it previously ran against the dev bundle).
- ~~`cargo fmt --check` and `cargo clippy -- -D warnings` pass locally~~ (N/A: no Rust source changed, version bump only)
- [x] `CHANGELOG.md` updated: `[Unreleased]` promoted to `## [0.11.0]`, plus a Keep a Changelog comparison-link footer for the tagged range.
- [x] Linked issue, discussion, or a short note explaining the motivation (below).

**Motivation:** 0.11.0 collects the wasm engine work (`UpdateTable`, the official `@sqlite.org/sqlite-wasm` migration, the batched index fan-out, the new engine package) and a run of native fidelity fixes. The minify is a size win on the shipping Worker; the preview-track publishing keeps the unverified wasm engine off `latest` so it cannot be installed by accident.
