### PR TITLE
fix(partiql): real list-index writes and dense-pack MODIFIED projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Breaking (Rust API):** the public `partiql::parser::Statement` enum gained a `returning` field on its `Update` and `Delete` variants, and both variants are now `#[non_exhaustive]`. Library consumers that construct or exhaustively match these AST variants must add `..`. This is a source-breaking change for the crate's public API, so the next release is a minor bump (0.12.0). The DynamoDB wire API and the CLI/server/MCP surfaces are unaffected.
+- **Breaking (Rust API):** the public `partiql::parser::Statement` enum gained a `returning` field on its `Update` and `Delete` variants, and both variants are now `#[non_exhaustive]`; the public `actions::batch_execute_statement::BatchStatementResponse` struct gained a `table_name` field and is now `#[non_exhaustive]` too. Library consumers that construct or exhaustively match these types must add `..`. This is a source-breaking change for the crate's public API, so the next release is a minor bump (0.12.0). The DynamoDB wire API and the CLI/server/MCP surfaces are unaffected.
 
 ### Added
 
 - PartiQL now honours the `RETURNING` clause on `ExecuteStatement`, where dynoxide previously parsed the statement but silently dropped the clause. `DELETE ... RETURNING ALL OLD *` returns the deleted item in `Items` (a present but empty `Items` array on a missing target, matching DynamoDB rather than the classic `DeleteItem` path), and `UPDATE ... RETURNING <ALL|MODIFIED> <OLD|NEW> *` returns the matching projection of the item; the `MODIFIED` variants return only the changed paths (a nested `SET a.b` returns just the changed leaf, not the whole `a` attribute), exclude the primary key, and return an empty `Items` array when nothing was projected. `BatchExecuteStatement` honours a member's `RETURNING` clause; `ExecuteTransaction` rejects one with a top-level `ValidationException`. The `RETURNING` variants DynamoDB does not allow on `DELETE` (`MODIFIED OLD *`, `ALL NEW *`, `MODIFIED NEW *`) are rejected with its exact validation message instead of being ignored ([#137](https://github.com/nubo-db/dynoxide/issues/137)).
-### Added
+- `dynoxide serve` and `dynoxide` (no-subcommand) now accept a `--schema` flag, taking the same DynamoDB DescribeTable JSON format as `import --schema`. On startup, dynoxide creates each table defined in the file and skips any that already exist. This lets you pre-populate an empty database (in-memory or persistent) with the correct table structure without running an import first.
 
-- `dynoxide serve` and `dynoxide` (no-subcommand) now accept a `--schema` flag, taking the same DynamoDB DescribeTable JSON format as `import --schema`. On startup, dynoxide creates each table defined in the file and skips any that already exist. This lets you pre-populate an empty database — in-memory or persistent — with the correct table structure without running an import first.
+### Fixed
+
+- PartiQL `UPDATE` now performs real list-index writes. `SET tags[0] = :v` updates the list element (appending when the index is at or beyond the end) and `REMOVE tags[0]` deletes it and shifts the rest, where dynoxide previously treated `tags[0]` as a literal map key so both the stored item and a `RETURNING MODIFIED` projection over it diverged from DynamoDB. A `RETURNING MODIFIED` projection over list-index paths now packs the changed elements into a dense list in ascending index order (`SET a[0], a[2]` yields `{a: [v0, v2]}`), matching DynamoDB.
+- `BatchExecuteStatement` now echoes `TableName` on each successful member response, and a member that fails to parse now carries the short-form `ValidationError` code (matching a per-statement execution error) instead of the long-form `ValidationException`. Both match DynamoDB.
 
 ## [0.11.4] - 2026-07-17
 

--- a/src/actions/batch_execute_statement.rs
+++ b/src/actions/batch_execute_statement.rs
@@ -25,11 +25,17 @@ pub struct BatchExecuteStatementResponse {
 }
 
 #[derive(Debug, Default, Serialize)]
+#[non_exhaustive]
 pub struct BatchStatementResponse {
     #[serde(rename = "Error", skip_serializing_if = "Option::is_none")]
     pub error: Option<BatchStatementError>,
     #[serde(rename = "Item", skip_serializing_if = "Option::is_none")]
     pub item: Option<Item>,
+    /// The member statement's target table, echoed on a successful response
+    /// (with or without an `Item`), matching DynamoDB. Omitted on a
+    /// per-statement error and when the statement fails to parse.
+    #[serde(rename = "TableName", skip_serializing_if = "Option::is_none")]
+    pub table_name: Option<String>,
 }
 
 #[derive(Debug, Default, Serialize)]
