### PR TITLE
fix: map/list equality in conditions, plus expression-value nesting and number-set precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A `ConditionExpression` comparing a Map (`M`) or List (`L`) attribute for equality now works, where `=` always reported not-equal and `<>` always equal regardless of the values. `compare_values` had no arm for document types, so every map or list comparison fell through to the not-equal default; it now compares them deeply - maps order-independently, lists element-wise in order - with nested numbers normalised as elsewhere. The same path backs `IN`, `BETWEEN`, and `contains` over document operands, so those are fixed too ([#103](https://github.com/nubo-db/dynoxide/issues/103)).
+- `ExpressionAttributeValues` nested beyond DynamoDB's 32-level document limit are now rejected up front with the same `ValidationException` AWS returns, where before they were accepted and evaluated. The check runs on every path that takes expression values - PutItem, UpdateItem, DeleteItem, Query, Scan, and TransactWriteItems. The stored-item nesting check was also one level too lenient (it accepted a value AWS rejects) and carried a non-AWS message; both now match DynamoDB's limit and wording, confirmed against real AWS in eu-west-2 ([#110](https://github.com/nubo-db/dynoxide/issues/110)).
+- Number-set equality in a condition or filter expression now compares at full precision, where it parsed each member to `f64` and so reported two sets differing only beyond ~15 significant digits as equal. It now uses the canonical numeric form, matching DynamoDB and the way number-set duplicates are already detected on write; the fix also covers number sets nested inside a map or list ([#111](https://github.com/nubo-db/dynoxide/issues/111)).
+
 ## [0.11.0] - 2026-06-24
 
 ### Added

--- a/src/actions/helpers.rs
+++ b/src/actions/helpers.rs
@@ -741,6 +741,9 @@ pub fn validate_expression_params(
 
 /// Validate a single ExpressionAttributeValues entry.
 fn validate_expression_attribute_value(key: &str, value: &AttributeValue) -> Result<()> {
+    // Over-deep expression values are rejected up front, before evaluation, with the
+    // bare nesting message real DynamoDB uses (no "contains invalid value" wrapper).
+    crate::validation::validate_nesting_depth(value)?;
     // Check for empty/unsupported datatypes
     match value {
         AttributeValue::NULL(b) if !b => {

--- a/src/actions/transact_write_items.rs
+++ b/src/actions/transact_write_items.rs
@@ -273,6 +273,18 @@ async fn execute_single_action<S: StorageBackend>(
     }
 }
 
+/// Reject any ExpressionAttributeValue that nests deeper than DynamoDB allows.
+/// TransactWriteItems does not route through the shared expression-param helper, so
+/// the per-value nesting check is applied here for each sub-action's values.
+fn validate_eav_nesting(values: &Option<HashMap<String, AttributeValue>>) -> Result<()> {
+    if let Some(map) = values {
+        for value in map.values() {
+            crate::validation::validate_nesting_depth(value)?;
+        }
+    }
+    Ok(())
+}
+
 async fn execute_put<S: StorageBackend>(storage: &S, put: &TransactPut) -> Result<()> {
     crate::validation::validate_table_name(&put.table_name)?;
     let meta = helpers::require_table_for_item_op(storage, &put.table_name).await?;
@@ -294,6 +306,8 @@ async fn execute_put<S: StorageBackend>(storage: &S, put: &TransactPut) -> Resul
 
     // TODO: validation must precede this call -- if reaching this line, caller has already validated keys.
     let (pk, sk) = helpers::extract_key_strings(&item, &key_schema)?;
+
+    validate_eav_nesting(&put.expression_attribute_values)?;
 
     let tracker = crate::expressions::TrackedExpressionAttributes::new(
         &put.expression_attribute_names,
@@ -383,6 +397,8 @@ async fn execute_update<S: StorageBackend>(storage: &S, update: &TransactUpdate)
         .as_ref()
         .and_then(|j| serde_json::from_str(j).ok())
         .unwrap_or_default();
+
+    validate_eav_nesting(&update.expression_attribute_values)?;
 
     let tracker = crate::expressions::TrackedExpressionAttributes::new(
         &update.expression_attribute_names,
@@ -500,6 +516,8 @@ async fn execute_delete<S: StorageBackend>(storage: &S, delete: &TransactDelete)
     // TODO: validation must precede this call -- if reaching this line, caller has already validated keys.
     let (pk, sk) = helpers::extract_key_strings(&delete.key, &key_schema)?;
 
+    validate_eav_nesting(&delete.expression_attribute_values)?;
+
     let tracker = crate::expressions::TrackedExpressionAttributes::new(
         &delete.expression_attribute_names,
         &delete.expression_attribute_values,
@@ -564,6 +582,8 @@ async fn execute_condition_check<S: StorageBackend>(
         .as_ref()
         .and_then(|j| serde_json::from_str(j).ok())
         .unwrap_or_default();
+
+    validate_eav_nesting(&check.expression_attribute_values)?;
 
     let tracker = crate::expressions::TrackedExpressionAttributes::new(
         &check.expression_attribute_names,

--- a/src/expressions/condition.rs
+++ b/src/expressions/condition.rs
@@ -645,6 +645,36 @@ fn compare_values(left: &AttributeValue, op: &CompOp, right: &AttributeValue) ->
             }
         }
 
+        // List: element-wise deep equality, order-sensitive. Recurses so nested
+        // numbers and documents use the same comparison semantics as scalars.
+        // DynamoDB only allows = and <> on documents, not ordering.
+        (AttributeValue::L(a), AttributeValue::L(b)) => {
+            let equal = a.len() == b.len()
+                && a.iter()
+                    .zip(b.iter())
+                    .all(|(x, y)| compare_values(x, &CompOp::Eq, y));
+            match op {
+                CompOp::Eq => equal,
+                CompOp::Ne => !equal,
+                _ => false,
+            }
+        }
+
+        // Map: key-set plus per-key deep equality, order-independent. Recurses so
+        // nested numbers normalise (1 == 1.0) and nested documents compare deeply.
+        (AttributeValue::M(a), AttributeValue::M(b)) => {
+            let equal = a.len() == b.len()
+                && a.iter().all(|(k, av)| {
+                    b.get(k)
+                        .is_some_and(|bv| compare_values(av, &CompOp::Eq, bv))
+                });
+            match op {
+                CompOp::Eq => equal,
+                CompOp::Ne => !equal,
+                _ => false,
+            }
+        }
+
         // Different types — only <> is true
         _ => matches!(op, CompOp::Ne),
     }
@@ -1405,5 +1435,300 @@ mod tests {
                 expected
             );
         }
+    }
+
+    fn map_of(pairs: &[(&str, AttributeValue)]) -> AttributeValue {
+        AttributeValue::M(
+            pairs
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.clone()))
+                .collect(),
+        )
+    }
+
+    // #103: equality on Map (M) attributes always returned false because
+    // compare_values lacked an arm for M, falling through to the catch-all.
+    #[test]
+    fn test_map_equality_true() {
+        let expr = parse("#s = :p").unwrap();
+        let item = make_item(&[(
+            "Status",
+            map_of(&[("Union_Case", AttributeValue::S("Passive".into()))]),
+        )]);
+        let an = names(&[("#s", "Status")]);
+        let av = vals(&[(
+            ":p",
+            map_of(&[("Union_Case", AttributeValue::S("Passive".into()))]),
+        )]);
+        assert!(evaluate_without_tracking(&expr, &item, &an, &av).unwrap());
+    }
+
+    #[test]
+    fn test_map_equality_false_and_ne_true() {
+        let item = make_item(&[(
+            "Status",
+            map_of(&[("Union_Case", AttributeValue::S("Passive".into()))]),
+        )]);
+        let an = names(&[("#s", "Status")]);
+        let av = vals(&[(
+            ":p",
+            map_of(&[("Union_Case", AttributeValue::S("Active".into()))]),
+        )]);
+
+        let eq = parse("#s = :p").unwrap();
+        assert!(!evaluate_without_tracking(&eq, &item, &an, &av).unwrap());
+
+        let ne = parse("#s <> :p").unwrap();
+        assert!(evaluate_without_tracking(&ne, &item, &an, &av).unwrap());
+    }
+
+    #[test]
+    fn test_map_equality_is_key_order_independent() {
+        let item = make_item(&[(
+            "m",
+            map_of(&[
+                ("a", AttributeValue::S("1".into())),
+                ("b", AttributeValue::S("2".into())),
+            ]),
+        )]);
+        // Same entries, constructed in the opposite order.
+        let av = vals(&[(
+            ":p",
+            map_of(&[
+                ("b", AttributeValue::S("2".into())),
+                ("a", AttributeValue::S("1".into())),
+            ]),
+        )]);
+        let expr = parse("m = :p").unwrap();
+        assert!(evaluate_without_tracking(&expr, &item, &None, &av).unwrap());
+    }
+
+    #[test]
+    fn test_map_equality_differing_key_sets() {
+        // Same size, different keys: must not be equal.
+        let item = make_item(&[("m", map_of(&[("a", AttributeValue::N("1".into()))]))]);
+        let av = vals(&[(":p", map_of(&[("b", AttributeValue::N("1".into()))]))]);
+        let expr = parse("m = :p").unwrap();
+        assert!(!evaluate_without_tracking(&expr, &item, &None, &av).unwrap());
+    }
+
+    #[test]
+    fn test_nested_map_equality() {
+        let item = make_item(&[(
+            "m",
+            map_of(&[("inner", map_of(&[("x", AttributeValue::S("v".into()))]))]),
+        )]);
+        let av = vals(&[(
+            ":p",
+            map_of(&[("inner", map_of(&[("x", AttributeValue::S("v".into()))]))]),
+        )]);
+        let expr = parse("m = :p").unwrap();
+        assert!(evaluate_without_tracking(&expr, &item, &None, &av).unwrap());
+    }
+
+    #[test]
+    fn test_map_equality_normalises_nested_numbers() {
+        // Nested numbers compare numerically: 1 == 1.0, consistent with scalar N.
+        let item = make_item(&[("m", map_of(&[("n", AttributeValue::N("1".into()))]))]);
+        let av = vals(&[(":p", map_of(&[("n", AttributeValue::N("1.0".into()))]))]);
+        let expr = parse("m = :p").unwrap();
+        assert!(evaluate_without_tracking(&expr, &item, &None, &av).unwrap());
+    }
+
+    #[test]
+    fn test_list_equality_true() {
+        let item = make_item(&[(
+            "l",
+            AttributeValue::L(vec![
+                AttributeValue::S("a".into()),
+                AttributeValue::N("1".into()),
+            ]),
+        )]);
+        let av = vals(&[(
+            ":p",
+            AttributeValue::L(vec![
+                AttributeValue::S("a".into()),
+                AttributeValue::N("1".into()),
+            ]),
+        )]);
+        let expr = parse("l = :p").unwrap();
+        assert!(evaluate_without_tracking(&expr, &item, &None, &av).unwrap());
+    }
+
+    #[test]
+    fn test_list_equality_is_order_sensitive() {
+        let item = make_item(&[(
+            "l",
+            AttributeValue::L(vec![
+                AttributeValue::S("a".into()),
+                AttributeValue::S("b".into()),
+            ]),
+        )]);
+        let av = vals(&[(
+            ":p",
+            AttributeValue::L(vec![
+                AttributeValue::S("b".into()),
+                AttributeValue::S("a".into()),
+            ]),
+        )]);
+        let eq = parse("l = :p").unwrap();
+        assert!(!evaluate_without_tracking(&eq, &item, &None, &av).unwrap());
+        let ne = parse("l <> :p").unwrap();
+        assert!(evaluate_without_tracking(&ne, &item, &None, &av).unwrap());
+    }
+
+    #[test]
+    fn test_map_ordering_operators_are_false() {
+        let item = make_item(&[("m", map_of(&[("a", AttributeValue::S("1".into()))]))]);
+        let av = vals(&[(":p", map_of(&[("a", AttributeValue::S("1".into()))]))]);
+        for op in ["<", "<=", ">", ">="] {
+            let expr = parse(&format!("m {} :p", op)).unwrap();
+            assert!(
+                !evaluate_without_tracking(&expr, &item, &None, &av).unwrap(),
+                "ordering operator {} on maps should be false",
+                op
+            );
+        }
+    }
+
+    #[test]
+    fn test_list_ordering_operators_are_false() {
+        let item = make_item(&[("l", AttributeValue::L(vec![AttributeValue::S("a".into())]))]);
+        let av = vals(&[(":p", AttributeValue::L(vec![AttributeValue::S("a".into())]))]);
+        for op in ["<", "<=", ">", ">="] {
+            let expr = parse(&format!("l {} :p", op)).unwrap();
+            assert!(
+                !evaluate_without_tracking(&expr, &item, &None, &av).unwrap(),
+                "ordering operator {} on lists should be false",
+                op
+            );
+        }
+    }
+
+    // Ne on EQUAL documents must be false. The order-sensitivity tests only cover
+    // Ne on unequal operands, so a constant-true Ne branch would otherwise survive.
+    #[test]
+    fn test_ne_on_equal_map_and_list_is_false() {
+        let map_item = make_item(&[("m", map_of(&[("a", AttributeValue::S("1".into()))]))]);
+        let map_av = vals(&[(":p", map_of(&[("a", AttributeValue::S("1".into()))]))]);
+        let map_ne = parse("m <> :p").unwrap();
+        assert!(!evaluate_without_tracking(&map_ne, &map_item, &None, &map_av).unwrap());
+
+        let list_item = make_item(&[("l", AttributeValue::L(vec![AttributeValue::S("a".into())]))]);
+        let list_av = vals(&[(":p", AttributeValue::L(vec![AttributeValue::S("a".into())]))]);
+        let list_ne = parse("l <> :p").unwrap();
+        assert!(!evaluate_without_tracking(&list_ne, &list_item, &None, &list_av).unwrap());
+    }
+
+    // <> on maps with differing key sets (same length) must be true.
+    #[test]
+    fn test_ne_on_differing_key_sets_is_true() {
+        let item = make_item(&[("m", map_of(&[("a", AttributeValue::N("1".into()))]))]);
+        let av = vals(&[(":p", map_of(&[("b", AttributeValue::N("1".into()))]))]);
+        let expr = parse("m <> :p").unwrap();
+        assert!(evaluate_without_tracking(&expr, &item, &None, &av).unwrap());
+    }
+
+    #[test]
+    fn test_empty_map_equality() {
+        let item = make_item(&[("m", AttributeValue::M(HashMap::new()))]);
+        let av = vals(&[(":p", AttributeValue::M(HashMap::new()))]);
+        let eq = parse("m = :p").unwrap();
+        assert!(evaluate_without_tracking(&eq, &item, &None, &av).unwrap());
+        let ne = parse("m <> :p").unwrap();
+        assert!(!evaluate_without_tracking(&ne, &item, &None, &av).unwrap());
+    }
+
+    #[test]
+    fn test_empty_list_equality() {
+        let item = make_item(&[("l", AttributeValue::L(vec![]))]);
+        let av = vals(&[(":p", AttributeValue::L(vec![]))]);
+        let eq = parse("l = :p").unwrap();
+        assert!(evaluate_without_tracking(&eq, &item, &None, &av).unwrap());
+        let ne = parse("l <> :p").unwrap();
+        assert!(!evaluate_without_tracking(&ne, &item, &None, &av).unwrap());
+    }
+
+    // A shared key whose values differ in type (S vs N) routes through the
+    // cross-type catch-all on the recursive call and must compare not-equal.
+    #[test]
+    fn test_map_equality_type_mismatch_at_shared_key() {
+        let item = make_item(&[("m", map_of(&[("x", AttributeValue::S("1".into()))]))]);
+        let av = vals(&[(":p", map_of(&[("x", AttributeValue::N("1".into()))]))]);
+        let eq = parse("m = :p").unwrap();
+        assert!(!evaluate_without_tracking(&eq, &item, &None, &av).unwrap());
+        let ne = parse("m <> :p").unwrap();
+        assert!(evaluate_without_tracking(&ne, &item, &None, &av).unwrap());
+    }
+
+    #[test]
+    fn test_list_length_mismatch_is_not_equal() {
+        let item = make_item(&[("l", AttributeValue::L(vec![AttributeValue::S("a".into())]))]);
+        let av = vals(&[(
+            ":p",
+            AttributeValue::L(vec![
+                AttributeValue::S("a".into()),
+                AttributeValue::S("b".into()),
+            ]),
+        )]);
+        let expr = parse("l = :p").unwrap();
+        assert!(!evaluate_without_tracking(&expr, &item, &None, &av).unwrap());
+    }
+
+    // IN routes through compare_values, so document operands now match correctly.
+    #[test]
+    fn test_in_operator_with_map_operands() {
+        let item = make_item(&[(
+            "m",
+            map_of(&[("status", AttributeValue::S("active".into()))]),
+        )]);
+        let av = vals(&[
+            (
+                ":p1",
+                map_of(&[("status", AttributeValue::S("closed".into()))]),
+            ),
+            (
+                ":p2",
+                map_of(&[("status", AttributeValue::S("active".into()))]),
+            ),
+        ]);
+        let hit = parse("m IN (:p1, :p2)").unwrap();
+        assert!(evaluate_without_tracking(&hit, &item, &None, &av).unwrap());
+
+        let miss_av = vals(&[
+            (
+                ":p1",
+                map_of(&[("status", AttributeValue::S("closed".into()))]),
+            ),
+            (
+                ":p2",
+                map_of(&[("status", AttributeValue::S("pending".into()))]),
+            ),
+        ]);
+        let miss = parse("m IN (:p1, :p2)").unwrap();
+        assert!(!evaluate_without_tracking(&miss, &item, &None, &miss_av).unwrap());
+    }
+
+    // contains(list, :v) compares each element via compare_values, so a map
+    // element now matches deeply.
+    #[test]
+    fn test_contains_list_of_maps() {
+        let item = make_item(&[(
+            "l",
+            AttributeValue::L(vec![
+                map_of(&[("role", AttributeValue::S("admin".into()))]),
+                map_of(&[("role", AttributeValue::S("viewer".into()))]),
+            ]),
+        )]);
+        let hit_av = vals(&[(":p", map_of(&[("role", AttributeValue::S("admin".into()))]))]);
+        let hit = parse("contains(l, :p)").unwrap();
+        assert!(evaluate_without_tracking(&hit, &item, &None, &hit_av).unwrap());
+
+        let miss_av = vals(&[(
+            ":p",
+            map_of(&[("role", AttributeValue::S("unknown".into()))]),
+        )]);
+        let miss = parse("contains(l, :p)").unwrap();
+        assert!(!evaluate_without_tracking(&miss, &item, &None, &miss_av).unwrap());
     }
 }

--- a/src/expressions/condition.rs
+++ b/src/expressions/condition.rs
@@ -610,24 +610,27 @@ fn compare_values(left: &AttributeValue, op: &CompOp, right: &AttributeValue) ->
             }
         }
 
-        // Number Set — set equality (order-independent)
+        // Number Set — set equality (order-independent). Compared via the canonical
+        // numeric form (full 38-digit precision), matching how NS duplicates are
+        // detected on write. f64 would collapse values differing only beyond ~15
+        // significant digits and wrongly report distinct sets as equal.
         (AttributeValue::NS(a), AttributeValue::NS(b)) => {
             if a.len() != b.len() {
                 return matches!(op, CompOp::Ne);
             }
-            let mut fa: Vec<f64> = match a.iter().map(|n| n.parse::<f64>()).collect() {
-                Ok(v) => v,
-                Err(_) => return false,
-            };
-            let mut fb: Vec<f64> = match b.iter().map(|n| n.parse::<f64>()).collect() {
-                Ok(v) => v,
-                Err(_) => return false,
-            };
-            fa.sort_by(|x, y| x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal));
-            fb.sort_by(|x, y| x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal));
+            let mut na: Vec<String> = a
+                .iter()
+                .map(|n| crate::types::normalize_dynamo_number(n))
+                .collect();
+            let mut nb: Vec<String> = b
+                .iter()
+                .map(|n| crate::types::normalize_dynamo_number(n))
+                .collect();
+            na.sort();
+            nb.sort();
             match op {
-                CompOp::Eq => fa == fb,
-                CompOp::Ne => fa != fb,
+                CompOp::Eq => na == nb,
+                CompOp::Ne => na != nb,
                 _ => false,
             }
         }
@@ -1730,5 +1733,31 @@ mod tests {
         )]);
         let miss = parse("contains(l, :p)").unwrap();
         assert!(!evaluate_without_tracking(&miss, &item, &None, &miss_av).unwrap());
+    }
+
+    // Number sets are compared at full precision: two 18-digit values differing only
+    // in the last digit are distinct, where an f64 comparison would wrongly match them.
+    #[test]
+    fn test_number_set_equality_full_precision() {
+        let item = make_item(&[("ns", AttributeValue::NS(vec!["100000000000000001".into()]))]);
+
+        let same = vals(&[(":p", AttributeValue::NS(vec!["100000000000000001".into()]))]);
+        let eq = parse("ns = :p").unwrap();
+        assert!(evaluate_without_tracking(&eq, &item, &None, &same).unwrap());
+
+        let off_by_one = vals(&[(":p", AttributeValue::NS(vec!["100000000000000002".into()]))]);
+        let eq2 = parse("ns = :p").unwrap();
+        assert!(!evaluate_without_tracking(&eq2, &item, &None, &off_by_one).unwrap());
+        let ne = parse("ns <> :p").unwrap();
+        assert!(evaluate_without_tracking(&ne, &item, &None, &off_by_one).unwrap());
+    }
+
+    // Equality is numeric, not textual: 1 and 1.0 are the same set member.
+    #[test]
+    fn test_number_set_equality_normalises_members() {
+        let item = make_item(&[("ns", AttributeValue::NS(vec!["1".into(), "2".into()]))]);
+        let av = vals(&[(":p", AttributeValue::NS(vec!["1.0".into(), "2.00".into()]))]);
+        let eq = parse("ns = :p").unwrap();
+        assert!(evaluate_without_tracking(&eq, &item, &None, &av).unwrap());
     }
 }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -309,8 +309,14 @@ pub fn partition_key_name(key_schema: &[KeySchemaElement]) -> Option<&str> {
         .map(|k| k.attribute_name.as_str())
 }
 
