### PR TITLE
fix(mcp): publish to Smithery via an MCPB bundle, not smithery.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ tests/external/results/
 .claude/settings.local.json
 .worktrees
 .kos
+# Built MCPB bundle for Smithery; rebuild with: mcpb pack mcpb mcpb/dynoxide.mcpb
+/mcpb/*.mcpb

--- a/docs/mcp-registries.md
+++ b/docs/mcp-registries.md
@@ -42,19 +42,29 @@ above.
 
 ## Smithery (smithery.ai)
 
-One-off, and it needs a Smithery account. `smithery.yaml` at the repo root
-already tells Smithery to launch the server over stdio via `npx -y dynoxide mcp`,
-so the repo side is done. To list it:
+One-off, and it needs a Smithery account. Smithery distributes a local stdio
+server as an [MCPB bundle](https://github.com/anthropics/mcpb) that clients
+download and run. The bundle source is `mcpb/manifest.json`; it launches the
+server with `npx -y dynoxide mcp`, so the runtime always pulls the current npm
+release regardless of the bundle's own version.
+
+Build the bundle, sign in, and publish:
 
 ```sh
-npm install -g @smithery/cli
-smithery auth login
+npx -y @anthropic-ai/mcpb pack mcpb mcpb/dynoxide.mcpb
+npx -y @smithery/cli auth login
+npx -y @smithery/cli mcp publish mcpb/dynoxide.mcpb -n nubo-db/dynoxide
 ```
 
-Then publish following <https://smithery.ai/docs/build/publish> (the publish
-subcommand changed in CLI v1.1.0, so follow the current docs rather than a
-pinned command here). Optionally install the Smithery GitHub App on the repo
-for push-triggered redeploys.
+The empty `"tools": []` in the manifest is load-bearing. The Smithery CLI drops
+the `tools` field from its upload when the key is absent, and the registry then
+rejects the payload with `400 "No values to set"`
+(<https://github.com/smithery-ai/cli/issues/770>). Leave it empty; a populated
+list is rejected on a separate schema mismatch.
+
+To republish after a release, bump `version` in `mcpb/manifest.json`, rebuild,
+and re-run the publish command. The server already exists, so it goes straight
+to the new release.
 
 ## Glama (glama.ai)
 
@@ -62,10 +72,11 @@ One-off, and it needs your GitHub OAuth. `glama.json` at the repo root names the
 maintainer (`hicksy`) for the ownership claim. To list it:
 
 1. Go to <https://glama.ai/mcp/servers> and choose "Add MCP Server".
-2. Sign in with GitHub and enter the repo URL.
-3. Glama build-checks the server in a sandbox; it usually appears within minutes.
-4. Because this is an org-owned repo, complete the "Claim ownership" flow, which
-   reads `glama.json`.
+2. Sign in with GitHub and submit the repo URL for review.
+3. Glama build-checks the server in a sandbox and lists it, usually within minutes.
+
+`glama.json` names the maintainer (`hicksy`) so the listing is attributed to you;
+the current flow submits for review rather than offering a separate claim step.
 
 A directory listing needs no Dockerfile. To later have Glama host and run it
 through their gateway, point them at the `dynoxide` npm package in the admin

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -1,0 +1,20 @@
+{
+  "manifest_version": "0.3",
+  "name": "dynoxide",
+  "version": "0.11.1",
+  "description": "DynamoDB-compatible database engine with an MCP server exposing 34 DynamoDB tools.",
+  "author": {
+    "name": "Martin Hicks",
+    "url": "https://dynoxide.dev"
+  },
+  "server": {
+    "type": "binary",
+    "entry_point": "npx",
+    "mcp_config": {
+      "command": "npx",
+      "args": ["-y", "dynoxide", "mcp"],
+      "env": {}
+    }
+  },
+  "tools": []
+}

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,9 +1,0 @@
-# Smithery configuration. See https://smithery.ai/docs/config
-#
-# Dynoxide's MCP server is a CLI binary distributed on npm, so Smithery
-# launches it over stdio via npx. No configuration is required.
-startCommand:
-  type: stdio
-  configSchema: {}
-  commandFunction: |-
-    (config) => ({ command: "npx", args: ["-y", "dynoxide", "mcp"] })


### PR DESCRIPTION
## What this changes

Corrects the Smithery side of the MCP registry work, which targeted the wrong publish path.

- Replaces `smithery.yaml` (the stdio `commandFunction` path, which Smithery's current publish flow does not use) with `mcpb/manifest.json` - the source for an MCPB bundle that Smithery accepts. The bundle launches the server with `npx -y dynoxide mcp`, so it always runs the current npm release.
- Gitignores the built `.mcpb` artefact.
- Rewrites the runbook's Smithery section to the bundle flow and documents why `"tools": []` is required (Smithery CLI [issue #770](https://github.com/smithery-ai/cli/issues/770)), and corrects the Glama section to "submit for review" (there is no separate claim step).

## Checklist

- ~~Tests added or updated~~ - config and docs only, no engine behaviour change
- ~~`cargo fmt --check` and `cargo clippy -- -D warnings` pass locally~~ - no Rust touched
- ~~`CHANGELOG.md` updated if this is a user-visible change~~ - distribution/docs, not user-visible engine behaviour
- [x] Linked issue, discussion, or a short note explaining the motivation (note above)
- [x] I agree my contribution is licensed under the project's terms (MIT License and Apache License, Version 2.0)

_DynamoDB compatibility note: not applicable._
