### PR TITLE
feat(import): add schema scaffolding functionality in serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `dynoxide serve` and `dynoxide` (no-subcommand) now accept a `--schema` flag, taking the same DynamoDB DescribeTable JSON format as `import --schema`. On startup, dynoxide creates each table defined in the file and skips any that already exist. This lets you pre-populate an empty database — in-memory or persistent — with the correct table structure without running an import first.
+
 ## [0.11.3] - 2026-07-05
 
 ### Security

--- a/docs/http-server.md
+++ b/docs/http-server.md
@@ -26,6 +26,16 @@ dynoxide --db-path data.db --encryption-key-file key.hex
 DYNOXIDE_ENCRYPTION_KEY=$(cat key.hex) dynoxide --db-path data.db
 ```
 
+With tables pre-created from a schema:
+
+```sh
+# Generate schema
+aws dynamodb describe-table --table-name Users > schema.json
+
+# Start with schema
+dynoxide --schema schema.json --port 8000
+```
+
 Then use the AWS CLI or any DynamoDB SDK pointed at localhost:
 
 ```sh

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -109,10 +109,7 @@ pub struct TableImportResult {
 /// The schema file format is identical to `import --schema`: a JSON file
 /// containing a single `aws dynamodb describe-table` response or an array
 /// of them.
-pub fn scaffold_from_schema(
-    db: &Database,
-    path: &std::path::Path,
-) -> Result<usize, ImportError> {
+pub fn scaffold_from_schema(db: &Database, path: &std::path::Path) -> Result<usize, ImportError> {
     let (schemas, _) = schema::load_schemas(path).map_err(ImportError::Config)?;
     let mut created = 0;
     for table_schema in schemas {

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -110,16 +110,29 @@ pub struct TableImportResult {
 /// containing a single `aws dynamodb describe-table` response or an array
 /// of them.
 pub fn scaffold_from_schema(db: &Database, path: &std::path::Path) -> Result<usize, ImportError> {
-    let (schemas, _) = schema::load_schemas(path).map_err(ImportError::Config)?;
+    let (schemas, schema_json) = schema::load_schemas(path).map_err(ImportError::Config)?;
     let mut created = 0;
-    for table_schema in schemas {
-        match db.create_table(table_schema.create_request) {
-            Ok(_) => {
-                created += 1;
-            }
-            Err(crate::errors::DynoxideError::ResourceInUseException(_)) => {
-                // Table already exists — skip silently.
-            }
+    for table_schema in &schemas {
+        // Use raw JSON + find_table_json (same path as run_into) so the full
+        // CreateTableRequest Deserialize impl runs — LSIs, billing mode, and
+        // table class are preserved rather than dropped by the hand-parser.
+        let table_json =
+            find_table_json(&schema_json, &table_schema.table_name).ok_or_else(|| {
+                ImportError::Config(format!(
+                    "Schema JSON not found for table '{}'",
+                    table_schema.table_name
+                ))
+            })?;
+        let create_request: crate::actions::create_table::CreateTableRequest =
+            serde_json::from_value(table_json).map_err(|e| {
+                ImportError::Config(format!(
+                    "Failed to deserialize schema for '{}': {e}",
+                    table_schema.table_name
+                ))
+            })?;
+        match db.create_table(create_request) {
+            Ok(_) => created += 1,
+            Err(crate::errors::DynoxideError::ResourceInUseException(_)) => {} // already exists
             Err(e) => return Err(ImportError::Database(e.to_string())),
         }
     }

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -113,23 +113,7 @@ pub fn scaffold_from_schema(db: &Database, path: &std::path::Path) -> Result<usi
     let (schemas, schema_json) = schema::load_schemas(path).map_err(ImportError::Config)?;
     let mut created = 0;
     for table_schema in &schemas {
-        // Use raw JSON + find_table_json (same path as run_into) so the full
-        // CreateTableRequest Deserialize impl runs — LSIs, billing mode, and
-        // table class are preserved rather than dropped by the hand-parser.
-        let table_json =
-            find_table_json(&schema_json, &table_schema.table_name).ok_or_else(|| {
-                ImportError::Config(format!(
-                    "Schema JSON not found for table '{}'",
-                    table_schema.table_name
-                ))
-            })?;
-        let create_request: crate::actions::create_table::CreateTableRequest =
-            serde_json::from_value(table_json).map_err(|e| {
-                ImportError::Config(format!(
-                    "Failed to deserialize schema for '{}': {e}",
-                    table_schema.table_name
-                ))
-            })?;
+        let create_request = build_create_request(&schema_json, &table_schema.table_name)?;
         match db.create_table(create_request) {
             Ok(_) => created += 1,
             Err(crate::errors::DynoxideError::ResourceInUseException(_)) => {} // already exists
@@ -137,6 +121,24 @@ pub fn scaffold_from_schema(db: &Database, path: &std::path::Path) -> Result<usi
         }
     }
     Ok(created)
+}
+
+/// Build a `CreateTableRequest` for `table_name` from raw schema JSON.
+///
+/// Deserializes through `CreateTableRequest`'s `Deserialize` impl (rather than
+/// building the struct by hand) so GlobalSecondaryIndexes and
+/// LocalSecondaryIndexes are picked up from the schema. Shared by `run_into`
+/// and `scaffold_from_schema` so the two can't drift apart on which fields a
+/// schema-sourced table ends up with.
+fn build_create_request(
+    schema_json: &serde_json::Value,
+    table_name: &str,
+) -> Result<crate::actions::create_table::CreateTableRequest, String> {
+    let table_json = find_table_json(schema_json, table_name)
+        .ok_or_else(|| format!("Schema JSON not found for table '{table_name}'"))?;
+
+    serde_json::from_value(table_json)
+        .map_err(|e| format!("Failed to deserialize schema for '{table_name}': {e}"))
 }
 
 /// Execute the import pipeline into a caller-provided database.
@@ -204,13 +206,7 @@ pub fn run_into(db: &Database, cmd: ImportCommand) -> Result<ImportSummary, Impo
             )));
         }
 
-        // Find the matching schema JSON and deserialize into a fresh CreateTableRequest
-        let table_json = find_table_json(&schema_json, table_name)
-            .ok_or_else(|| format!("Schema JSON not found for table '{table_name}'"))?;
-
-        let create_request: crate::actions::create_table::CreateTableRequest =
-            serde_json::from_value(table_json)
-                .map_err(|e| format!("Failed to deserialize schema for '{}': {e}", table_name))?;
+        let create_request = build_create_request(&schema_json, table_name)?;
 
         db.create_table(create_request)
             .map_err(|e| format!("Failed to create table '{}': {e}", table_name))?;

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -101,6 +101,34 @@ pub struct TableImportResult {
     pub lines_skipped: usize,
 }
 
+/// Scaffold empty tables from a DynamoDB DescribeTable JSON schema file.
+///
+/// Reads the schema file, creates each table defined in it, and skips any
+/// tables that already exist. Returns the number of tables created.
+///
+/// The schema file format is identical to `import --schema`: a JSON file
+/// containing a single `aws dynamodb describe-table` response or an array
+/// of them.
+pub fn scaffold_from_schema(
+    db: &Database,
+    path: &std::path::Path,
+) -> Result<usize, ImportError> {
+    let (schemas, _) = schema::load_schemas(path).map_err(ImportError::Config)?;
+    let mut created = 0;
+    for table_schema in schemas {
+        match db.create_table(table_schema.create_request) {
+            Ok(_) => {
+                created += 1;
+            }
+            Err(crate::errors::DynoxideError::ResourceInUseException(_)) => {
+                // Table already exists — skip silently.
+            }
+            Err(e) => return Err(ImportError::Database(e.to_string())),
+        }
+    }
+    Ok(created)
+}
+
 /// Execute the import pipeline into a caller-provided database.
 ///
 /// This is the core import logic — database-agnostic. The caller is

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,11 @@ struct Cli {
     /// Path to file containing the encryption key (requires encryption feature)
     #[arg(long, value_name = "PATH")]
     encryption_key_file: Option<PathBuf>,
+
+    /// Schema file (JSON with DescribeTable responses) — scaffolds empty tables on startup
+    #[cfg(feature = "import")]
+    #[arg(long, value_name = "PATH")]
+    schema: Option<PathBuf>,
 }
 
 #[derive(Subcommand)]
@@ -406,7 +411,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
                 #[cfg(feature = "mcp-server")]
                 mcp_allowed_host: Vec::new(),
                 #[cfg(feature = "import")]
-                schema: None,
+                schema: cli.schema,
             };
             run_serve(args).await
         }
@@ -484,7 +489,7 @@ async fn run_serve(args: ServeArgs) -> Result<(), Box<dyn std::error::Error>> {
     if let Some(schema_path) = &args.schema {
         let n = dynoxide::import::scaffold_from_schema(&db, schema_path)
             .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
-        eprintln!("Scaffolded {n} table(s) from schema");
+        eprintln!("Scaffolded {} table(s) from schema", n);
     }
 
     #[cfg(feature = "mcp-server")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,6 +129,11 @@ struct ServeArgs {
     #[cfg(feature = "mcp-server")]
     #[arg(long, value_name = "HOST", requires = "mcp")]
     mcp_allowed_host: Vec<String>,
+
+    /// Schema file (JSON with DescribeTable responses) — scaffolds empty tables on startup
+    #[cfg(feature = "import")]
+    #[arg(long, value_name = "PATH")]
+    schema: Option<PathBuf>,
 }
 
 /// Arguments for the `healthcheck` subcommand.
@@ -400,6 +405,8 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
                 mcp_no_auth: false,
                 #[cfg(feature = "mcp-server")]
                 mcp_allowed_host: Vec::new(),
+                #[cfg(feature = "import")]
+                schema: None,
             };
             run_serve(args).await
         }