-/// Maximum nesting depth for item attribute values (DynamoDB's limit).
+/// DynamoDB caps document nesting at 32 levels, counting the top-level attribute
+/// value as level 1. Values are validated 0-indexed (top-level = depth 0), so the
+/// deepest permitted leaf sits at depth 31 and a value reaching depth 32 is rejected.
 const MAX_NESTING_DEPTH: usize = 32;
+
+/// Real DynamoDB's verbatim message when document nesting exceeds the limit. Shared
+/// by the stored-item and ExpressionAttributeValue checks so both match AWS.
+const NESTING_LIMIT_MESSAGE: &str = "Nesting Levels have exceeded supported limits: Attributes in the item have nested levels beyond supported limit";
 
 /// Validate all attribute values in an item.
 ///
@@ -335,9 +341,9 @@ pub fn validate_item_attribute_values(item: &Item) -> Result<()> {
 }
 
 fn validate_attribute_value(value: &AttributeValue, depth: usize) -> Result<()> {
-    if depth > MAX_NESTING_DEPTH {
+    if depth >= MAX_NESTING_DEPTH {
         return Err(DynoxideError::ValidationException(
-            "Nesting level exceeds limit of 32".to_string(),
+            NESTING_LIMIT_MESSAGE.to_string(),
         ));
     }
     match value {
@@ -415,6 +421,35 @@ fn validate_attribute_value(value: &AttributeValue, depth: usize) -> Result<()> 
             }
             Ok(())
         }
+        _ => Ok(()),
+    }
+}
+
+/// Validate that a single `ExpressionAttributeValue` does not nest deeper than
+/// DynamoDB allows.
+///
+/// Real DynamoDB rejects expression values whose document nesting exceeds 32 levels
+/// up front, before the expression is evaluated, raising the same bare nesting
+/// `ValidationException` it raises for over-deep stored items (no "ExpressionAttributeValues
+/// contains invalid value" wrapper). Only the nesting depth is checked here; empty
+/// strings and other shapes that are legal in comparisons are left untouched.
+pub fn validate_nesting_depth(value: &AttributeValue) -> Result<()> {
+    check_nesting_depth(value, 0)
+}
+
+fn check_nesting_depth(value: &AttributeValue, depth: usize) -> Result<()> {
+    if depth >= MAX_NESTING_DEPTH {
+        return Err(DynoxideError::ValidationException(
+            NESTING_LIMIT_MESSAGE.to_string(),
+        ));
+    }
+    match value {
+        AttributeValue::L(list) => list
+            .iter()
+            .try_for_each(|v| check_nesting_depth(v, depth + 1)),
+        AttributeValue::M(map) => map
+            .values()
+            .try_for_each(|v| check_nesting_depth(v, depth + 1)),
         _ => Ok(()),
     }
 }

