### PR TITLE
feat(mcp): list the MCP server in the public registries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -526,6 +526,72 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   # -------------------------------------------------------------------
+  # Publish to the official MCP registry (registry.modelcontextprotocol.io)
+  # via GitHub OIDC, so no token is needed. Runs after npm and Docker have
+  # published because the registry verifies ownership against the live npm
+  # package (its mcpName field) and the GHCR image (its OCI label). The
+  # GitHub MCP Registry ingests from the official registry, so this single
+  # publish covers that surface too.
+  # -------------------------------------------------------------------
+  publish-mcp-registry:
+    name: Publish to MCP registry
+    needs: [validate, publish-npm, publish-docker]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      # publish-npm only dispatches npm.yml, so the npm publish finishes
+      # asynchronously. Wait for the version to appear before publishing the
+      # registry entry, otherwise the npm ownership check fails.
+      - name: Wait for npm package to go live
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          for i in $(seq 1 60); do
+            if npm view "dynoxide@$VERSION" version >/dev/null 2>&1; then
+              echo "dynoxide@$VERSION is live on npm"
+              exit 0
+            fi
+            echo "Waiting for dynoxide@$VERSION on npm ($i/60)..."
+            sleep 10
+          done
+          echo "::error::dynoxide@$VERSION did not appear on npm within 10 minutes"
+          exit 1
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+            | tar xz mcp-publisher
+
+      - name: Stamp release version into server.json
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          jq --arg v "$VERSION" '
+            .version = $v
+            | (.packages[] | select(.registryType == "npm")).version = $v
+            | (.packages[] | select(.registryType == "oci")).identifier = "ghcr.io/nubo-db/dynoxide:\($v)"
+          ' server.json > server.json.tmp
+          mv server.json.tmp server.json
+          cat server.json
+
+      - name: Authenticate to the MCP registry via GitHub OIDC
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server.json
+        run: ./mcp-publisher publish
+
+  # -------------------------------------------------------------------
   # Notify dynoxide.dev so the marketing site rebuilds and the banner /
   # changelog pick up the new version. The site reads CHANGELOG.md from
   # this repo at build time, so it only needs a kick.

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,11 @@ ARG TARGETARCH
 
 COPY dist/${TARGETARCH}/dynoxide /usr/local/bin/dynoxide
 
+# Ownership marker for the MCP registry. Must match the `name` in server.json;
+# the registry reads this label off the published image to verify the OCI
+# package belongs to io.github.nubo-db/dynoxide.
+LABEL io.modelcontextprotocol.server.name="io.github.nubo-db/dynoxide"
+
 WORKDIR /data
 
 # 8000: DynamoDB HTTP API (started by the default CMD).

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 - [HTTP server](http-server.md) - running the DynamoDB-compatible HTTP API
 - [MCP server](mcp.md) - the Model Context Protocol server for coding agents
 - [MCP data model](mcp-data-model.md) - the `--data-model` format reference
+- [MCP registries](mcp-registries.md) - listing the MCP server in the public registries
 - [DynamoDB Streams](streams.md) - enabling and reading stream records
 - [Import CLI](import.md) - loading data, table filtering, and anonymisation
 - [WebAssembly (preview)](wasm.md) - the browser build and embed contract