@@ -472,6 +479,13 @@ async fn run_serve(args: ServeArgs) -> Result<(), Box<dyn std::error::Error>> {
             None::<&str>
         }
     })?;
+
+    #[cfg(feature = "import")]
+    if let Some(schema_path) = &args.schema {
+        let n = dynoxide::import::scaffold_from_schema(&db, schema_path)
+            .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+        eprintln!("Scaffolded {n} table(s) from schema");
+    }
 
     #[cfg(feature = "mcp-server")]
     if args.mcp {

--- a/tests/import.rs
+++ b/tests/import.rs
@@ -563,10 +563,7 @@ fields = ["email"]
             })
             .unwrap();
         assert!(info.table.global_secondary_indexes.is_some());
-        assert_eq!(
-            info.table.global_secondary_indexes.unwrap().len(),
-            1
-        );
+        assert_eq!(info.table.global_secondary_indexes.unwrap().len(), 1);
     }
 
     #[test]
@@ -577,7 +574,12 @@ fields = ["email"]
             std::path::Path::new("/tmp/dynoxide-nonexistent-schema-file.json"),
         );
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Failed to read schema file"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Failed to read schema file")
+        );
     }
 
     #[test]

--- a/tests/import.rs
+++ b/tests/import.rs
@@ -460,6 +460,126 @@ fields = ["email"]
         );
     }
 