--- a/tests/expressions.rs
+++ b/tests/expressions.rs
@@ -144,6 +144,135 @@ fn test_put_condition_with_comparison() {
     assert!(err.to_string().contains("conditional request failed"));
 }
 
+// #103: a ConditionExpression that compares a Map (M) attribute for equality
+// must succeed when the stored map equals the supplied value. Before the fix,
+// compare_values had no arm for M, so map equality always failed.
+#[test]
+fn test_condition_map_equality() {
+    let db = make_db();
+    create_table(&db, "Tbl");
+
+    let status = || {
+        AttributeValue::M(HashMap::from([(
+            "Union_Case".to_string(),
+            AttributeValue::S("Passive".into()),
+        )]))
+    };
+
+    put(
+        &db,
+        "Tbl",
+        &[("pk", AttributeValue::S("k1".into())), ("Status", status())],
+    );
+
+    // Should succeed: Status equals the supplied map.
+    db.update_item(UpdateItemRequest {
+        table_name: "Tbl".to_string(),
+        key: key_map(&[("pk", AttributeValue::S("k1".into()))]),
+        update_expression: Some("SET Touched = :t".into()),
+        condition_expression: Some("#S = :p".into()),
+        expression_attribute_names: Some(HashMap::from([("#S".to_string(), "Status".to_string())])),
+        expression_attribute_values: Some(make_item(&[
+            (":t", AttributeValue::S("yes".into())),
+            (":p", status()),
+        ])),
+        return_values: None,
+        ..Default::default()
+    })
+    .unwrap();
+
+    // Should fail: the stored map no longer matches a different map.
+    let err = db
+        .update_item(UpdateItemRequest {
+            table_name: "Tbl".to_string(),
+            key: key_map(&[("pk", AttributeValue::S("k1".into()))]),
+            update_expression: Some("SET Touched = :t".into()),
+            condition_expression: Some("#S = :p".into()),
+            expression_attribute_names: Some(HashMap::from([(
+                "#S".to_string(),
+                "Status".to_string(),
+            )])),
+            expression_attribute_values: Some(make_item(&[
+                (":t", AttributeValue::S("again".into())),
+                (
+                    ":p",
+                    AttributeValue::M(HashMap::from([(
+                        "Union_Case".to_string(),
+                        AttributeValue::S("Active".into()),
+                    )])),
+                ),
+            ])),
+            return_values: None,
+            ..Default::default()
+        })
+        .unwrap_err();
+    assert!(err.to_string().contains("conditional request failed"));
+}
+
+// #103: the List (L) counterpart to test_condition_map_equality. Element-wise,
+// order-sensitive deep equality must gate a real UpdateItem end-to-end.
+#[test]
+fn test_condition_list_equality() {
+    let db = make_db();
+    create_table(&db, "Tbl");
+
+    let roles = || {
+        AttributeValue::L(vec![
+            AttributeValue::S("admin".into()),
+            AttributeValue::S("viewer".into()),
+        ])
+    };
+
+    put(
+        &db,
+        "Tbl",
+        &[("pk", AttributeValue::S("k1".into())), ("Roles", roles())],
+    );
+
+    // Should succeed: Roles equals the supplied list.
+    db.update_item(UpdateItemRequest {
+        table_name: "Tbl".to_string(),
+        key: key_map(&[("pk", AttributeValue::S("k1".into()))]),
+        update_expression: Some("SET Touched = :t".into()),
+        condition_expression: Some("#R = :p".into()),
+        expression_attribute_names: Some(HashMap::from([("#R".to_string(), "Roles".to_string())])),
+        expression_attribute_values: Some(make_item(&[
+            (":t", AttributeValue::S("yes".into())),
+            (":p", roles()),
+        ])),
+        return_values: None,
+        ..Default::default()
+    })
+    .unwrap();
+
+    // Should fail: same elements, reversed order is not equal for a List.
+    let err = db
+        .update_item(UpdateItemRequest {
+            table_name: "Tbl".to_string(),
+            key: key_map(&[("pk", AttributeValue::S("k1".into()))]),
+            update_expression: Some("SET Touched = :t".into()),
+            condition_expression: Some("#R = :p".into()),
+            expression_attribute_names: Some(HashMap::from([(
+                "#R".to_string(),
+                "Roles".to_string(),
+            )])),
+            expression_attribute_values: Some(make_item(&[
+                (":t", AttributeValue::S("again".into())),
+                (
+                    ":p",
+                    AttributeValue::L(vec![
+                        AttributeValue::S("viewer".into()),
+                        AttributeValue::S("admin".into()),
+                    ]),
+                ),
+            ])),
+            return_values: None,
+            ..Default::default()
+        })
+        .unwrap_err();
+    assert!(err.to_string().contains("conditional request failed"));
+}
+
 // ---------------------------------------------------------------------------
 // ConditionExpression on DeleteItem
 // ---------------------------------------------------------------------------

