### PR TITLE
fix: reject two CreateTable shapes that DynamoDB rejects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A `CreateTable` global or local secondary index using `ProjectionType: INCLUDE` without a `NonKeyAttributes` list is now rejected with the `ValidationException` real DynamoDB returns (`One or more parameter values were invalid: ProjectionType is INCLUDE, but NonKeyAttributes is not specified`), where dynoxide accepted it and created the table. `INCLUDE` projects the index key attributes plus an explicit list, so the list is mandatory; the shared projection validator now requires it, closing the gap for both index types ([#116](https://github.com/nubo-db/dynoxide/issues/116)).
+
 ## [0.11.1] - 2026-06-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A `CreateTable` request whose `StreamSpecification` sets `StreamEnabled: false` but also supplies a `StreamViewType` is now rejected with the `ValidationException` real DynamoDB returns (`One or more parameter values were invalid: Table is being created with a stream disabled, UpdateViewType should not be specified`), where dynoxide accepted it. A view type only has meaning when the stream is enabled, so the two cannot be combined at table creation ([#115](https://github.com/nubo-db/dynoxide/issues/115)).
 - A `CreateTable` global or local secondary index using `ProjectionType: INCLUDE` without a `NonKeyAttributes` list is now rejected with the `ValidationException` real DynamoDB returns (`One or more parameter values were invalid: ProjectionType is INCLUDE, but NonKeyAttributes is not specified`), where dynoxide accepted it and created the table. `INCLUDE` projects the index key attributes plus an explicit list, so the list is mandatory; the shared projection validator now requires it, closing the gap for both index types ([#116](https://github.com/nubo-db/dynoxide/issues/116)).
 
 ## [0.11.1] - 2026-06-26

--- a/src/actions/create_table.rs
+++ b/src/actions/create_table.rs
@@ -300,6 +300,7 @@ fn ve(msg: String) -> DynoxideError {
 /// 8. LSI/GSI structural validation (key schema, projections, duplicates, limits)
 /// 9. Cross-index duplicate names
 /// 10. Attribute definition count mismatch
+/// 11. StreamSpecification consistency (a disabled stream must not set a view type)
 fn validate_typed_request(request: &CreateTableRequest) -> Result<()> {
     if request.table_name.is_empty() {
         return Err(DynoxideError::ValidationException(
@@ -412,7 +413,7 @@ fn validate_typed_request(request: &CreateTableRequest) -> Result<()> {
     )
     .map_err(ve)?;
 
-    // Attribute definition count (last)
+    // Attribute definition count (last of the key/index checks)
     validate_attr_def_count(
         &request.key_schema,
         &request.attribute_definitions,
@@ -420,6 +421,19 @@ fn validate_typed_request(request: &CreateTableRequest) -> Result<()> {
         &request.global_secondary_indexes,
     )
     .map_err(ve)?;
+
+    // StreamSpecification consistency: a disabled stream must not carry a view
+    // type. Real DynamoDB rejects the combination, because a view type only has
+    // meaning when the stream is enabled.
+    if let Some(ref spec) = request.stream_specification {
+        if !spec.stream_enabled && spec.stream_view_type.is_some() {
+            return Err(DynoxideError::ValidationException(
+                "One or more parameter values were invalid: Table is being created with a stream \
+                 disabled, UpdateViewType should not be specified"
+                    .to_string(),
+            ));
+        }
+    }
 
     Ok(())
 }

--- a/src/actions/create_table.rs
+++ b/src/actions/create_table.rs
@@ -1132,19 +1132,26 @@ fn validate_gsi_structure(gsi: &GlobalSecondaryIndex) -> std::result::Result<(),
 }
 
 fn validate_proj_structure(p: &Projection) -> std::result::Result<(), String> {
+    // Matched on the projection type regardless of whether NonKeyAttributes is
+    // present, so the INCLUDE-without-list case (DynamoDB rejects it) is
+    // reachable. ALL and KEYS_ONLY must not carry a list; INCLUDE requires a
+    // non-empty one. Reached by both GSI and LSI validation.
     match &p.projection_type {
         None => Err(
             "One or more parameter values were invalid: Unknown ProjectionType: null".to_string(),
         ),
-        Some(pt) => {
-            if let Some(ref nka) = p.non_key_attributes {
-                match pt {
-                    ProjectionType::ALL => return Err("One or more parameter values were invalid: ProjectionType is ALL, but NonKeyAttributes is specified".to_string()),
-                    ProjectionType::KEYS_ONLY => return Err("One or more parameter values were invalid: ProjectionType is KEYS_ONLY, but NonKeyAttributes is specified".to_string()),
-                    ProjectionType::INCLUDE => { if nka.is_empty() { return Err("One or more parameter values were invalid: NonKeyAttributes must not be empty".to_string()); } }
-                }
-            }
-            Ok(())
-        }
+        Some(ProjectionType::ALL) => match &p.non_key_attributes {
+            Some(_) => Err("One or more parameter values were invalid: ProjectionType is ALL, but NonKeyAttributes is specified".to_string()),
+            None => Ok(()),
+        },
+        Some(ProjectionType::KEYS_ONLY) => match &p.non_key_attributes {
+            Some(_) => Err("One or more parameter values were invalid: ProjectionType is KEYS_ONLY, but NonKeyAttributes is specified".to_string()),
+            None => Ok(()),
+        },
+        Some(ProjectionType::INCLUDE) => match &p.non_key_attributes {
+            None => Err("One or more parameter values were invalid: ProjectionType is INCLUDE, but NonKeyAttributes is not specified".to_string()),
+            Some(nka) if nka.is_empty() => Err("One or more parameter values were invalid: NonKeyAttributes must not be empty".to_string()),
+            Some(_) => Ok(()),
+        },
     }
 }

--- a/tests/tier3_conformance.rs
+++ b/tests/tier3_conformance.rs
@@ -535,3 +535,174 @@ fn update_expression_missing_eav_carries_invalid_update_expression_prefix() {
         "Expected Invalid UpdateExpression: prefix on missing-EAV error, got: {err}"
     );
 }
+
+// ---- Group D: CreateTable INCLUDE-projection NonKeyAttributes validation ----
+//
+// A secondary index with ProjectionType INCLUDE must carry a NonKeyAttributes
+// list. The rejection fires in the typed validator (validate_proj_structure),
+// reached by both GSI and LSI, so the request deserialises and the
+// ValidationException surfaces at create_table time. The exact wording is
+// asserted against real AWS eu-west-2 by the Parity Suite.
+
+#[test]
+fn create_table_gsi_include_without_non_key_attributes_rejected() {
+    let db = make_db();
+    let req: CreateTableRequest = serde_json::from_value(serde_json::json!({
+        "TableName": "GsiIncludeNoNka",
+        "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+        "AttributeDefinitions": [
+            {"AttributeName": "pk", "AttributeType": "S"},
+            {"AttributeName": "gsipk", "AttributeType": "S"}
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+        "GlobalSecondaryIndexes": [{
+            "IndexName": "gsi_inc",
+            "KeySchema": [{"AttributeName": "gsipk", "KeyType": "HASH"}],
+            "Projection": {"ProjectionType": "INCLUDE"}
+        }]
+    }))
+    .expect("INCLUDE with no NonKeyAttributes deserialises; rejection happens at create_table");
+    match db.create_table(req) {
+        Err(DynoxideError::ValidationException(msg)) => assert_eq!(
+            msg,
+            "One or more parameter values were invalid: ProjectionType is INCLUDE, but NonKeyAttributes is not specified"
+        ),
+        other => panic!("Expected ValidationException, got: {other:?}"),
+    }
+}
+
+#[test]
+fn create_table_lsi_include_without_non_key_attributes_rejected() {
+    let db = make_db();
+    let req: CreateTableRequest = serde_json::from_value(serde_json::json!({
+        "TableName": "LsiIncludeNoNka",
+        "KeySchema": [
+            {"AttributeName": "pk", "KeyType": "HASH"},
+            {"AttributeName": "sk", "KeyType": "RANGE"}
+        ],
+        "AttributeDefinitions": [
+            {"AttributeName": "pk", "AttributeType": "S"},
+            {"AttributeName": "sk", "AttributeType": "S"},
+            {"AttributeName": "lsi_sk", "AttributeType": "S"}
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+        "LocalSecondaryIndexes": [{
+            "IndexName": "lsi_inc",
+            "KeySchema": [
+                {"AttributeName": "pk", "KeyType": "HASH"},
+                {"AttributeName": "lsi_sk", "KeyType": "RANGE"}
+            ],
+            "Projection": {"ProjectionType": "INCLUDE"}
+        }]
+    }))
+    .expect("INCLUDE with no NonKeyAttributes deserialises; rejection happens at create_table");
+    match db.create_table(req) {
+        Err(DynoxideError::ValidationException(msg)) => assert_eq!(
+            msg,
+            "One or more parameter values were invalid: ProjectionType is INCLUDE, but NonKeyAttributes is not specified"
+        ),
+        other => panic!("Expected ValidationException, got: {other:?}"),
+    }
+}
+
+#[test]
+fn create_table_gsi_include_with_non_key_attributes_succeeds() {
+    let db = make_db();
+    let req: CreateTableRequest = serde_json::from_value(serde_json::json!({
+        "TableName": "GsiIncludeOk",
+        "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+        "AttributeDefinitions": [
+            {"AttributeName": "pk", "AttributeType": "S"},
+            {"AttributeName": "gsipk", "AttributeType": "S"}
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+        "GlobalSecondaryIndexes": [{
+            "IndexName": "gsi_inc",
+            "KeySchema": [{"AttributeName": "gsipk", "KeyType": "HASH"}],
+            "Projection": {"ProjectionType": "INCLUDE", "NonKeyAttributes": ["extra"]}
+        }]
+    }))
+    .unwrap();
+    db.create_table(req)
+        .expect("INCLUDE with a NonKeyAttributes list should succeed");
+}
+
+#[test]
+fn create_table_gsi_all_with_non_key_attributes_rejected() {
+    let db = make_db();
+    let req: CreateTableRequest = serde_json::from_value(serde_json::json!({
+        "TableName": "GsiAllWithNka",
+        "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+        "AttributeDefinitions": [
+            {"AttributeName": "pk", "AttributeType": "S"},
+            {"AttributeName": "gsipk", "AttributeType": "S"}
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+        "GlobalSecondaryIndexes": [{
+            "IndexName": "gsi_all",
+            "KeySchema": [{"AttributeName": "gsipk", "KeyType": "HASH"}],
+            "Projection": {"ProjectionType": "ALL", "NonKeyAttributes": ["extra"]}
+        }]
+    }))
+    .unwrap();
+    match db.create_table(req) {
+        Err(DynoxideError::ValidationException(msg)) => assert_eq!(
+            msg,
+            "One or more parameter values were invalid: ProjectionType is ALL, but NonKeyAttributes is specified"
+        ),
+        other => panic!("Expected ValidationException, got: {other:?}"),
+    }
+}
+
+#[test]
+fn create_table_gsi_keys_only_with_non_key_attributes_rejected() {
+    let db = make_db();
+    let req: CreateTableRequest = serde_json::from_value(serde_json::json!({
+        "TableName": "GsiKeysOnlyWithNka",
+        "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+        "AttributeDefinitions": [
+            {"AttributeName": "pk", "AttributeType": "S"},
+            {"AttributeName": "gsipk", "AttributeType": "S"}
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+        "GlobalSecondaryIndexes": [{
+            "IndexName": "gsi_ko",
+            "KeySchema": [{"AttributeName": "gsipk", "KeyType": "HASH"}],
+            "Projection": {"ProjectionType": "KEYS_ONLY", "NonKeyAttributes": ["extra"]}
+        }]
+    }))
+    .unwrap();
+    match db.create_table(req) {
+        Err(DynoxideError::ValidationException(msg)) => assert_eq!(
+            msg,
+            "One or more parameter values were invalid: ProjectionType is KEYS_ONLY, but NonKeyAttributes is specified"
+        ),
+        other => panic!("Expected ValidationException, got: {other:?}"),
+    }
+}
+
+#[test]
+fn create_table_gsi_include_empty_non_key_attributes_still_rejected() {
+    // The empty-list case is caught earlier, on the JSON collector path, with
+    // the multi-field "length greater than or equal to 1" envelope. This guards
+    // that the new INCLUDE/absent rule does not disturb it.
+    let result = serde_json::from_value::<CreateTableRequest>(serde_json::json!({
+        "TableName": "GsiIncludeEmpty",
+        "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+        "AttributeDefinitions": [
+            {"AttributeName": "pk", "AttributeType": "S"},
+            {"AttributeName": "gsipk", "AttributeType": "S"}
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+        "GlobalSecondaryIndexes": [{
+            "IndexName": "gsi_inc",
+            "KeySchema": [{"AttributeName": "gsipk", "KeyType": "HASH"}],
+            "Projection": {"ProjectionType": "INCLUDE", "NonKeyAttributes": []}
+        }]
+    }));
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("Member must have length greater than or equal to 1"),
+        "Expected empty-NonKeyAttributes length constraint, got: {err}"
+    );
+}

--- a/tests/tier3_conformance.rs
+++ b/tests/tier3_conformance.rs
@@ -706,3 +706,76 @@ fn create_table_gsi_include_empty_non_key_attributes_still_rejected() {
         "Expected empty-NonKeyAttributes length constraint, got: {err}"
     );
 }
+
+// ---- Group E: CreateTable StreamSpecification consistency ----
+//
+// A stream that is disabled must not also carry a view type: the view type only
+// has meaning when the stream is enabled, and real DynamoDB (eu-west-2, asserted
+// by the Parity Suite) rejects the combination. The check lives in the typed
+// validator, so the request deserialises and the ValidationException surfaces at
+// create_table time.
+
+#[test]
+fn create_table_stream_disabled_with_view_type_rejected() {
+    let db = make_db();
+    let req: CreateTableRequest = serde_json::from_value(serde_json::json!({
+        "TableName": "StreamDisabledView",
+        "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+        "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+        "BillingMode": "PAY_PER_REQUEST",
+        "StreamSpecification": {"StreamEnabled": false, "StreamViewType": "NEW_AND_OLD_IMAGES"}
+    }))
+    .expect("disabled stream with a view type deserialises; rejection happens at create_table");
+    match db.create_table(req) {
+        Err(DynoxideError::ValidationException(msg)) => assert_eq!(
+            msg,
+            "One or more parameter values were invalid: Table is being created with a stream disabled, UpdateViewType should not be specified"
+        ),
+        other => panic!("Expected ValidationException, got: {other:?}"),
+    }
+}
+
+#[test]
+fn create_table_stream_disabled_without_view_type_succeeds() {
+    let db = make_db();
+    let req: CreateTableRequest = serde_json::from_value(serde_json::json!({
+        "TableName": "StreamDisabledNoView",
+        "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+        "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+        "BillingMode": "PAY_PER_REQUEST",
+        "StreamSpecification": {"StreamEnabled": false}
+    }))
+    .unwrap();
+    db.create_table(req)
+        .expect("disabled stream with no view type should succeed");
+}
+
+#[test]
+fn create_table_stream_enabled_with_view_type_succeeds() {
+    let db = make_db();
+    let req: CreateTableRequest = serde_json::from_value(serde_json::json!({
+        "TableName": "StreamEnabledView",
+        "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+        "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+        "BillingMode": "PAY_PER_REQUEST",
+        "StreamSpecification": {"StreamEnabled": true, "StreamViewType": "NEW_IMAGE"}
+    }))
+    .unwrap();
+    db.create_table(req)
+        .expect("enabled stream with a view type should succeed");
+}
+
+#[test]
+fn create_table_stream_enabled_without_view_type_succeeds() {
+    let db = make_db();
+    let req: CreateTableRequest = serde_json::from_value(serde_json::json!({
+        "TableName": "StreamEnabledNoView",
+        "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+        "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+        "BillingMode": "PAY_PER_REQUEST",
+        "StreamSpecification": {"StreamEnabled": true}
+    }))
+    .unwrap();
+    db.create_table(req)
+        .expect("enabled stream with no view type should default and succeed");
+}


### PR DESCRIPTION
## What this changes

Two `CreateTable` requests that real DynamoDB rejects were being accepted, and the table created. Both now return the `ValidationException` AWS returns, before the table exists.

- A stream spec that disables the stream but still sets a `StreamViewType` (#115).
- A secondary index with `ProjectionType: INCLUDE` and no `NonKeyAttributes` list (#116).

Both checks sit in the typed validator that runs at the top of every `CreateTable`, so they apply to the HTTP/JSON and the programmatic paths alike. The projection check lives in the shared index-projection helper, so it closes the gap for local secondary indexes as well as the global one named in the issue.

Verified against the conformance suite: the four CreateTable assertions for these cases (the tier1 rejection and the tier3 exact message, for each issue) now pass, and the rest of the suite is unchanged.

Closes #115
Closes #116

## Checklist

- [x] Tests added or updated
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` pass locally
- [x] `CHANGELOG.md` updated if this is a user-visible change
- [x] Linked issue, discussion, or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms (MIT License and Apache License, Version 2.0)

## DynamoDB compatibility note

This tightens validation towards AWS: two request shapes Dynoxide used to accept are now rejected with DynamoDB's exact `ValidationException` strings, confirmed against real AWS (eu-west-2) by the conformance suite:

- `One or more parameter values were invalid: Table is being created with a stream disabled, UpdateViewType should not be specified`
- `One or more parameter values were invalid: ProjectionType is INCLUDE, but NonKeyAttributes is not specified`

The projection rule is shared between GSI and LSI, so a local secondary index with the same `INCLUDE`-without-`NonKeyAttributes` shape is now rejected too. The conformance suite pins the GSI case against live AWS today; LSI coverage for it is being added separately.