@@ -64,12 +70,19 @@ pub async fn execute<S: StorageBackend>(
         let response = match parsed {
             Err(e) => BatchStatementResponse {
                 error: Some(BatchStatementError {
-                    code: "ValidationException".to_string(),
+                    // A per-statement parse failure carries the short-form
+                    // `ValidationError` code, the same as an execution error,
+                    // matching DynamoDB.
+                    code: "ValidationError".to_string(),
                     message: format!("Statement wasn't well formed, got error: {e}"),
                 }),
                 item: None,
+                table_name: None,
             },
             Ok(stmt) => {
+                // DynamoDB echoes the target table on a successful response, but
+                // not on a per-statement error.
+                let table = partiql::parser::table_name(&stmt).map(str::to_string);
                 let params = stmt_req.parameters.as_deref().unwrap_or_default();
                 match partiql::executor::execute(storage, &stmt, params, None).await {
                     Ok(Some(items)) => {
@@ -79,11 +92,13 @@ pub async fn execute<S: StorageBackend>(
                         BatchStatementResponse {
                             error: None,
                             item: items.into_iter().next(),
+                            table_name: table,
                         }
                     }
                     Ok(None) => BatchStatementResponse {
                         error: None,
                         item: None,
+                        table_name: table,
                     },
                     Err(e) => BatchStatementResponse {
                         error: Some(BatchStatementError {
@@ -91,6 +106,7 @@ pub async fn execute<S: StorageBackend>(
                             message: e.to_string(),
                         }),
                         item: None,
+                        table_name: None,
                     },
                 }
             }

--- a/src/partiql/executor.rs
+++ b/src/partiql/executor.rs
@@ -521,9 +521,9 @@ async fn execute_update<S: StorageBackend>(
     crate::streams::record_stream_event(storage, &meta, old_ref, Some(&item)).await?;
 
     // Build the RETURNING projection from the item's before/after states. The
-    // "modified" paths are the full document paths the SET/REMOVE clauses
-    // touched; the MODIFIED variants project only those (a nested `a.b` yields
-    // just the changed leaf, never the whole `a` attribute and never the key).
+    // MODIFIED variants project each touched path (a nested `a.b` yields just
+    // the changed leaf, never the whole `a` attribute and never the key),
+    // resolved against the relevant item.
     let projection = returning.map(|variant| {
         let modified: std::collections::BTreeSet<String> = set_clauses
             .iter()
@@ -538,10 +538,11 @@ async fn execute_update<S: StorageBackend>(
 
 /// Build the `RETURNING` projection for an UPDATE from the item's before/after
 /// states. `ALL` variants return the whole item (key included); `MODIFIED`
-/// variants return only the paths the statement touched, at their old or new
-/// values, which never includes the key. A `MODIFIED` projection can be empty
-/// (e.g. a REMOVE under `MODIFIED NEW`, or a newly-created attribute under
-/// `MODIFIED OLD`), which the caller surfaces as an empty `Items` array.
+/// variants project only the touched paths, resolved against the old item
+/// (`MODIFIED OLD *`) or the new item (`MODIFIED NEW *`), which never includes
+/// the key. A `MODIFIED` projection can be empty (a path that no longer
+/// resolves contributes nothing), which the caller surfaces as an empty `Items`
+/// array.
 fn project_returning(
     variant: ReturningVariant,
     old_item: &Item,
@@ -556,42 +557,94 @@ fn project_returning(
     }
 }
 
-/// Project only the modified paths from `source`, rebuilding nested map
-/// structure so a nested `SET a.b` yields `{a: {b: ...}}` (just the changed
-/// leaf, matching DynamoDB) rather than the whole `a` attribute. A path absent
-/// from `source` contributes nothing, so the projection may be empty.
-fn project_modified(paths: &std::collections::BTreeSet<String>, source: &Item) -> Item {
-    let mut projection = Item::new();
-    for path in paths {
-        if let Some(val) = get_nested_value(source, path) {
-            // set_nested_value only errors on a non-map intermediate, which
-            // cannot arise when the value was just read from `source` along the
-            // same path.
-            let _ = set_nested_value(&mut projection, path, val.clone());
-        }
-    }
-    projection
+/// An intermediate `MODIFIED` projection node. List positions are collected by
+/// their real index in a `BTreeMap` so that, on conversion, the contributed
+/// elements emerge as a dense list in ascending index order: DynamoDB does not
+/// keep gaps, so `SET a[0], a[2]` projects `{a: [v0, v2]}`, not a sparse list.
+enum ProjNode {
+    Leaf(AttributeValue),
+    Map(HashMap<String, ProjNode>),
+    List(std::collections::BTreeMap<usize, ProjNode>),
 }
 
-/// Read the value at a dotted document path, mirroring `set_nested_value`'s
-/// navigation: dots descend into maps, and a segment is matched as a whole key
-/// (so a bracket-index path like `a[0]` is treated as the single key `a[0]`,
-/// consistent with how SET stored it).
-///
-/// This deliberately mirrors `set_nested_value`, not `resolve_nested_path`
-/// (which navigates real list indices). The projection must read a path exactly
-/// as SET wrote it, so swapping in `resolve_nested_path` would silently
-/// mishandle a bracket-index `SET`/`REMOVE` under a `MODIFIED` projection.
-fn get_nested_value<'a>(item: &'a Item, path: &str) -> Option<&'a AttributeValue> {
-    let mut parts = path.split('.');
-    let mut current = item.get(parts.next()?)?;
-    for part in parts {
-        match current {
-            AttributeValue::M(map) => current = map.get(part)?,
-            _ => return None,
+/// Project the touched paths from `source` into a `MODIFIED` projection. Each
+/// path is resolved against `source` (navigating map keys and real list
+/// indices); a path that resolves contributes its value, one that does not
+/// contributes nothing. This is why a map REMOVE yields nothing under
+/// `MODIFIED NEW` (the key is gone) while a list REMOVE contributes the
+/// shifted-in element (`tags[1]` still resolves after `REMOVE tags[1]`).
+/// Contributed list elements pack densely in ascending index order. This is by
+/// index, not statement order: for `SET a[2]=.., a[0]=..` real DynamoDB returns
+/// `{a: [v0, v2]}`, which the `BTreeMap`-keyed pack matches.
+fn project_modified(paths: &std::collections::BTreeSet<String>, source: &Item) -> Item {
+    let mut root: HashMap<String, ProjNode> = HashMap::new();
+    for path in paths {
+        if let (Some(val), Some(segments)) =
+            (resolve_nested_path(source, path), split_path_segments(path))
+        {
+            // The top-level of an item is always addressed by a map key.
+            if let Some((PathSegment::Key(key), rest)) = segments.split_first() {
+                let node = root
+                    .entry((*key).to_string())
+                    .or_insert_with(|| fresh_proj_node(rest));
+                insert_proj_node(node, rest, val.clone());
+            }
         }
     }
-    Some(current)
+    root.into_iter()
+        .map(|(k, node)| (k, proj_node_to_value(node)))
+        .collect()
+}
+
+/// The container a projection node needs for its next segment: a list for an
+/// index, a map otherwise. An empty `segments` is a leaf position, overwritten
+/// immediately by the value, so the placeholder type there is immaterial.
+fn fresh_proj_node(segments: &[PathSegment]) -> ProjNode {
+    match segments.first() {
+        Some(PathSegment::Index(_)) => ProjNode::List(std::collections::BTreeMap::new()),
+        _ => ProjNode::Map(HashMap::new()),
+    }
+}
+
+/// Insert `val` at `segments` within `node`, creating intermediate map/list
+/// nodes as needed.
+fn insert_proj_node(node: &mut ProjNode, segments: &[PathSegment], val: AttributeValue) {
+    let Some((seg, rest)) = segments.split_first() else {
+        *node = ProjNode::Leaf(val);
+        return;
+    };
+    match seg {
+        PathSegment::Key(k) => {
+            if let ProjNode::Map(map) = node {
+                let child = map
+                    .entry((*k).to_string())
+                    .or_insert_with(|| fresh_proj_node(rest));
+                insert_proj_node(child, rest, val);
+            }
+        }
+        PathSegment::Index(i) => {
+            if let ProjNode::List(list) = node {
+                let child = list.entry(*i).or_insert_with(|| fresh_proj_node(rest));
+                insert_proj_node(child, rest, val);
+            }
+        }
+    }
+}
+
+/// Convert a projection node into an `AttributeValue`. A `List` node's
+/// `BTreeMap` yields its elements in ascending index order, densely.
+fn proj_node_to_value(node: ProjNode) -> AttributeValue {
+    match node {
+        ProjNode::Leaf(v) => v,
+        ProjNode::Map(map) => AttributeValue::M(
+            map.into_iter()
+                .map(|(k, n)| (k, proj_node_to_value(n)))
+                .collect(),
+        ),
+        ProjNode::List(list) => {
+            AttributeValue::L(list.into_values().map(proj_node_to_value).collect())
+        }
+    }
 }
 
 /// Returns the deleted item (None when the target was missing and the delete
@@ -841,53 +894,146 @@ fn resolve_set_value(
     }
 }
 
-/// Set a value at a potentially nested path (e.g. `address.city`).
-fn set_nested_value(item: &mut Item, path: &str, val: AttributeValue) -> Result<()> {
-    let parts: Vec<&str> = path.split('.').collect();
-    if parts.len() == 1 {
-        item.insert(path.to_string(), val);
-        return Ok(());
-    }
-    // Navigate into nested maps, creating them if needed
-    let mut current = item;
-    for part in &parts[..parts.len() - 1] {
-        let entry = current
-            .entry(part.to_string())
-            .or_insert_with(|| AttributeValue::M(HashMap::new()));
-        match entry {
-            AttributeValue::M(map) => {
-                current = map;
-            }
-            _ => {
-                return Err(DynoxideError::ValidationException(
-                    "The document path provided in the update expression is invalid for update"
-                        .to_string(),
-                ));
-            }
-        }
-    }
-    current.insert(parts.last().unwrap().to_string(), val);
-    Ok(())
+/// The `ValidationException` DynamoDB raises for a document path that cannot be
+/// applied by an update (e.g. indexing a scalar, or a missing intermediate).
+fn invalid_update_path() -> DynoxideError {
+    DynoxideError::ValidationException(
+        "The document path provided in the update expression is invalid for update".to_string(),
+    )
 }
 
-/// Remove a value at a potentially nested path (e.g. `address.city`).
+/// Set a value at a document path, navigating both map keys and list indices,
+/// so `SET tags[0] = :v` writes the real list element rather than a literal
+/// `tags[0]` key. A list index at or beyond the end appends, matching DynamoDB.
+/// Intermediate map keys are created if absent, preserving the prior behaviour
+/// for dotted map paths.
+fn set_nested_value(item: &mut Item, path: &str, val: AttributeValue) -> Result<()> {
+    let segments = split_path_segments(path).ok_or_else(invalid_update_path)?;
+    let (first, rest) = segments.split_first().ok_or_else(invalid_update_path)?;
+    let key = match first {
+        PathSegment::Key(k) => (*k).to_string(),
+        // The top-level item is a map; it cannot be indexed.
+        PathSegment::Index(_) => return Err(invalid_update_path()),
+    };
+    if rest.is_empty() {
+        item.insert(key, val);
+        return Ok(());
+    }
+    let entry = item
+        .entry(key)
+        .or_insert_with(|| AttributeValue::M(HashMap::new()));
+    set_into_value(entry, rest, val)
+}
+
+/// Recursive helper for [`set_nested_value`]: apply the remaining path segments
+/// to `current`.
+fn set_into_value(
+    current: &mut AttributeValue,
+    segments: &[PathSegment],
+    val: AttributeValue,
+) -> Result<()> {
+    let (seg, rest) = segments.split_first().expect("segments is non-empty");
+    if rest.is_empty() {
+        return match seg {
+            PathSegment::Key(k) => match current {
+                AttributeValue::M(map) => {
+                    map.insert((*k).to_string(), val);
+                    Ok(())
+                }
+                _ => Err(invalid_update_path()),
+            },
+            PathSegment::Index(i) => match current {
+                AttributeValue::L(list) => {
+                    if *i < list.len() {
+                        list[*i] = val;
+                    } else {
+                        list.push(val);
+                    }
+                    Ok(())
+                }
+                _ => Err(invalid_update_path()),
+            },
+        };
+    }
+    match seg {
+        PathSegment::Key(k) => match current {
+            AttributeValue::M(map) => {
+                let next = map
+                    .entry((*k).to_string())
+                    .or_insert_with(|| AttributeValue::M(HashMap::new()));
+                set_into_value(next, rest, val)
+            }
+            _ => Err(invalid_update_path()),
+        },
+        PathSegment::Index(i) => match current {
+            AttributeValue::L(list) => match list.get_mut(*i) {
+                Some(next) => set_into_value(next, rest, val),
+                None => Err(invalid_update_path()),
+            },
+            _ => Err(invalid_update_path()),
+        },
+    }
+}
+
+/// Remove the value at a document path, navigating both map keys and list
+/// indices, so `REMOVE tags[0]` deletes the list element (shifting the rest)
+/// rather than a literal `tags[0]` key.
 fn remove_nested_value(item: &mut Item, path: &str) {
-    let parts: Vec<&str> = path.split('.').collect();
-    if parts.len() == 1 {
-        item.remove(path);
+    let Some(segments) = split_path_segments(path) else {
+        return;
+    };
+    let Some((first, rest)) = segments.split_first() else {
+        return;
+    };
+    let PathSegment::Key(key) = first else {
+        return; // the top-level item cannot be indexed
+    };
+    if rest.is_empty() {
+        item.remove(*key);
         return;
     }
-    // Navigate into nested maps
-    let mut current = item;
-    for part in &parts[..parts.len() - 1] {
-        match current.get_mut(*part) {
-            Some(AttributeValue::M(map)) => {
-                current = map;
+    if let Some(current) = item.get_mut(*key) {
+        remove_from_value(current, rest);
+    }
+}
+
+/// Recursive helper for [`remove_nested_value`]. A path that does not exist or
+/// whose type does not match is a no-op, mirroring DynamoDB's tolerant REMOVE.
+fn remove_from_value(current: &mut AttributeValue, segments: &[PathSegment]) {
+    let (seg, rest) = segments.split_first().expect("segments is non-empty");
+    if rest.is_empty() {
+        match seg {
+            PathSegment::Key(k) => {
+                if let AttributeValue::M(map) = current {
+                    map.remove(*k);
+                }
             }
-            _ => return, // Path doesn't exist or isn't a map — nothing to remove
+            PathSegment::Index(i) => {
+                if let AttributeValue::L(list) = current {
+                    if *i < list.len() {
+                        list.remove(*i);
+                    }
+                }
+            }
+        }
+        return;
+    }
+    match seg {
+        PathSegment::Key(k) => {
+            if let AttributeValue::M(map) = current {
+                if let Some(next) = map.get_mut(*k) {
+                    remove_from_value(next, rest);
+                }
+            }
+        }
+        PathSegment::Index(i) => {
+            if let AttributeValue::L(list) = current {
+                if let Some(next) = list.get_mut(*i) {
+                    remove_from_value(next, rest);
+                }
+            }
         }
     }
-    current.remove(*parts.last().unwrap());
 }
 
 /// Check if an item matches a WHERE clause (with OR-group support).

--- a/tests/partiql.rs
+++ b/tests/partiql.rs
@@ -85,6 +85,38 @@ fn put_nested_item(
     .unwrap();
 }
 
+/// Seed an item with `pk` plus one list attribute of strings, for list-index
+/// UPDATE tests.
+fn put_list_item(db: &Database, table_name: &str, pk: &str, list_attr: &str, elems: &[&str]) {
+    let list = elems
+        .iter()
+        .map(|e| AttributeValue::S(e.to_string()))
+        .collect();
+    let mut item = HashMap::new();
+    item.insert("pk".to_string(), AttributeValue::S(pk.to_string()));
+    item.insert(list_attr.to_string(), AttributeValue::L(list));
+    db.put_item(PutItemRequest {
+        table_name: table_name.to_string(),
+        item,
+        ..Default::default()
+    })
+    .unwrap();
+}
+
+/// Read `pk` back and assert its `attr` is a string list equal to `expected`.
+fn assert_string_list(db: &Database, pk: &str, attr: &str, expected: &[&str]) {
+    let sel = exec(db, &format!("SELECT * FROM \"Users\" WHERE pk = '{pk}'"));
+    let items = sel.items.unwrap();
+    let want: Vec<AttributeValue> = expected
+        .iter()
+        .map(|e| AttributeValue::S(e.to_string()))
+        .collect();
+    match items[0].get(attr) {
+        Some(AttributeValue::L(list)) => assert_eq!(list, &want),
+        other => panic!("expected {attr} list, got {other:?}"),
+    }
+}
+
 fn exec(
     db: &Database,
     statement: &str,
@@ -727,6 +759,436 @@ fn test_update_returning_modified_deep_nested_path() {
 }
 
 // -----------------------------------------------------------------------
+// List-index SET/REMOVE: a real list-index write, and the MODIFIED projection
+// returning the changed element in list shape (index collapsed to 0).
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_update_set_list_index_writes_the_element() {
+    let db = Database::memory().unwrap();
+    create_test_table(&db, "Users");
+    put_list_item(&db, "Users", "l1", "tags", &["a", "b"]);
+
+    exec(&db, "UPDATE \"Users\" SET tags[0] = 'x' WHERE pk = 'l1'");
+
+    let sel = exec(&db, "SELECT * FROM \"Users\" WHERE pk = 'l1'");
+    match sel.items.unwrap()[0].get("tags") {
+        Some(AttributeValue::L(list)) => assert_eq!(
+            list,
+            &vec![
+                AttributeValue::S("x".to_string()),
+                AttributeValue::S("b".to_string()),
+            ],
+            "SET tags[0] writes the real list element, not a literal tags[0] key"
+        ),
+        other => panic!("expected tags list, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_update_remove_list_index_removes_the_element() {
+    let db = Database::memory().unwrap();
+    create_test_table(&db, "Users");
+    put_list_item(&db, "Users", "l1", "tags", &["a", "b", "c"]);
+
+    exec(&db, "UPDATE \"Users\" REMOVE tags[1] WHERE pk = 'l1'");
+
+    let sel = exec(&db, "SELECT * FROM \"Users\" WHERE pk = 'l1'");
+    match sel.items.unwrap()[0].get("tags") {
+        Some(AttributeValue::L(list)) => assert_eq!(
+            list,
+            &vec![
+                AttributeValue::S("a".to_string()),
+                AttributeValue::S("c".to_string()),
+            ],
+            "REMOVE tags[1] deletes the element and shifts the rest"
+        ),
+        other => panic!("expected tags list, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_update_returning_modified_list_index_projects_changed_element() {
+    let db = Database::memory().unwrap();
+    create_test_table(&db, "Users");
+
+    // MODIFIED NEW: only the changed element, in list shape, collapsed to [x].
+    put_list_item(&db, "Users", "l1", "tags", &["a", "b"]);
+    let resp = exec(
+        &db,
+        "UPDATE \"Users\" SET tags[0] = 'x' WHERE pk = 'l1' RETURNING MODIFIED NEW *",
+    );
+    let items = resp.items.expect("RETURNING should return items");
+    assert_eq!(items.len(), 1);
+    assert!(!items[0].contains_key("pk"), "MODIFIED excludes the key");
+    match items[0].get("tags") {
+        Some(AttributeValue::L(list)) => {
+            assert_eq!(list, &vec![AttributeValue::S("x".to_string())])
+        }
+        other => panic!("expected tags list, got {other:?}"),
+    }
+
+    // MODIFIED OLD: the prior element value, same collapsed list shape.
+    put_list_item(&db, "Users", "l2", "tags", &["a", "b"]);
+    let resp = exec(
+        &db,
+        "UPDATE \"Users\" SET tags[0] = 'x' WHERE pk = 'l2' RETURNING MODIFIED OLD *",
+    );
+    match resp.items.unwrap()[0].get("tags") {
+        Some(AttributeValue::L(list)) => {
+            assert_eq!(list, &vec![AttributeValue::S("a".to_string())])
+        }
+        other => panic!("expected tags list, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_update_returning_modified_after_list_remove() {
+    let db = Database::memory().unwrap();
+    create_test_table(&db, "Users");
+
+    // MODIFIED OLD: the removed element's old value at that index.
+    put_list_item(&db, "Users", "l1", "tags", &["a", "b", "c"]);
+    let resp = exec(
+        &db,
+        "UPDATE \"Users\" REMOVE tags[1] WHERE pk = 'l1' RETURNING MODIFIED OLD *",
+    );
+    match resp.items.unwrap()[0].get("tags") {
+        Some(AttributeValue::L(list)) => {
+            assert_eq!(list, &vec![AttributeValue::S("b".to_string())])
+        }
+        other => panic!("expected tags list, got {other:?}"),
+    }
+
+    // MODIFIED NEW: a list REMOVE shifts rather than deletes, so `tags[1]` still
+    // resolves on the new list `['a','c']` and points at the shifted-in 'c'.
+    // (This differs from a map REMOVE, whose key is gone and yields no row.)
+    put_list_item(&db, "Users", "l2", "tags", &["a", "b", "c"]);
+    let resp = exec(
+        &db,
+        "UPDATE \"Users\" REMOVE tags[1] WHERE pk = 'l2' RETURNING MODIFIED NEW *",
+    );
+    match resp.items.unwrap()[0].get("tags") {
+        Some(AttributeValue::L(list)) => {
+            assert_eq!(list, &vec![AttributeValue::S("c".to_string())])
+        }
+        other => panic!("expected tags list, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_update_returning_modified_list_index_non_zero_and_multiple() {
+    let db = Database::memory().unwrap();
+    create_test_table(&db, "Users");
+
+    // A single non-zero index projects a single-element list of the changed value.
+    put_list_item(&db, "Users", "l1", "tags", &["a", "b", "c"]);
+    let resp = exec(
+        &db,
+        "UPDATE \"Users\" SET tags[2] = 'y' WHERE pk = 'l1' RETURNING MODIFIED NEW *",
+    );
+    match resp.items.unwrap()[0].get("tags") {
+        Some(AttributeValue::L(list)) => {
+            assert_eq!(list, &vec![AttributeValue::S("y".to_string())])
+        }
+        other => panic!("expected tags list, got {other:?}"),
+    }
+
+    // Several indices pack into a dense list in ascending index order, dropping
+    // the untouched positions (not collapsed onto one slot).
+    put_list_item(&db, "Users", "l2", "tags", &["a", "b", "c"]);
+    let resp = exec(
+        &db,
+        "UPDATE \"Users\" SET tags[0] = 'x', tags[2] = 'y' WHERE pk = 'l2' RETURNING MODIFIED NEW *",
+    );
+    match resp.items.unwrap()[0].get("tags") {
+        Some(AttributeValue::L(list)) => assert_eq!(
+            list,
+            &vec![
+                AttributeValue::S("x".to_string()),
+                AttributeValue::S("y".to_string()),
+            ]
+        ),
+        other => panic!("expected tags list, got {other:?}"),
+    }
+    // The stored item keeps positions: ['x','b','y'].
+    assert_string_list(&db, "l2", "tags", &["x", "b", "y"]);
+
+    // MODIFIED OLD packs the prior values at the touched indices the same way.
+    put_list_item(&db, "Users", "l3", "tags", &["a", "b", "c"]);
+    let resp = exec(
+        &db,
+        "UPDATE \"Users\" SET tags[0] = 'x', tags[2] = 'y' WHERE pk = 'l3' RETURNING MODIFIED OLD *",
+    );
+    match resp.items.unwrap()[0].get("tags") {
+        Some(AttributeValue::L(list)) => assert_eq!(
+            list,
+            &vec![
+                AttributeValue::S("a".to_string()),
+                AttributeValue::S("c".to_string()),
+            ]
+        ),
+        other => panic!("expected tags list, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_update_returning_modified_list_index_orders_by_index_not_statement() {
+    let db = Database::memory().unwrap();
+    create_test_table(&db, "Users");
+    put_list_item(&db, "Users", "l1", "tags", &["a", "b", "c"]);
+
+    // The indices are listed descending in the statement (tags[2] then tags[0]),
+    // but AWS packs the projection by index, so the result is ['x','y'] (index 0
+    // before index 2), not statement order ['y','x'].
+    let resp = exec(
+        &db,
+        "UPDATE \"Users\" SET tags[2] = 'y', tags[0] = 'x' WHERE pk = 'l1' RETURNING MODIFIED NEW *",
+    );
+    match resp.items.unwrap()[0].get("tags") {
+        Some(AttributeValue::L(list)) => assert_eq!(
+            list,
+            &vec![
+                AttributeValue::S("x".to_string()),
+                AttributeValue::S("y".to_string()),
+            ]
+        ),
+        other => panic!("expected tags list, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_update_returning_modified_list_index_multi_digit_ordering() {
+    let db = Database::memory().unwrap();
+    create_test_table(&db, "Users");
+    // An 11-element list so index 10 exists.
+    put_list_item(
+        &db,
+        "Users",
+        "l1",
+        "tags",
+        &[
+            "e0", "e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8", "e9", "e10",
+        ],
+    );
+
+    // The path set sorts "tags[10]" before "tags[2]" as strings, but the pack is
+    // keyed by numeric index, so index 2's value comes before index 10's.
+    let resp = exec(
+        &db,
+        "UPDATE \"Users\" SET tags[2] = 'y', tags[10] = 'k' WHERE pk = 'l1' RETURNING MODIFIED NEW *",
+    );
+    match resp.items.unwrap()[0].get("tags") {
+        Some(AttributeValue::L(list)) => assert_eq!(
+            list,
+            &vec![
+                AttributeValue::S("y".to_string()),
+                AttributeValue::S("k".to_string()),
+            ]
+        ),
+        other => panic!("expected tags list, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_update_returning_modified_append_is_empty() {
+    let db = Database::memory().unwrap();
+    create_test_table(&db, "Users");
+
+    // The write appends (stored ['a','b','c']), but tags[5] does not resolve on
+    // the new 3-element list, so MODIFIED NEW projects nothing.
+    put_list_item(&db, "Users", "l1", "tags", &["a", "b"]);
+    let resp = exec(
+        &db,
+        "UPDATE \"Users\" SET tags[5] = 'c' WHERE pk = 'l1' RETURNING MODIFIED NEW *",
+    );
+    let items = resp.items.expect("present Items array");
+    assert!(
+        items.is_empty(),
+        "MODIFIED NEW over an out-of-range append returns Items: []"
+    );
+    assert_string_list(&db, "l1", "tags", &["a", "b", "c"]);
+
+    // MODIFIED OLD: tags[5] does not resolve on the old 2-element list either.
+    put_list_item(&db, "Users", "l2", "tags", &["a", "b"]);
+    let resp = exec(
+        &db,
+        "UPDATE \"Users\" SET tags[5] = 'c' WHERE pk = 'l2' RETURNING MODIFIED OLD *",
+    );
+    assert!(
+        resp.items.expect("present Items array").is_empty(),
+        "MODIFIED OLD over an out-of-range append returns Items: []"
+    );
+}
+
+#[test]
+fn test_update_set_list_index_on_absent_attribute_is_rejected() {
+    let db = Database::memory().unwrap();
+    create_test_table(&db, "Users");
+    put_test_item(&db, "Users", "u1", "Alice"); // no `newlist` attribute
+
+    // You cannot set a nested path whose parent is absent; AWS rejects with this
+    // exact message rather than creating the list.
+    let err = db
+        .execute_statement(ExecuteStatementRequest {
+            statement: "UPDATE \"Users\" SET newlist[0] = 'x' WHERE pk = 'u1'".to_string(),
+            parameters: None,
+            ..Default::default()
+        })
+        .unwrap_err();
+    match err {
+        DynoxideError::ValidationException(msg) => assert_eq!(
+            msg,
+            "The document path provided in the update expression is invalid for update"
+        ),
+        other => panic!("expected ValidationException, got {other:?}"),
+    }
+    let sel = exec(&db, "SELECT * FROM \"Users\" WHERE pk = 'u1'");
+    assert!(
+        !sel.items.unwrap()[0].contains_key("newlist"),
+        "the rejected statement must not create the attribute"
+    );
+}
+
+#[test]
+fn test_update_set_list_index_at_or_beyond_end_appends() {
+    let db = Database::memory().unwrap();
+    create_test_table(&db, "Users");
+
+    // Index == length: appended.
+    put_list_item(&db, "Users", "l1", "tags", &["a", "b"]);
+    exec(&db, "UPDATE \"Users\" SET tags[2] = 'c' WHERE pk = 'l1'");
+    assert_string_list(&db, "l1", "tags", &["a", "b", "c"]);
+
+    // Index beyond the end: also appended (no gap), matching DynamoDB.
+    put_list_item(&db, "Users", "l2", "tags", &["a", "b"]);
+    exec(&db, "UPDATE \"Users\" SET tags[5] = 'c' WHERE pk = 'l2'");
+    assert_string_list(&db, "l2", "tags", &["a", "b", "c"]);
+}
+
+#[test]
+fn test_update_set_list_index_on_non_list_is_rejected() {
+    let db = Database::memory().unwrap();
+    create_test_table(&db, "Users");
+    put_test_item(&db, "Users", "u1", "Alice"); // `name` is a scalar string
+
+    let err = db
+        .execute_statement(ExecuteStatementRequest {
+            statement: "UPDATE \"Users\" SET name[0] = 'x' WHERE pk = 'u1'".to_string(),
+            parameters: None,
+            ..Default::default()
+        })
+        .unwrap_err();
+    match err {
+        DynoxideError::ValidationException(msg) => assert!(
+            msg.contains("invalid for update"),
+            "unexpected message: {msg}"
+        ),
+        other => panic!("expected ValidationException, got {other:?}"),
+    }
+
+    // The rejected statement must not have changed the attribute.
+    let sel = exec(&db, "SELECT * FROM \"Users\" WHERE pk = 'u1'");
+    assert_eq!(
+        sel.items.unwrap()[0].get("name"),
+        Some(&AttributeValue::S("Alice".to_string()))
+    );
+}
+
+#[test]
+fn test_update_set_nested_list_index_writes_element() {
+    let db = Database::memory().unwrap();
+    create_test_table(&db, "Users");
+
+    // Seed profile = { tags: ['a', 'b'] } (a map holding a list).
+    let mut inner = HashMap::new();
+    inner.insert(
+        "tags".to_string(),
+        AttributeValue::L(vec![
+            AttributeValue::S("a".to_string()),
+            AttributeValue::S("b".to_string()),
+        ]),
+    );
+    let mut item = HashMap::new();
+    item.insert("pk".to_string(), AttributeValue::S("n1".to_string()));
+    item.insert("profile".to_string(), AttributeValue::M(inner));
+    db.put_item(PutItemRequest {
+        table_name: "Users".to_string(),
+        item,
+        ..Default::default()
+    })
+    .unwrap();
+
+    exec(
+        &db,
+        "UPDATE \"Users\" SET profile.tags[0] = 'x' WHERE pk = 'n1'",
+    );
+
+    let sel = exec(&db, "SELECT * FROM \"Users\" WHERE pk = 'n1'");
+    match sel.items.unwrap()[0].get("profile") {
+        Some(AttributeValue::M(p)) => match p.get("tags") {
+            Some(AttributeValue::L(list)) => assert_eq!(
+                list,
+                &vec![
+                    AttributeValue::S("x".to_string()),
+                    AttributeValue::S("b".to_string()),
+                ]
+            ),
+            other => panic!("expected tags list, got {other:?}"),
+        },
+        other => panic!("expected profile map, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_update_returning_modified_nested_list_index() {
+    let db = Database::memory().unwrap();
+    create_test_table(&db, "Users");
+
+    // Seed profile = { tags: ['a', 'b'] } (a map holding a list), so the
+    // projection builds a Map node holding a List node.
+    let mut inner = HashMap::new();
+    inner.insert(
+        "tags".to_string(),
+        AttributeValue::L(vec![
+            AttributeValue::S("a".to_string()),
+            AttributeValue::S("b".to_string()),
+        ]),
+    );
+    let mut item = HashMap::new();
+    item.insert("pk".to_string(), AttributeValue::S("n1".to_string()));
+    item.insert("profile".to_string(), AttributeValue::M(inner));
+    db.put_item(PutItemRequest {
+        table_name: "Users".to_string(),
+        item,
+        ..Default::default()
+    })
+    .unwrap();
+
+    // MODIFIED NEW: only the changed nested list element, in list shape.
+    let resp = exec(
+        &db,
+        "UPDATE \"Users\" SET profile.tags[0] = 'x' WHERE pk = 'n1' RETURNING MODIFIED NEW *",
+    );
+    let want_new = AttributeValue::M(HashMap::from([(
+        "tags".to_string(),
+        AttributeValue::L(vec![AttributeValue::S("x".to_string())]),
+    )]));
+    assert_eq!(resp.items.unwrap()[0].get("profile"), Some(&want_new));
+
+    // MODIFIED OLD: the prior value at that nested index, same shape.
+    let resp = exec(
+        &db,
+        "UPDATE \"Users\" SET profile.tags[0] = 'z' WHERE pk = 'n1' RETURNING MODIFIED OLD *",
+    );
+    let want_old = AttributeValue::M(HashMap::from([(
+        "tags".to_string(),
+        AttributeValue::L(vec![AttributeValue::S("x".to_string())]),
+    )]));
+    assert_eq!(resp.items.unwrap()[0].get("profile"), Some(&want_old));
+}
+
+// -----------------------------------------------------------------------
 // RETURNING inside BatchExecuteStatement (honoured) and ExecuteTransaction
 // (rejected), per the real-AWS ground truth.
 // -----------------------------------------------------------------------
@@ -756,6 +1218,11 @@ fn test_batch_delete_returning_all_old_surfaces_item() {
     assert_eq!(
         item.get("name"),
         Some(&AttributeValue::S("Batch".to_string()))
+    );
+    assert_eq!(
+        resp.responses[0].table_name.as_deref(),
+        Some("Users"),
+        "batch echoes TableName on a successful response"
     );
 
     // The item is gone.
@@ -788,6 +1255,7 @@ fn test_batch_update_returning_surfaces_projection() {
         item.get("data"),
         Some(&AttributeValue::S("new".to_string()))
     );
+    assert_eq!(resp.responses[0].table_name.as_deref(), Some("Users"));
 
     // MODIFIED NEW: only the changed attribute, no key.
     let resp = db
@@ -835,6 +1303,97 @@ fn test_batch_update_empty_modified_omits_item() {
         resp.responses[0].item.is_none(),
         "an empty MODIFIED projection omits Item in a batch response"
     );
+    assert_eq!(
+        resp.responses[0].table_name.as_deref(),
+        Some("Users"),
+        "TableName is still echoed even when Item is omitted"
+    );
+}
+
+#[test]
+fn test_batch_update_list_index_modified_projects_changed_element() {
+    let db = Database::memory().unwrap();
+    create_test_table(&db, "Users");
+    put_list_item(&db, "Users", "b1", "tags", &["a", "b"]);
+
+    let resp = db
+        .batch_execute_statement(BatchExecuteStatementRequest {
+            statements: vec![BatchStatementRequest {
+                statement:
+                    "UPDATE \"Users\" SET tags[0] = 'x' WHERE pk = 'b1' RETURNING MODIFIED NEW *"
+                        .to_string(),
+                parameters: None,
+            }],
+        })
+        .unwrap();
+    let item = resp.responses[0]
+        .item
+        .as_ref()
+        .expect("batch surfaces the list-index MODIFIED projection");
+    match item.get("tags") {
+        Some(AttributeValue::L(list)) => {
+            assert_eq!(list, &vec![AttributeValue::S("x".to_string())])
+        }
+        other => panic!("expected tags list, got {other:?}"),
+    }
+    assert_eq!(resp.responses[0].table_name.as_deref(), Some("Users"));
+}
+
+#[test]
+fn test_batch_plain_update_echoes_table_name() {
+    let db = Database::memory().unwrap();
+    create_test_table(&db, "Users");
+    put_item_with_attrs(&db, "Users", "b1", &[("data", "old")]);
+
+    // A plain (no-RETURNING) member still echoes TableName, with no Item.
+    let resp = db
+        .batch_execute_statement(BatchExecuteStatementRequest {
+            statements: vec![BatchStatementRequest {
+                statement: "UPDATE \"Users\" SET data = 'new' WHERE pk = 'b1'".to_string(),
+                parameters: None,
+            }],
+        })
+        .unwrap();
+    assert!(resp.responses[0].error.is_none());
+    assert!(
+        resp.responses[0].item.is_none(),
+        "no RETURNING means no Item"
+    );
+    assert_eq!(resp.responses[0].table_name.as_deref(), Some("Users"));
+}
+
+#[test]
+fn test_batch_parse_error_uses_short_validation_code() {
+    let db = Database::memory().unwrap();
+    create_test_table(&db, "Users");
+    put_test_item(&db, "Users", "b1", "Batch");
+
+    // A malformed member fails per-statement with the short-form code (as a
+    // per-statement execution error does), while a valid sibling still executes.
+    let resp = db
+        .batch_execute_statement(BatchExecuteStatementRequest {
+            statements: vec![
+                BatchStatementRequest {
+                    statement: "SLECT * FROM \"Users\"".to_string(),
+                    parameters: None,
+                },
+                BatchStatementRequest {
+                    statement: "SELECT * FROM \"Users\" WHERE pk = 'b1'".to_string(),
+                    parameters: None,
+                },
+            ],
+        })
+        .unwrap();
+    let err = resp.responses[0]
+        .error
+        .as_ref()
+        .expect("the malformed member errors");
+    assert_eq!(err.code, "ValidationError");
+    assert!(
+        resp.responses[1].error.is_none(),
+        "the valid sibling executes"
+    );
+    assert!(resp.responses[1].item.is_some());
 }
 
 #[test]
@@ -864,6 +1423,10 @@ fn test_batch_invalid_delete_returning_variant_is_a_per_statement_error() {
     assert_eq!(
         err.message,
         "Invalid returning clause: RETURNING MODIFIED OLD *. Only RETURNING ALL OLD * is allowed in DELETE statements."
+    );
+    assert!(
+        resp.responses[0].table_name.is_none(),
+        "TableName is not echoed on a per-statement error"
     );
 
     // The rejected statement must not have deleted the item.

--- a/tests/partiql.rs
+++ b/tests/partiql.rs
@@ -995,8 +995,10 @@ fn test_update_returning_modified_append_is_empty() {
     let db = Database::memory().unwrap();
     create_test_table(&db, "Users");
 
-    // The write appends (stored ['a','b','c']), but tags[5] does not resolve on
-    // the new 3-element list, so MODIFIED NEW projects nothing.
+    // The write appends (stored ['a','b','c']), but a far-out-of-range index
+    // (tags[5]) does not resolve on the new 3-element list, so MODIFIED NEW
+    // projects nothing. This is specific to a far index, not appends in general
+    // (see the at-length case below, where the index resolves).
     put_list_item(&db, "Users", "l1", "tags", &["a", "b"]);
     let resp = exec(
         &db,
@@ -1005,7 +1007,7 @@ fn test_update_returning_modified_append_is_empty() {
     let items = resp.items.expect("present Items array");
     assert!(
         items.is_empty(),
-        "MODIFIED NEW over an out-of-range append returns Items: []"
+        "MODIFIED NEW over a far-out-of-range append returns Items: []"
     );
     assert_string_list(&db, "l1", "tags", &["a", "b", "c"]);
 
@@ -1017,8 +1019,71 @@ fn test_update_returning_modified_append_is_empty() {
     );
     assert!(
         resp.items.expect("present Items array").is_empty(),
-        "MODIFIED OLD over an out-of-range append returns Items: []"
+        "MODIFIED OLD over a far-out-of-range append returns Items: []"
     );
+}
+
+#[test]
+fn test_update_returning_modified_append_at_length() {
+    let db = Database::memory().unwrap();
+    create_test_table(&db, "Users");
+
+    // Appending at exactly the old length: the index resolves on the new list
+    // under NEW (so the element is projected) but is out of range on the old
+    // list under OLD (so nothing is projected).
+    put_list_item(&db, "Users", "l1", "tags", &["a", "b"]);
+    let resp = exec(
+        &db,
+        "UPDATE \"Users\" SET tags[2] = 'c' WHERE pk = 'l1' RETURNING MODIFIED NEW *",
+    );
+    match resp.items.unwrap()[0].get("tags") {
+        Some(AttributeValue::L(list)) => {
+            assert_eq!(list, &vec![AttributeValue::S("c".to_string())])
+        }
+        other => panic!("expected tags list, got {other:?}"),
+    }
+
+    put_list_item(&db, "Users", "l2", "tags", &["a", "b"]);
+    let resp = exec(
+        &db,
+        "UPDATE \"Users\" SET tags[2] = 'c' WHERE pk = 'l2' RETURNING MODIFIED OLD *",
+    );
+    assert!(
+        resp.items.expect("present Items array").is_empty(),
+        "the appended index is out of range on the old list"
+    );
+}
+
+#[test]
+fn test_update_returning_modified_remove_last_index() {
+    let db = Database::memory().unwrap();
+    create_test_table(&db, "Users");
+
+    // Removing the last index: nothing shifts into it, so under NEW the index no
+    // longer resolves and the projection is empty; under OLD it still resolves
+    // on the pre-remove list.
+    put_list_item(&db, "Users", "l1", "tags", &["a", "b", "c"]);
+    let resp = exec(
+        &db,
+        "UPDATE \"Users\" REMOVE tags[2] WHERE pk = 'l1' RETURNING MODIFIED NEW *",
+    );
+    assert!(
+        resp.items.expect("present Items array").is_empty(),
+        "removing the last index leaves nothing to project under MODIFIED NEW"
+    );
+    assert_string_list(&db, "l1", "tags", &["a", "b"]);
+
+    put_list_item(&db, "Users", "l2", "tags", &["a", "b", "c"]);
+    let resp = exec(
+        &db,
+        "UPDATE \"Users\" REMOVE tags[2] WHERE pk = 'l2' RETURNING MODIFIED OLD *",
+    );
+    match resp.items.unwrap()[0].get("tags") {
+        Some(AttributeValue::L(list)) => {
+            assert_eq!(list, &vec![AttributeValue::S("c".to_string())])
+        }
+        other => panic!("expected tags list, got {other:?}"),
+    }
 }
 
 #[test]


### PR DESCRIPTION
## What this changes

PartiQL `UPDATE` now performs real list-index writes in the shared `SET`/`REMOVE` path. `SET tags[0] = :v` updates the list element (appending when the index is at or beyond the end) and `REMOVE tags[0]` deletes it and shifts the rest, where a bracket index was previously treated as a literal map key, so both the stored item and a `RETURNING MODIFIED` projection over it diverged from DynamoDB.

A `RETURNING MODIFIED` projection over list-index paths packs the changed elements into a dense list in ascending index order (`SET a[0], a[2]` yields `{a: [v0, v2]}`, dropping untouched positions). `MODIFIED NEW` and `MODIFIED OLD` resolve the touched paths against the new or old item, so a list `REMOVE` that shifts an index still contributes its shifted-in element, and an out-of-range append contributes nothing.

`BatchExecuteStatement` now echoes `TableName` on a successful member response, and a member that fails to parse carries the short-form `ValidationError` code.

## Breaking change (Rust API)

The public `actions::batch_execute_statement::BatchStatementResponse` struct gains a `table_name` field and is now `#[non_exhaustive]`. Downstream code that constructs or exhaustively matches it needs a `..`. This is source-breaking for the crate's public Rust API, so the next release is `0.12.0`. The DynamoDB wire API and the CLI, server, and MCP surfaces are unaffected.

## Checklist

- [x] Tests added or updated
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` pass locally
- [x] `CHANGELOG.md` updated if this is a user-visible change
- [x] Linked issue, discussion, or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms (MIT License and Apache License, Version 2.0)

## DynamoDB compatibility note

Brings dynoxide closer to AWS. The list-index write and projection shapes, the `TableName` echo, and the batch parse error code are confirmed against real DynamoDB (eu-west-2). One gap is deferred and unrelated: a batch member that fails to parse now carries the correct code, but dynoxide's parser produces different message detail than AWS.