--- a/tests/nesting_depth.rs
+++ b/tests/nesting_depth.rs
@@ -1,0 +1,137 @@
+//! Document nesting is capped at 32 levels, counting the top-level attribute as
+//! level 1. Real DynamoDB rejects deeper values with a ValidationException, on both
+//! the stored-item path (PutItem) and the ExpressionAttributeValue path, before the
+//! expression is evaluated. Boundary and message captured against real DynamoDB
+//! (eu-west-2, 2026-06): accepts 31 map-wraps, rejects 32.
+
+use dynoxide::Database;
+use dynoxide::actions::create_table::CreateTableRequest;
+use dynoxide::actions::put_item::PutItemRequest;
+use dynoxide::actions::update_item::UpdateItemRequest;
+use dynoxide::types::*;
+use std::collections::HashMap;
+
+const NEST_MSG: &str = "Nesting Levels have exceeded supported limits";
+
+fn make_db() -> Database {
+    Database::memory().unwrap()
+}
+
+fn create_table(db: &Database) {
+    db.create_table(CreateTableRequest {
+        table_name: "Tbl".to_string(),
+        key_schema: vec![KeySchemaElement {
+            attribute_name: "pk".to_string(),
+            key_type: KeyType::HASH,
+        }],
+        attribute_definitions: vec![AttributeDefinition {
+            attribute_name: "pk".to_string(),
+            attribute_type: ScalarAttributeType::S,
+        }],
+        ..Default::default()
+    })
+    .unwrap();
+}
+
+/// Wrap a scalar leaf in `depth` single-key maps. depth=1 -> M{ n: S("leaf") }.
+fn deep_map(depth: usize) -> AttributeValue {
+    let mut v = AttributeValue::S("leaf".into());
+    for _ in 0..depth {
+        v = AttributeValue::M(HashMap::from([("n".to_string(), v)]));
+    }
+    v
+}
+
+fn put_with_data(db: &Database, pk: &str, data: AttributeValue) -> dynoxide::errors::Result<()> {
+    db.put_item(PutItemRequest {
+        table_name: "Tbl".to_string(),
+        item: HashMap::from([
+            ("pk".to_string(), AttributeValue::S(pk.into())),
+            ("data".to_string(), data),
+        ]),
+        ..Default::default()
+    })
+    .map(|_| ())
+}
+
+fn update_with_deep_condition(db: &Database, depth: usize) -> dynoxide::errors::Result<()> {
+    db.update_item(UpdateItemRequest {
+        table_name: "Tbl".to_string(),
+        key: HashMap::from([("pk".to_string(), AttributeValue::S("k1".into()))]),
+        update_expression: Some("SET touched = :t".into()),
+        condition_expression: Some("#d = :deep".into()),
+        expression_attribute_names: Some(HashMap::from([("#d".to_string(), "data".to_string())])),
+        expression_attribute_values: Some(HashMap::from([
+            (":t".to_string(), AttributeValue::S("y".into())),
+            (":deep".to_string(), deep_map(depth)),
+        ])),
+        ..Default::default()
+    })
+    .map(|_| ())
+}
+
+// --- Stored item (PutItem) ---
+
+#[test]
+fn stored_item_accepts_31_levels() {
+    let db = make_db();
+    create_table(&db);
+    put_with_data(&db, "ok", deep_map(31)).expect("31 levels should store");
+}
+
+#[test]
+fn stored_item_rejects_32_levels() {
+    let db = make_db();
+    create_table(&db);
+    let err = put_with_data(&db, "bad", deep_map(32)).unwrap_err();
+    assert!(
+        err.to_string().contains(NEST_MSG),
+        "expected nesting ValidationException, got: {err}"
+    );
+}
+
+// --- ExpressionAttributeValue (UpdateItem ConditionExpression) ---
+
+#[test]
+fn condition_eav_accepts_31_levels_and_evaluates() {
+    let db = make_db();
+    create_table(&db);
+    // Seed an item with no `data` attribute, so the condition is false once evaluated.
+    db.put_item(PutItemRequest {
+        table_name: "Tbl".to_string(),
+        item: HashMap::from([("pk".to_string(), AttributeValue::S("k1".into()))]),
+        ..Default::default()
+    })
+    .unwrap();
+
+    let err = update_with_deep_condition(&db, 31).unwrap_err();
+    let msg = err.to_string();
+    // A 31-level value is accepted and the condition is evaluated, so this is a
+    // conditional failure, NOT a nesting ValidationException.
+    assert!(
+        msg.contains("conditional request failed"),
+        "expected conditional failure, got: {msg}"
+    );
+    assert!(
+        !msg.contains(NEST_MSG),
+        "31 levels must not trip the nesting cap"
+    );
+}
+
+#[test]
+fn condition_eav_rejects_32_levels() {
+    let db = make_db();
+    create_table(&db);
+    db.put_item(PutItemRequest {
+        table_name: "Tbl".to_string(),
+        item: HashMap::from([("pk".to_string(), AttributeValue::S("k1".into()))]),
+        ..Default::default()
+    })
+    .unwrap();
+
+    let err = update_with_deep_condition(&db, 32).unwrap_err();
+    assert!(
+        err.to_string().contains(NEST_MSG),
+        "expected nesting ValidationException, got: {err}"
+    );
+}