--- a/docs/mcp-registries.md
+++ b/docs/mcp-registries.md
@@ -1,0 +1,85 @@
+# MCP registries
+
+Dynoxide's [MCP server](mcp.md) is listed in the public MCP registries so
+coding agents can discover it. This is the maintainer runbook for each listing:
+what is automated, what is a one-off, and what needs an account you control.
+
+The canonical server identifier across every registry is
+`io.github.nubo-db/dynoxide`.
+
+## Official registry (registry.modelcontextprotocol.io)
+
+Automated. `server.json` at the repo root describes the server, and the
+`publish-mcp-registry` job in `.github/workflows/release.yml` publishes it on
+every `v*` release tag, authenticating with GitHub OIDC (no token). Cutting a
+release as normal is all that is needed; the job waits for npm to go live,
+stamps the release version into `server.json`, and runs `mcp-publisher publish`.
+
+Ownership is proved against the live release artefacts, so both markers must
+stay in place:
+
+- the npm package carries `"mcpName": "io.github.nubo-db/dynoxide"` in
+  `npm/dynoxide/package.json`
+- the GHCR image carries `LABEL io.modelcontextprotocol.server.name="io.github.nubo-db/dynoxide"`
+  in the `Dockerfile`
+
+The **GitHub MCP Registry** (github.com/mcp) ingests from the official
+registry, so a successful publish covers it too. If the server has not appeared
+there a day or two after a release, email partnerships@github.com with the
+official-registry URL.
+
+To publish out of band (for example to test a `server.json` change):
+
+```sh
+brew install mcp-publisher    # or download from the registry's GitHub releases
+mcp-publisher login github    # device-code OAuth; grants the io.github.nubo-db/* namespace
+mcp-publisher publish         # run from the repo root, where server.json lives
+```
+
+A manual publish still validates against the live npm package and GHCR image,
+so it only works for a version that has already been released with the markers
+above.
+
+## Smithery (smithery.ai)
+
+One-off, and it needs a Smithery account. `smithery.yaml` at the repo root
+already tells Smithery to launch the server over stdio via `npx -y dynoxide mcp`,
+so the repo side is done. To list it:
+
+```sh
+npm install -g @smithery/cli
+smithery auth login
+```
+
+Then publish following <https://smithery.ai/docs/build/publish> (the publish
+subcommand changed in CLI v1.1.0, so follow the current docs rather than a
+pinned command here). Optionally install the Smithery GitHub App on the repo
+for push-triggered redeploys.
+
+## Glama (glama.ai)
+
+One-off, and it needs your GitHub OAuth. `glama.json` at the repo root names the
+maintainer (`hicksy`) for the ownership claim. To list it:
+
+1. Go to <https://glama.ai/mcp/servers> and choose "Add MCP Server".
+2. Sign in with GitHub and enter the repo URL.
+3. Glama build-checks the server in a sandbox; it usually appears within minutes.
+4. Because this is an org-owned repo, complete the "Claim ownership" flow, which
+   reads `glama.json`.
+
+A directory listing needs no Dockerfile. To later have Glama host and run it
+through their gateway, point them at the `dynoxide` npm package in the admin
+panel.
+
+## mcp.so
+
+One-off, and it needs your GitHub account. No repo file. Comment on
+<https://github.com/chatmcp/mcpso/issues/1> with:
+
+- name: `dynoxide`
+- repo: <https://github.com/nubo-db/dynoxide>
+- run: `npx -y dynoxide mcp`
+- transport: stdio (also streamable HTTP via `dynoxide mcp --http`)
+- 34 tools
+
+The mcp.so team adds it to the directory from there.

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["hicksy"]
+}

--- a/npm/dynoxide/package.json
+++ b/npm/dynoxide/package.json
@@ -2,6 +2,7 @@
   "name": "dynoxide",
   "version": "0.0.0-development",
   "description": "Embedded DynamoDB-compatible engine. Drop-in dynalite replacement.",
+  "mcpName": "io.github.nubo-db/dynoxide",
   "author": "Martin Hicks",
   "license": "(MIT OR Apache-2.0)",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.nubo-db/dynoxide",
+  "title": "Dynoxide",
+  "description": "DynamoDB-compatible database engine, written in Rust and backed by SQLite. Its MCP server exposes 34 DynamoDB operations (tables, items, query and scan, batch, transactions, PartiQL, TTL, tags, streams, and snapshots) as tools for coding agents.",
+  "version": "0.11.1",
+  "websiteUrl": "https://dynoxide.dev",
+  "repository": {
+    "url": "https://github.com/nubo-db/dynoxide",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "dynoxide",
+      "version": "0.11.1",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp",
+          "isRequired": true
+        }
+      ]
+    },
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/nubo-db/dynoxide:0.11.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp",
+          "isRequired": true
+        }
+      ]
+    }
+  ]
+}

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,9 @@
+# Smithery configuration. See https://smithery.ai/docs/config
+#
+# Dynoxide's MCP server is a CLI binary distributed on npm, so Smithery
+# launches it over stdio via npx. No configuration is required.
+startCommand:
+  type: stdio
+  configSchema: {}
+  commandFunction: |-
+    (config) => ({ command: "npx", args: ["-y", "dynoxide", "mcp"] })


### PR DESCRIPTION
## What this changes

Lists Dynoxide's MCP server in the public MCP registries so coding agents can discover it.

- **Official registry** (registry.modelcontextprotocol.io): adds `server.json`, the `mcpName` marker in the npm package, the OCI ownership label on the Docker image, and a `publish-mcp-registry` job that publishes on each release over GitHub OIDC (no token). The GitHub MCP Registry ingests from the official one, so that surface is covered too.
- **Smithery and Glama**: adds `smithery.yaml` and `glama.json`. The listing itself is a one-off maintainer action under a personal account; the repo side is ready.
- **mcp.so**: no repo file needed; submission is a comment on their tracker.

`docs/mcp-registries.md` is the maintainer runbook for all five, including which steps need a maintainer account.

The official-registry job activates on the next release, when the npm package and GHCR image republish carrying the ownership markers the registry validates against.

## Checklist

- ~~Tests added or updated~~ - config and docs only, no engine behaviour change
- ~~`cargo fmt --check` and `cargo clippy -- -D warnings` pass locally~~ - no Rust touched; the workflow change was validated with `actionlint`
- ~~`CHANGELOG.md` updated if this is a user-visible change~~ - distribution/discoverability infra, not user-visible engine behaviour
- [x] Linked issue, discussion, or a short note explaining the motivation (note above)
- [x] I agree my contribution is licensed under the project's terms (MIT License and Apache License, Version 2.0)

_DynamoDB compatibility note: not applicable._
