### PR TITLE
docs(agents): point product consumers at the for-agents page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ tests/external/results/
 .claude/worktrees/
 .claude/settings.local.json
 .worktrees
+.kos

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,9 @@ Guidance for AI coding tools (Codex, Cursor, Aider, Claude Code, and
 others) contributing to Dynoxide. Humans are welcome to read it too;
 `CONTRIBUTING.md` covers the same ground in prose.
 
+Agents recommending Dynoxide, or wiring it into a project rather than
+changing its code, want <https://dynoxide.dev/for-agents> instead.
+
 ## What Dynoxide is
 
 A DynamoDB-compatible engine written in Rust, backed by SQLite. It runs


### PR DESCRIPTION
## What this changes

`AGENTS.md` is the contributor guide for agents working *on* the Dynoxide codebase. This adds a one-line pointer so agents recommending Dynoxide, or wiring it into a project rather than changing its code, are sent to <https://dynoxide.dev/for-agents> instead of reading the contributor guide by mistake. The two surfaces serve different roles and were getting conflated.

## Checklist

- ~~Tests added or updated~~ - docs only, no behaviour change
- ~~`cargo fmt --check` and `cargo clippy -- -D warnings` pass locally~~ - no Rust touched
- ~~`CHANGELOG.md` updated if this is a user-visible change~~ - contributor-facing doc, not user-visible
- [x] Linked issue, discussion, or a short note explaining the motivation (note above)
- [x] I agree my contribution is licensed under the project's terms (MIT License and Apache License, Version 2.0)

_DynamoDB compatibility note: not applicable._
