### PR TITLE
fix(cli): reject top-level args combined with a subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Passing a top-level argument together with a subcommand is now a hard parse error, where the argument was silently ignored. The top-level `--host`, `--port`, `--db-path` and `--encryption-key-file` exist for the bare pre-subcommand form (`dynoxide --port 8000`) and only fed the no-subcommand path, so `dynoxide --db-path data.db serve` started an in-memory server, never created the file, and the data was gone on exit with nothing said about it; `dynoxide --port 8893 serve` listened on 8000. Combining one with `serve`, `mcp`, `import` or `healthcheck` now fails up front with clap's conflict error naming the offending option, and the same option after the subcommand keeps working as before ([#141](https://github.com/nubo-db/dynoxide/issues/141)).
+
 ## [0.11.3] - 2026-07-05
 
 ### Security

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ use zeroize::Zeroizing;
     version,
     about = "A fast, lightweight drop-in replacement for DynamoDB Local, backed by SQLite",
     after_help = after_help_text(),
+    args_conflicts_with_subcommands = true,
 )]
 struct Cli {
     #[command(subcommand)]
@@ -34,7 +35,10 @@ struct Cli {
 
     // --- Top-level args for backward compatibility (no subcommand = serve) ---
     // These are only used when no subcommand is given, for backward compat
-    // with `dynoxide --port 8000` style invocations.
+    // with `dynoxide --port 8000` style invocations. Combining one with an
+    // explicit subcommand is a parse error (args_conflicts_with_subcommands
+    // above): the subcommands take these options themselves, so accepting
+    // both would silently drop the top-level value.
     /// Host to bind to
     #[arg(long, default_value = "127.0.0.1")]
     host: Option<String>,
@@ -1141,6 +1145,55 @@ fn validate_key(key: &str) -> Result<(), Box<dyn std::error::Error>> {
 mod tests {
     #[cfg(feature = "encryption")]
     use super::*;
+
+    mod cli_parse_tests {
+        use super::super::*;
+
+        #[test]
+        fn top_level_args_are_rejected_alongside_a_subcommand() {
+            for argv in [
+                vec!["dynoxide", "--db-path", "data.db", "serve"],
+                vec!["dynoxide", "--port", "8893", "serve"],
+                vec!["dynoxide", "--host", "0.0.0.0", "serve"],
+                vec!["dynoxide", "--encryption-key-file", "key.hex", "serve"],
+            ] {
+                assert!(
+                    Cli::try_parse_from(&argv).is_err(),
+                    "expected parse error for {argv:?}, top-level args must not be \
+                     silently dropped when a subcommand is given"
+                );
+            }
+        }
+
+        #[cfg(feature = "mcp-server")]
+        #[test]
+        fn top_level_args_are_rejected_alongside_mcp_subcommand() {
+            assert!(Cli::try_parse_from(["dynoxide", "--db-path", "data.db", "mcp"]).is_err());
+        }
+
+        #[test]
+        fn bare_subcommand_still_parses() {
+            assert!(Cli::try_parse_from(["dynoxide", "serve"]).is_ok());
+        }
+
+        #[test]
+        fn top_level_args_still_parse_without_a_subcommand() {
+            let cli = Cli::try_parse_from(["dynoxide", "--port", "8893", "--db-path", "data.db"])
+                .unwrap();
+            assert!(cli.command.is_none());
+            assert_eq!(cli.port, Some(8893));
+            assert_eq!(cli.db_path.as_deref(), Some("data.db"));
+        }
+
+        #[test]
+        fn subcommand_level_args_still_parse() {
+            let cli = Cli::try_parse_from(["dynoxide", "serve", "--port", "8893"]).unwrap();
+            match cli.command {
+                Some(Commands::Serve(args)) => assert_eq!(args.port, 8893),
+                _ => panic!("expected serve subcommand"),
+            }
+        }
+    }
 
     #[cfg(feature = "encryption")]
     mod validate_key_tests {


### PR DESCRIPTION
## What this changes

The top-level `--host`, `--port`, `--db-path` and `--encryption-key-file` only feed the no-subcommand path, so `dynoxide --db-path data.db serve` parsed cleanly, dropped the path, and served from memory - data gone on exit with nothing said about it. `--port 8893 serve` listened on 8000 the same way. This marks the combination as a clap conflict, so it's now a hard parse error:

```
error: the subcommand 'serve' cannot be used with '--db-path <DB_PATH>'
```

Flags after the subcommand are untouched, as is the bare `dynoxide --port 8000` form.

Went with the hard error rather than `global = true` because the subcommands each define their own `--port`/`--host` with different defaults and meanings (serve's 8000, mcp's 19280, healthcheck's probe target), so a propagated global would collide with them.

Fixes #141

## Checklist

- [x] Tests added or updated
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` pass locally
- [x] `CHANGELOG.md` updated if this is a user-visible change
- [x] Linked issue, discussion, or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms (MIT License and Apache License, Version 2.0)