### PR TITLE
fix: harden listener binds on Windows with SO_EXCLUSIVEADDRUSE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,21 @@ jobs:
       - name: Test
         run: cargo test ${{ matrix.flags }}
 
+  # The listener bind path is platform-specific (SO_REUSEADDR on Unix,
+  # SO_EXCLUSIVEADDRUSE on Windows), so the unit tests need a Windows run;
+  # test-build.yml only builds there.
+  test-windows:
+    name: Test (windows)
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Test
+        run: cargo test --lib
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- On Windows, the HTTP listener now binds with `SO_EXCLUSIVEADDRUSE`, closing a hole where another process running as the same user could take over the port with `SO_REUSEADDR` while dynoxide was serving. Restarting immediately after a clean shutdown still works; a regression test covers the rebind, and CI now runs the unit tests on Windows ([#23](https://github.com/nubo-db/dynoxide/issues/23)).
+- On Windows, the HTTP and MCP listeners now bind with `SO_EXCLUSIVEADDRUSE`, closing a hole where another process running as the same user could take over either port with `SO_REUSEADDR` while dynoxide was serving. Restarting immediately after a clean shutdown still works; a regression test covers the rebind, and CI now runs the unit tests on Windows ([#23](https://github.com/nubo-db/dynoxide/issues/23)).
 
 ## [0.11.2] - 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- On Windows, the HTTP listener now binds with `SO_EXCLUSIVEADDRUSE`, closing a hole where another process running as the same user could take over the port with `SO_REUSEADDR` while dynoxide was serving. Restarting immediately after a clean shutdown still works; a regression test covers the rebind, and CI now runs the unit tests on Windows ([#23](https://github.com/nubo-db/dynoxide/issues/23)).
+
 ## [0.11.2] - 2026-07-02
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1016,6 +1016,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "web-time",
+ "windows-sys 0.61.2",
  "zeroize",
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ default = ["native-sqlite", "http-server", "mcp-server", "import"]
 # keys off `cli` so the binary is skipped in backend-neutral builds such as
 # `--no-default-features --features wasm-sqlite`, which ship the library only.
 cli = ["dep:clap"]
-http-server = ["cli", "dep:axum", "dep:tokio", "dep:tower-http", "dep:tracing", "dep:tracing-subscriber", "dep:socket2", "dep:crc32fast"]
+http-server = ["cli", "dep:axum", "dep:tokio", "dep:tower-http", "dep:tracing", "dep:tracing-subscriber", "dep:socket2", "dep:crc32fast", "dep:windows-sys"]
 native-sqlite = ["dep:rusqlite", "rusqlite/bundled"]
 _has-encryption = ["dep:zeroize"]
 encryption = ["_has-encryption", "rusqlite/bundled-sqlcipher-vendored-openssl"]
@@ -117,6 +117,11 @@ async-lock = { version = "3", optional = true }
 # and keep the default getrandom-backed RNG.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 uuid = { version = "1", features = ["js"] }
+
+# The HTTP server sets SO_EXCLUSIVEADDRUSE on its listener, which socket2
+# does not expose, so it needs raw setsockopt access.
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Networking_WinSock"], optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ encryption-cc = ["_has-encryption", "rusqlite/bundled-sqlcipher"]
 encrypted-server = ["encryption", "http-server"]
 encrypted-server-cc = ["encryption-cc", "http-server"]
 encrypted-full = ["encryption", "http-server", "mcp-server", "import"]
-mcp-server = ["cli", "dep:rmcp", "dep:schemars", "dep:tokio", "dep:tokio-util", "dep:axum", "dep:tracing", "dep:tracing-subscriber", "dep:libc", "dep:directories", "dep:subtle"]
+mcp-server = ["cli", "dep:rmcp", "dep:schemars", "dep:tokio", "dep:tokio-util", "dep:axum", "dep:tracing", "dep:tracing-subscriber", "dep:libc", "dep:directories", "dep:subtle", "dep:socket2", "dep:windows-sys"]
 import = ["cli", "dep:toml", "dep:fake", "dep:sha2", "dep:flate2", "dep:indicatif", "dep:zstd", "dep:tempfile"]
 
 # Real wasm SQLite backend. dynoxide compiles to wasm32-unknown-unknown and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,8 @@ pub mod import;
 pub mod macros;
 #[cfg(feature = "mcp-server")]
 pub mod mcp;
+#[cfg(any(feature = "http-server", feature = "mcp-server"))]
+pub(crate) mod net;
 pub mod partiql;
 pub mod schema;
 #[cfg(feature = "http-server")]

--- a/src/mcp/auth.rs
+++ b/src/mcp/auth.rs
@@ -410,15 +410,18 @@ mod tests {
 
     #[test]
     fn unreadable_file_errors_without_regenerating() {
-        // A directory where the token file is expected is unreadable as a file.
-        let dir =
-            std::env::temp_dir().join(format!("dynoxide-unreadable-{}", uuid::Uuid::new_v4()));
-        std::fs::create_dir_all(&dir).unwrap();
-        // path points at a directory, so create_new fails with AlreadyExists,
-        // then read_to_string fails -> Unreadable.
-        let result = resolve_auth(true, None, false, Some(dir.clone()));
+        let path = temp_token_path();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        // An existing token file that is not valid UTF-8 fails read_to_string
+        // on every platform (a directory at the path only reproduces this on
+        // Unix; Windows rejects it at create_new with a different error).
+        let junk = [0xFF, 0xFE, 0x00, 0x9F];
+        std::fs::write(&path, junk).unwrap();
+        let result = resolve_auth(true, None, false, Some(path.clone()));
         assert!(matches!(result, Err(AuthError::Unreadable { .. })));
-        let _ = std::fs::remove_dir_all(&dir);
+        // Still the same bytes: the failure must not regenerate the file.
+        assert_eq!(std::fs::read(&path).unwrap(), junk);
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
     }
 
     #[test]

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -136,7 +136,11 @@ pub async fn serve_http_with_shutdown(
         axum::middleware::from_fn_with_state(opts.auth.clone(), auth::enforce),
     );
     let addr = format_bind_addr(&opts.host, opts.port);
-    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    // The shared exclusive-bind path gives this port the same Windows
+    // hijack protection as the DynamoDB listener. Unix behaviour is
+    // unchanged: tokio's bind also set SO_REUSEADDR there.
+    let std_listener = crate::net::bind_exclusive_to(&addr).map_err(std::io::Error::other)?;
+    let listener = tokio::net::TcpListener::from_std(std_listener)?;
     let local_addr = listener.local_addr()?;
 
     eprintln!("MCP HTTP server listening on http://{local_addr}/mcp");

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,0 +1,139 @@
+//! Shared TCP listener setup for the HTTP and MCP servers.
+
+use std::net::SocketAddr;
+
+/// Bind a TCP listener with platform-appropriate socket options.
+///
+/// Unix: `SO_REUSEADDR` lets us rebind past `TIME_WAIT` sockets from a
+/// previous clean shutdown. It doesn't let two live listeners share a port
+/// (that's `SO_REUSEPORT`), so port-conflict detection still works.
+///
+/// Windows: a plain bind already rebinds past `TIME_WAIT`, but it can be
+/// hijacked by another same-user process binding the port with
+/// `SO_REUSEADDR`. `SO_EXCLUSIVEADDRUSE` closes that hole, at the cost
+/// that MSDN warns the port may not be rebindable while connections
+/// accepted by a previous instance are still terminating.
+pub(crate) fn bind_exclusive(addr: SocketAddr) -> Result<std::net::TcpListener, String> {
+    use socket2::{Domain, Protocol, Socket, Type};
+
+    let domain = if addr.is_ipv6() {
+        Domain::IPV6
+    } else {
+        Domain::IPV4
+    };
+
+    let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))
+        .map_err(|e| format!("failed to create socket: {e}"))?;
+
+    #[cfg(unix)]
+    socket
+        .set_reuse_address(true)
+        .map_err(|e| format!("failed to set SO_REUSEADDR: {e}"))?;
+
+    #[cfg(windows)]
+    set_exclusiveaddruse(&socket)?;
+
+    socket
+        .set_nonblocking(true)
+        .map_err(|e| format!("failed to set nonblocking: {e}"))?;
+    socket
+        .bind(&addr.into())
+        .map_err(|e| format!("failed to bind {addr}: {e}"))?;
+    socket
+        .listen(1024)
+        .map_err(|e| format!("failed to listen on {addr}: {e}"))?;
+
+    Ok(std::net::TcpListener::from(socket))
+}
+
+/// Resolve `addr` and bind the first address that accepts a listener,
+/// mirroring `tokio::net::TcpListener::bind` over a resolved list.
+#[cfg(feature = "mcp-server")]
+pub(crate) fn bind_exclusive_to(addr: &str) -> Result<std::net::TcpListener, String> {
+    use std::net::ToSocketAddrs;
+
+    let addrs = addr
+        .to_socket_addrs()
+        .map_err(|e| format!("invalid address {addr}: {e}"))?;
+    let mut last_err = format!("no addresses resolved for {addr}");
+    for candidate in addrs {
+        match bind_exclusive(candidate) {
+            Ok(listener) => return Ok(listener),
+            Err(e) => last_err = e,
+        }
+    }
+    Err(last_err)
+}
+
+/// Set `SO_EXCLUSIVEADDRUSE` on a socket. socket2 does not expose this
+/// option, so it goes through raw `setsockopt`.
+#[cfg(windows)]
+fn set_exclusiveaddruse(socket: &socket2::Socket) -> Result<(), String> {
+    use std::os::windows::io::AsRawSocket;
+    use windows_sys::Win32::Networking::WinSock::{
+        SO_EXCLUSIVEADDRUSE, SOCKET, SOL_SOCKET, setsockopt,
+    };
+
+    let enable: i32 = 1;
+    // SAFETY: the socket handle is valid for the lifetime of `socket`, and
+    // optval/optlen describe a single i32 that outlives the call.
+    let rc = unsafe {
+        setsockopt(
+            socket.as_raw_socket() as SOCKET,
+            SOL_SOCKET,
+            SO_EXCLUSIVEADDRUSE,
+            std::ptr::from_ref(&enable).cast::<u8>(),
+            size_of_val(&enable) as i32,
+        )
+    };
+    if rc != 0 {
+        return Err(format!(
+            "failed to set SO_EXCLUSIVEADDRUSE: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+    use std::net::TcpStream;
+    use std::time::Duration;
+
+    /// A restart immediately after a clean shutdown must not fail on the old
+    /// connection's `TIME_WAIT` socket. Unix relies on `SO_REUSEADDR` for
+    /// this. On Windows, MSDN warns an `SO_EXCLUSIVEADDRUSE` bind may fail
+    /// while the previous connection is still settling, so this test has to
+    /// run on Windows to mean anything.
+    #[test]
+    fn rebind_succeeds_past_time_wait() {
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let listener = bind_exclusive(addr).unwrap();
+        listener.set_nonblocking(false).unwrap();
+        let bound = listener.local_addr().unwrap();
+
+        let mut client = TcpStream::connect(bound).unwrap();
+        // A lost FIN should fail the test in seconds, not hang the suite.
+        client
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        let (accepted, _) = listener.accept().unwrap();
+
+        // Server initiates the close so the server side owns the TIME_WAIT.
+        drop(accepted);
+
+        // Wait for the server's FIN, then close our side to complete the
+        // shutdown handshake.
+        let mut buf = [0u8; 1];
+        assert_eq!(client.read(&mut buf).unwrap(), 0);
+        drop(client);
+        drop(listener);
+
+        // Let the final ACK land so the old socket settles into TIME_WAIT.
+        std::thread::sleep(Duration::from_millis(50));
+
+        bind_exclusive(bound).expect("rebind past TIME_WAIT failed");
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -52,12 +52,17 @@ fn check_port_available(addr: SocketAddr) -> Result<(), String> {
     Ok(())
 }
 
-/// Bind a TCP listener.
+/// Bind a TCP listener with platform-appropriate socket options.
 ///
-/// `SO_REUSEADDR` on Unix lets us rebind past `TIME_WAIT` sockets from a
+/// Unix: `SO_REUSEADDR` lets us rebind past `TIME_WAIT` sockets from a
 /// previous clean shutdown. It doesn't let two live listeners share a port
-/// (that's `SO_REUSEPORT`), so port-conflict detection still works. Not set
-/// on Windows: the semantics there allow hijacking an active bind.
+/// (that's `SO_REUSEPORT`), so port-conflict detection still works.
+///
+/// Windows: a plain bind already rebinds past `TIME_WAIT`, but it can be
+/// hijacked by another same-user process binding the port with
+/// `SO_REUSEADDR`. `SO_EXCLUSIVEADDRUSE` closes that hole, at the cost
+/// that MSDN warns the port may not be rebindable while connections
+/// accepted by a previous instance are still terminating.
 fn bind_exclusive(addr: SocketAddr) -> Result<std::net::TcpListener, String> {
     use socket2::{Domain, Protocol, Socket, Type};
 
@@ -75,6 +80,9 @@ fn bind_exclusive(addr: SocketAddr) -> Result<std::net::TcpListener, String> {
         .set_reuse_address(true)
         .map_err(|e| format!("failed to set SO_REUSEADDR: {e}"))?;
 
+    #[cfg(windows)]
+    set_exclusiveaddruse(&socket)?;
+
     socket
         .set_nonblocking(true)
         .map_err(|e| format!("failed to set nonblocking: {e}"))?;
@@ -86,6 +94,36 @@ fn bind_exclusive(addr: SocketAddr) -> Result<std::net::TcpListener, String> {
         .map_err(|e| format!("failed to listen on {addr}: {e}"))?;
 
     Ok(std::net::TcpListener::from(socket))
+}
+
+/// Set `SO_EXCLUSIVEADDRUSE` on a socket. socket2 does not expose this
+/// option, so it goes through raw `setsockopt`.
+#[cfg(windows)]
+fn set_exclusiveaddruse(socket: &socket2::Socket) -> Result<(), String> {
+    use std::os::windows::io::AsRawSocket;
+    use windows_sys::Win32::Networking::WinSock::{
+        SO_EXCLUSIVEADDRUSE, SOCKET, SOL_SOCKET, setsockopt,
+    };
+
+    let enable: i32 = 1;
+    // SAFETY: the socket handle is valid for the lifetime of `socket`, and
+    // optval/optlen describe a single i32 that outlives the call.
+    let rc = unsafe {
+        setsockopt(
+            socket.as_raw_socket() as SOCKET,
+            SOL_SOCKET,
+            SO_EXCLUSIVEADDRUSE,
+            std::ptr::from_ref(&enable).cast::<u8>(),
+            size_of_val(&enable) as i32,
+        )
+    };
+    if rc != 0 {
+        return Err(format!(
+            "failed to set SO_EXCLUSIVEADDRUSE: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    Ok(())
 }
 
 /// Start the HTTP server.
@@ -1683,4 +1721,45 @@ fn dynamo_response_raw(status: StatusCode, body_str: &str) -> Response {
         .unwrap();
     add_dynamo_headers(&mut resp, body_bytes);
     resp
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+
+    /// A restart immediately after a clean shutdown must not fail on the old
+    /// connection's `TIME_WAIT` socket. Unix relies on `SO_REUSEADDR` for
+    /// this. On Windows, MSDN warns an `SO_EXCLUSIVEADDRUSE` bind may fail
+    /// while the previous connection is still settling, so this test has to
+    /// run on Windows to mean anything.
+    #[test]
+    fn rebind_succeeds_past_time_wait() {
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let listener = bind_exclusive(addr).unwrap();
+        listener.set_nonblocking(false).unwrap();
+        let bound = listener.local_addr().unwrap();
+
+        let mut client = TcpStream::connect(bound).unwrap();
+        // A lost FIN should fail the test in seconds, not hang the suite.
+        client
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        let (accepted, _) = listener.accept().unwrap();
+
+        // Server initiates the close so the server side owns the TIME_WAIT.
+        drop(accepted);
+
+        // Wait for the server's FIN, then close our side to complete the
+        // shutdown handshake.
+        let mut buf = [0u8; 1];
+        assert_eq!(client.read(&mut buf).unwrap(), 0);
+        drop(client);
+        drop(listener);
+
+        // Let the final ACK land so the old socket settles into TIME_WAIT.
+        std::thread::sleep(Duration::from_millis(50));
+
+        bind_exclusive(bound).expect("rebind past TIME_WAIT failed");
+    }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,6 +3,7 @@
 //! Only compiled with the `http-server` feature flag.
 
 use crate::Database;
+use crate::net::bind_exclusive;
 use axum::{
     Router,
     body::Body,
@@ -48,80 +49,6 @@ fn check_port_available(addr: SocketAddr) -> Result<(), String> {
                 "port {port} is already in use (detected listener on {probe})"
             ));
         }
-    }
-    Ok(())
-}
-
-/// Bind a TCP listener with platform-appropriate socket options.
-///
-/// Unix: `SO_REUSEADDR` lets us rebind past `TIME_WAIT` sockets from a
-/// previous clean shutdown. It doesn't let two live listeners share a port
-/// (that's `SO_REUSEPORT`), so port-conflict detection still works.
-///
-/// Windows: a plain bind already rebinds past `TIME_WAIT`, but it can be
-/// hijacked by another same-user process binding the port with
-/// `SO_REUSEADDR`. `SO_EXCLUSIVEADDRUSE` closes that hole, at the cost
-/// that MSDN warns the port may not be rebindable while connections
-/// accepted by a previous instance are still terminating.
-fn bind_exclusive(addr: SocketAddr) -> Result<std::net::TcpListener, String> {
-    use socket2::{Domain, Protocol, Socket, Type};
-
-    let domain = if addr.is_ipv6() {
-        Domain::IPV6
-    } else {
-        Domain::IPV4
-    };
-
-    let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))
-        .map_err(|e| format!("failed to create socket: {e}"))?;
-
-    #[cfg(unix)]
-    socket
-        .set_reuse_address(true)
-        .map_err(|e| format!("failed to set SO_REUSEADDR: {e}"))?;
-
-    #[cfg(windows)]
-    set_exclusiveaddruse(&socket)?;
-
-    socket
-        .set_nonblocking(true)
-        .map_err(|e| format!("failed to set nonblocking: {e}"))?;
-    socket
-        .bind(&addr.into())
-        .map_err(|e| format!("failed to bind {addr}: {e}"))?;
-    socket
-        .listen(1024)
-        .map_err(|e| format!("failed to listen on {addr}: {e}"))?;
-
-    Ok(std::net::TcpListener::from(socket))
-}
-
-/// Set `SO_EXCLUSIVEADDRUSE` on a socket. socket2 does not expose this
-/// option, so it goes through raw `setsockopt`.
-#[cfg(windows)]
-fn set_exclusiveaddruse(socket: &socket2::Socket) -> Result<(), String> {
-    use std::os::windows::io::AsRawSocket;
-    use windows_sys::Win32::Networking::WinSock::{
-        SO_EXCLUSIVEADDRUSE, SOCKET, SOL_SOCKET, setsockopt,
-    };
-
-    let enable: i32 = 1;
-    // SAFETY: the socket handle is valid for the lifetime of `socket`, and
-    // optval/optlen describe a single i32 that outlives the call.
-    let rc = unsafe {
-        setsockopt(
-            socket.as_raw_socket() as SOCKET,
-            SOL_SOCKET,
-            SO_EXCLUSIVEADDRUSE,
-            std::ptr::from_ref(&enable).cast::<u8>(),
-            size_of_val(&enable) as i32,
-        )
-    };
-    if rc != 0 {
-        return Err(format!(
-            "failed to set SO_EXCLUSIVEADDRUSE: {}",
-            std::io::Error::last_os_error()
-        ));
     }
     Ok(())
 }
@@ -1721,45 +1648,4 @@ fn dynamo_response_raw(status: StatusCode, body_str: &str) -> Response {
         .unwrap();
     add_dynamo_headers(&mut resp, body_bytes);
     resp
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::io::Read;
-
-    /// A restart immediately after a clean shutdown must not fail on the old
-    /// connection's `TIME_WAIT` socket. Unix relies on `SO_REUSEADDR` for
-    /// this. On Windows, MSDN warns an `SO_EXCLUSIVEADDRUSE` bind may fail
-    /// while the previous connection is still settling, so this test has to
-    /// run on Windows to mean anything.
-    #[test]
-    fn rebind_succeeds_past_time_wait() {
-        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-        let listener = bind_exclusive(addr).unwrap();
-        listener.set_nonblocking(false).unwrap();
-        let bound = listener.local_addr().unwrap();
-
-        let mut client = TcpStream::connect(bound).unwrap();
-        // A lost FIN should fail the test in seconds, not hang the suite.
-        client
-            .set_read_timeout(Some(Duration::from_secs(5)))
-            .unwrap();
-        let (accepted, _) = listener.accept().unwrap();
-
-        // Server initiates the close so the server side owns the TIME_WAIT.
-        drop(accepted);
-
-        // Wait for the server's FIN, then close our side to complete the
-        // shutdown handshake.
-        let mut buf = [0u8; 1];
-        assert_eq!(client.read(&mut buf).unwrap(), 0);
-        drop(client);
-        drop(listener);
-
-        // Let the final ACK land so the old socket settles into TIME_WAIT.
-        std::thread::sleep(Duration::from_millis(50));
-
-        bind_exclusive(bound).expect("rebind past TIME_WAIT failed");
-    }
 }

--- a/src/snapshots.rs
+++ b/src/snapshots.rs
@@ -637,7 +637,14 @@ mod tests {
 
         let path = resolve_snapshot_path(&db, "my-snap").unwrap();
         assert!(path.to_str().unwrap().ends_with("my-snap.db"));
-        assert!(path.to_str().unwrap().contains(".dynoxide/snapshots"));
+        // Compare components rather than a substring so the assertion holds
+        // under Windows path separators.
+        let comps: Vec<_> = path.components().map(|c| c.as_os_str()).collect();
+        let expected = [
+            std::ffi::OsStr::new(".dynoxide"),
+            std::ffi::OsStr::new("snapshots"),
+        ];
+        assert!(comps.windows(2).any(|w| w == expected));
     }
 
     #[test]


### PR DESCRIPTION
## What this changes

Fixes #23. On Windows a plain bind can be taken over by another same-user process using `SO_REUSEADDR`, so both listeners (the DynamoDB HTTP port and the MCP HTTP transport) now bind with `SO_EXCLUSIVEADDRUSE`, through a shared `net` module. The TIME_WAIT parity the issue asked about turned out to already exist: Windows rebinds past TIME_WAIT with no options set, so the gap ran the other way. Unix binds are unchanged.

MSDN warns an exclusively bound port may not be rebindable while connections from a previous instance are still settling, so there's a regression test for the restart path and a new CI job running the unit tests on windows-latest (they only ever ran on Linux before). The first run of that job confirmed the rebind works under the new option, and caught two unrelated unit tests that assumed Unix semantics; those are fixed here too.

## Checklist

- [x] Tests added or updated
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` pass locally
- [x] `CHANGELOG.md` updated if this is a user-visible change
- [x] Linked issue, discussion, or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms (MIT License and Apache License, Version 2.0)