### PR DESCRIPTION
## What this changes

Three condition-expression conformance fixes, all surfaced from #103.

- **Map and list equality (#103).** `compare_values` had no arm for `M` or `L`, so a `ConditionExpression` like `#m = :p` always reported not-equal and `<>` always equal, whatever the values. Document types now compare deeply: maps order-independently, lists element-wise in order, with nested numbers normalised as elsewhere. `IN`, `BETWEEN`, and `contains` over document operands share that path and are fixed too.
- **Expression-value nesting (#110).** `ExpressionAttributeValues` nested beyond DynamoDB's 32-level document limit were never depth-checked, so they reached the comparator instead of being rejected. They are now rejected up front on every path that takes them (PutItem, UpdateItem, DeleteItem, Query, Scan, TransactWriteItems) with the `ValidationException` AWS returns. The stored-item check was also one level too lenient and carried a non-AWS message; both now match.
- **Number-set precision (#111).** `NS` equality compared via `f64`, so two sets differing only beyond ~15 significant digits matched. It now compares via the canonical numeric form at full precision, including number sets nested inside a map or list.

## Checklist

- [x] Tests added or updated
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` pass locally
- [x] `CHANGELOG.md` updated if this is a user-visible change
- [x] Linked issue, discussion, or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms (MIT License and Apache License, Version 2.0)

## DynamoDB compatibility note

All three move dynoxide towards AWS. The nesting boundary and message, and the number-set precision behaviour, were captured against real DynamoDB in eu-west-2: both the stored-item and expression-value paths accept 31 levels of map nesting and reject 32 with `Nesting Levels have exceeded supported limits: Attributes in the item have nested levels beyond supported limit`, and AWS distinguishes number sets that differ past f64 precision. The one behaviour change for existing callers is that a 33-level stored item dynoxide used to accept is now rejected, exactly as AWS rejects it.

Fixes #103
Fixes #110
Fixes #111