+    // ---------------------------------------------------------------------------
+    // scaffold_from_schema tests
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn test_scaffold_creates_table() {
+        let tmp = tempfile::tempdir().unwrap();
+        let schema_file = tmp.path().join("schema.json");
+        create_schema_file(&schema_file, &[simple_table_schema("Users")]);
+
+        let db = dynoxide::Database::memory().unwrap();
+        let n = import::scaffold_from_schema(&db, &schema_file).unwrap();
+        assert_eq!(n, 1);
+
+        let tables = db
+            .list_tables(dynoxide::actions::list_tables::ListTablesRequest::default())
+            .unwrap();
+        assert_eq!(tables.table_names, vec!["Users"]);
+    }
+
+    #[test]
+    fn test_scaffold_multiple_tables() {
+        let tmp = tempfile::tempdir().unwrap();
+        let schema_file = tmp.path().join("schema.json");
+        create_schema_file(
+            &schema_file,
+            &[
+                simple_table_schema("Users"),
+                simple_table_schema("Orders"),
+                simple_table_schema("Products"),
+            ],
+        );
+
+        let db = dynoxide::Database::memory().unwrap();
+        let n = import::scaffold_from_schema(&db, &schema_file).unwrap();
+        assert_eq!(n, 3);
+
+        let mut tables = db
+            .list_tables(dynoxide::actions::list_tables::ListTablesRequest::default())
+            .unwrap()
+            .table_names;
+        tables.sort();
+        assert_eq!(tables, vec!["Orders", "Products", "Users"]);
+    }
+
+    #[test]
+    fn test_scaffold_skips_existing_tables() {
+        let tmp = tempfile::tempdir().unwrap();
+        let schema_file = tmp.path().join("schema.json");
+        create_schema_file(&schema_file, &[simple_table_schema("Users")]);
+
+        let db = dynoxide::Database::memory().unwrap();
+
+        // First call creates the table.
+        let n = import::scaffold_from_schema(&db, &schema_file).unwrap();
+        assert_eq!(n, 1);
+
+        // Second call should succeed and skip the already-existing table.
+        let n = import::scaffold_from_schema(&db, &schema_file).unwrap();
+        assert_eq!(n, 0);
+
+        // Still exactly one table.
+        let tables = db
+            .list_tables(dynoxide::actions::list_tables::ListTablesRequest::default())
+            .unwrap();
+        assert_eq!(tables.table_names.len(), 1);
+    }
+
+    #[test]
+    fn test_scaffold_with_gsi() {
+        let tmp = tempfile::tempdir().unwrap();
+        let schema_file = tmp.path().join("schema.json");
+        let schema = serde_json::json!({
+            "Table": {
+                "TableName": "Events",
+                "KeySchema": [
+                    {"AttributeName": "pk", "KeyType": "HASH"},
+                    {"AttributeName": "sk", "KeyType": "RANGE"}
+                ],
+                "AttributeDefinitions": [
+                    {"AttributeName": "pk", "AttributeType": "S"},
+                    {"AttributeName": "sk", "AttributeType": "S"},
+                    {"AttributeName": "gsi1pk", "AttributeType": "S"}
+                ],
+                "GlobalSecondaryIndexes": [{
+                    "IndexName": "gsi1",
+                    "KeySchema": [{"AttributeName": "gsi1pk", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "ALL"}
+                }]
+            }
+        });
+        create_schema_file(&schema_file, &[schema]);
+
+        let db = dynoxide::Database::memory().unwrap();
+        let n = import::scaffold_from_schema(&db, &schema_file).unwrap();
+        assert_eq!(n, 1);
+
+        let info = db
+            .describe_table(dynoxide::actions::describe_table::DescribeTableRequest {
+                table_name: "Events".to_string(),
+            })
+            .unwrap();
+        assert!(info.table.global_secondary_indexes.is_some());
+        assert_eq!(
+            info.table.global_secondary_indexes.unwrap().len(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_scaffold_missing_file_errors() {
+        let db = dynoxide::Database::memory().unwrap();
+        let result = import::scaffold_from_schema(
+            &db,
+            std::path::Path::new("/tmp/dynoxide-nonexistent-schema-file.json"),
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Failed to read schema file"));
+    }
+
     #[test]
     fn test_import_into_memory_database() {
         let tmp = tempfile::tempdir().unwrap();

--- a/tests/import.rs
+++ b/tests/import.rs
@@ -567,6 +567,50 @@ fields = ["email"]
     }
 
     #[test]
+    fn test_scaffold_with_lsi() {
+        // `created_at` is used only by the LSI's sort key, not by the table's
+        // own key schema. A hand-parsed CreateTableRequest that drops
+        // LocalSecondaryIndexes leaves it orphaned and table creation fails.
+        let tmp = tempfile::tempdir().unwrap();
+        let schema_file = tmp.path().join("schema.json");
+        let schema = serde_json::json!({
+            "Table": {
+                "TableName": "Orders",
+                "KeySchema": [
+                    {"AttributeName": "pk", "KeyType": "HASH"},
+                    {"AttributeName": "sk", "KeyType": "RANGE"}
+                ],
+                "AttributeDefinitions": [
+                    {"AttributeName": "pk", "AttributeType": "S"},
+                    {"AttributeName": "sk", "AttributeType": "S"},
+                    {"AttributeName": "created_at", "AttributeType": "S"}
+                ],
+                "LocalSecondaryIndexes": [{
+                    "IndexName": "by-created-at",
+                    "KeySchema": [
+                        {"AttributeName": "pk", "KeyType": "HASH"},
+                        {"AttributeName": "created_at", "KeyType": "RANGE"}
+                    ],
+                    "Projection": {"ProjectionType": "ALL"}
+                }]
+            }
+        });
+        create_schema_file(&schema_file, &[schema]);
+
+        let db = dynoxide::Database::memory().unwrap();
+        let n = import::scaffold_from_schema(&db, &schema_file).unwrap();
+        assert_eq!(n, 1);
+
+        let info = db
+            .describe_table(dynoxide::actions::describe_table::DescribeTableRequest {
+                table_name: "Orders".to_string(),
+            })
+            .unwrap();
+        assert!(info.table.local_secondary_indexes.is_some());
+        assert_eq!(info.table.local_secondary_indexes.unwrap().len(), 1);
+    }
+
+    #[test]
     fn test_scaffold_missing_file_errors() {
         let db = dynoxide::Database::memory().unwrap();
         let result = import::scaffold_from_schema(

--- a/tests/serve_schema.rs
+++ b/tests/serve_schema.rs
@@ -6,7 +6,7 @@
 #![cfg(all(feature = "http-server", feature = "import"))]
 
 use std::io::{BufRead, BufReader};
-use std::process::{Command, Stdio};
+use std::process::{Child, ChildStderr, Command, Stdio};
 use std::time::{Duration, Instant};
 
 fn dynoxide_bin() -> &'static str {
@@ -31,37 +31,62 @@ fn free_port() -> u16 {
     l.local_addr().unwrap().port()
 }
 
-/// Spawn `dynoxide` with the given args, wait up to `timeout` for a line on
-/// stderr matching `needle`, kill the process, then return whether it was found.
-fn spawn_and_wait_for_stderr(args: &[&str], needle: &str, timeout: Duration) -> bool {
+/// Spawn `dynoxide` with the given args and a piped stderr stream.
+fn spawn_dynoxide(args: &[&str]) -> (Child, BufReader<ChildStderr>) {
     let mut child = Command::new(dynoxide_bin())
         .args(args)
         .stderr(Stdio::piped())
         .stdout(Stdio::null())
         .spawn()
         .expect("spawn dynoxide");
-
     let stderr = child.stderr.take().unwrap();
-    let mut reader = BufReader::new(stderr);
-    let deadline = Instant::now() + timeout;
-    let mut found = false;
-    let mut line = String::new();
+    (child, BufReader::new(stderr))
+}
 
+/// Read lines from `reader` until one contains `needle` or `timeout` elapses.
+fn wait_for_line(reader: &mut impl BufRead, needle: &str, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    let mut line = String::new();
     while Instant::now() < deadline {
         line.clear();
         match reader.read_line(&mut line) {
             Ok(0) | Err(_) => break,
-            Ok(_) if line.contains(needle) => {
-                found = true;
-                break;
-            }
+            Ok(_) if line.contains(needle) => return true,
             Ok(_) => {}
         }
     }
+    false
+}
 
+/// Spawn `dynoxide` with the given args, wait up to `timeout` for a line on
+/// stderr matching `needle`, kill the process, then return whether it was found.
+fn spawn_and_wait_for_stderr(args: &[&str], needle: &str, timeout: Duration) -> bool {
+    let (mut child, mut reader) = spawn_dynoxide(args);
+    let found = wait_for_line(&mut reader, needle, timeout);
     let _ = child.kill();
     let _ = child.wait();
     found
+}
+
+/// Send a minimal DynamoDB `DescribeTable` request. Dynoxide doesn't verify
+/// SigV4 signatures, so a well-formed-but-fake Authorization header is enough.
+async fn describe_table(port: u16, table_name: &str) -> serde_json::Value {
+    reqwest::Client::new()
+        .post(format!("http://127.0.0.1:{port}"))
+        .header("x-amz-target", "DynamoDB_20120810.DescribeTable")
+        .header("content-type", "application/x-amz-json-1.0")
+        .header(
+            "authorization",
+            "AWS4-HMAC-SHA256 Credential=fakekey/20260101/us-east-1/dynamodb/aws4_request, SignedHeaders=host;x-amz-date;x-amz-target, Signature=fakesig",
+        )
+        .header("x-amz-date", "20260101T000000Z")
+        .json(&serde_json::json!({ "TableName": table_name }))
+        .send()
+        .await
+        .expect("send DescribeTable request")
+        .json()
+        .await
+        .expect("parse DescribeTable response")
 }
 
 #[test]
@@ -137,4 +162,63 @@ fn root_schema_scaffolds_tables_on_startup() {
         found,
         "`dynoxide --schema` (no subcommand) did not emit scaffold message within timeout"
     );
+}
+
+/// Regression test: `created_at` is used only by the LSI's sort key, not by
+/// the table's own key schema or any other index. A hand-parsed
+/// `CreateTableRequest` that drops `LocalSecondaryIndexes` leaves this
+/// attribute definition orphaned, which real table creation rejects outright.
+#[tokio::test]
+async fn serve_schema_scaffolds_lsi_with_orphaned_attribute() {
+    let tmp = tempfile::tempdir().unwrap();
+    let schema_file = tmp.path().join("schema.json");
+    let schema = serde_json::json!([{
+        "Table": {
+            "TableName": "Orders",
+            "KeySchema": [
+                {"AttributeName": "pk", "KeyType": "HASH"},
+                {"AttributeName": "sk", "KeyType": "RANGE"}
+            ],
+            "AttributeDefinitions": [
+                {"AttributeName": "pk", "AttributeType": "S"},
+                {"AttributeName": "sk", "AttributeType": "S"},
+                {"AttributeName": "created_at", "AttributeType": "S"}
+            ],
+            "LocalSecondaryIndexes": [{
+                "IndexName": "by-created-at",
+                "KeySchema": [
+                    {"AttributeName": "pk", "KeyType": "HASH"},
+                    {"AttributeName": "created_at", "KeyType": "RANGE"}
+                ],
+                "Projection": {"ProjectionType": "ALL"}
+            }]
+        }
+    }]);
+    std::fs::write(&schema_file, serde_json::to_string_pretty(&schema).unwrap()).unwrap();
+
+    let port = free_port();
+    let (mut child, mut reader) = spawn_dynoxide(&[
+        "serve",
+        "--port",
+        &port.to_string(),
+        "--schema",
+        schema_file.to_str().unwrap(),
+    ]);
+    let scaffolded = wait_for_line(
+        &mut reader,
+        "Scaffolded 1 table(s) from schema",
+        Duration::from_secs(10),
+    );
+    assert!(scaffolded, "server did not report scaffolding the table");
+
+    let body = describe_table(port, "Orders").await;
+    let _ = child.kill();
+    let _ = child.wait();
+
+    let lsis = &body["Table"]["LocalSecondaryIndexes"];
+    assert!(
+        lsis.is_array(),
+        "expected LocalSecondaryIndexes in DescribeTable response: {body}"
+    );
+    assert_eq!(lsis[0]["IndexName"], "by-created-at");
 }

--- a/tests/serve_schema.rs
+++ b/tests/serve_schema.rs
@@ -1,0 +1,140 @@
+//! CLI tests for the `--schema` flag on `serve` and the no-subcommand form.
+//!
+//! These tests spawn the compiled binary as a subprocess so the arg-parsing
+//! and startup routing are exercised end to end, not just the library API.
+
+#![cfg(all(feature = "http-server", feature = "import"))]
+
+use std::io::{BufRead, BufReader};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn dynoxide_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_dynoxide")
+}
+
+/// Write a minimal single-table DescribeTable schema file.
+fn write_schema_file(path: &std::path::Path, table_name: &str) {
+    let schema = serde_json::json!([{
+        "Table": {
+            "TableName": table_name,
+            "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+            "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}]
+        }
+    }]);
+    std::fs::write(path, serde_json::to_string_pretty(&schema).unwrap()).unwrap();
+}
+
+/// Bind and immediately release a loopback listener to obtain a free port.
+fn free_port() -> u16 {
+    let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    l.local_addr().unwrap().port()
+}
+
+/// Spawn `dynoxide` with the given args, wait up to `timeout` for a line on
+/// stderr matching `needle`, kill the process, then return whether it was found.
+fn spawn_and_wait_for_stderr(args: &[&str], needle: &str, timeout: Duration) -> bool {
+    let mut child = Command::new(dynoxide_bin())
+        .args(args)
+        .stderr(Stdio::piped())
+        .stdout(Stdio::null())
+        .spawn()
+        .expect("spawn dynoxide");
+
+    let stderr = child.stderr.take().unwrap();
+    let mut reader = BufReader::new(stderr);
+    let deadline = Instant::now() + timeout;
+    let mut found = false;
+    let mut line = String::new();
+
+    while Instant::now() < deadline {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) | Err(_) => break,
+            Ok(_) if line.contains(needle) => {
+                found = true;
+                break;
+            }
+            Ok(_) => {}
+        }
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+    found
+}
+
+#[test]
+fn serve_help_lists_schema_flag() {
+    let output = Command::new(dynoxide_bin())
+        .args(["serve", "--help"])
+        .output()
+        .expect("spawn dynoxide");
+    assert!(output.status.success(), "--help should exit 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("--schema"),
+        "`dynoxide serve --help` should list --schema; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn root_help_lists_schema_flag() {
+    let output = Command::new(dynoxide_bin())
+        .args(["--help"])
+        .output()
+        .expect("spawn dynoxide");
+    assert!(output.status.success(), "--help should exit 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("--schema"),
+        "`dynoxide --help` should list --schema; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn serve_schema_scaffolds_tables_on_startup() {
+    let tmp = tempfile::tempdir().unwrap();
+    let schema_file = tmp.path().join("schema.json");
+    write_schema_file(&schema_file, "Widgets");
+
+    let port = free_port();
+    let found = spawn_and_wait_for_stderr(
+        &[
+            "serve",
+            "--port",
+            &port.to_string(),
+            "--schema",
+            schema_file.to_str().unwrap(),
+        ],
+        "Scaffolded 1 table(s) from schema",
+        Duration::from_secs(10),
+    );
+    assert!(
+        found,
+        "`dynoxide serve --schema` did not emit scaffold message within timeout"
+    );
+}
+
+#[test]
+fn root_schema_scaffolds_tables_on_startup() {
+    let tmp = tempfile::tempdir().unwrap();
+    let schema_file = tmp.path().join("schema.json");
+    write_schema_file(&schema_file, "Gadgets");
+
+    let port = free_port();
+    let found = spawn_and_wait_for_stderr(
+        &[
+            "--port",
+            &port.to_string(),
+            "--schema",
+            schema_file.to_str().unwrap(),
+        ],
+        "Scaffolded 1 table(s) from schema",
+        Duration::from_secs(10),
+    );
+    assert!(
+        found,
+        "`dynoxide --schema` (no subcommand) did not emit scaffold message within timeout"
+    );
+}


### PR DESCRIPTION
<!-- Thanks for the PR. A short description and the checklist below
are usually enough. For anything non-trivial, please link the issue
where direction was agreed. -->

Resolves https://github.com/nubo-db/dynoxide/issues/138

## What this changes

- Adds the --schema option to serve to scaffold an empty table.

<!-- One or two sentences. What does this PR do and why? -->

## Checklist

- [x] Tests added or updated
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` pass locally
- [x] `CHANGELOG.md` updated if this is a user-visible change
- [x] Linked issue, discussion, or a short note explaining the
  motivation
- [x] I agree my contribution is licensed under the project's terms
  (MIT License and Apache License, Version 2.0)

## DynamoDB compatibility note (delete if not applicable)

<!-- Does this change Dynoxide's observable behaviour relative to AWS
DynamoDB? If yes, summarise the difference and link the AWS doc or
behaviour note that motivates it. -->
