### PR TITLE
fix(partiql): match DynamoDB's parse-error message wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - PartiQL `UPDATE` now performs real list-index writes. `SET tags[0] = :v` updates the list element (appending when the index is at or beyond the end) and `REMOVE tags[0]` deletes it and shifts the rest, where dynoxide previously treated `tags[0]` as a literal map key so both the stored item and a `RETURNING MODIFIED` projection over it diverged from DynamoDB. A `RETURNING MODIFIED` projection over list-index paths now packs the changed elements into a dense list in ascending index order (`SET a[0], a[2]` yields `{a: [v0, v2]}`), matching DynamoDB.
 - `BatchExecuteStatement` now echoes `TableName` on each successful member response, and a member that fails to parse now carries the short-form `ValidationError` code (matching a per-statement execution error) instead of the long-form `ValidationException`. Both match DynamoDB.
+- PartiQL parse errors now use DynamoDB's message wording: `Statement wasn't well formed, can't be processed: <detail>` (previously `... got error: ...`), and a statement that does not begin with a DML keyword reports `Expected data manipulation`. Applies to `ExecuteStatement`, `BatchExecuteStatement`, and `ExecuteTransaction`.
 
 ## [0.11.4] - 2026-07-17
 

--- a/src/actions/batch_execute_statement.rs
+++ b/src/actions/batch_execute_statement.rs
@@ -74,7 +74,7 @@ pub async fn execute<S: StorageBackend>(
                     // `ValidationError` code, the same as an execution error,
                     // matching DynamoDB.
                     code: "ValidationError".to_string(),
-                    message: format!("Statement wasn't well formed, got error: {e}"),
+                    message: format!("Statement wasn't well formed, can't be processed: {e}"),
                 }),
                 item: None,
                 table_name: None,

--- a/src/actions/execute_statement.rs
+++ b/src/actions/execute_statement.rs
@@ -37,7 +37,9 @@ pub async fn execute<S: StorageBackend>(
     request: ExecuteStatementRequest,
 ) -> Result<ExecuteStatementResponse> {
     let stmt = partiql::parser::parse(&request.statement).map_err(|e| {
-        DynoxideError::ValidationException(format!("Statement wasn't well formed, got error: {e}"))
+        DynoxideError::ValidationException(format!(
+            "Statement wasn't well formed, can't be processed: {e}"
+        ))
     })?;
 
     let params = request.parameters.unwrap_or_default();

--- a/src/actions/execute_transaction.rs
+++ b/src/actions/execute_transaction.rs
@@ -65,7 +65,7 @@ pub async fn execute<S: StorageBackend>(
     for (index, stmt) in statements.iter().enumerate() {
         let ast = partiql::parser::parse(&stmt.statement).map_err(|e| {
             DynoxideError::ValidationException(format!(
-                "Statement wasn't well formed, got error: {e}"
+                "Statement wasn't well formed, can't be processed: {e}"
             ))
         })?;
         // DynamoDB rejects a RETURNING clause on any member of a transaction with

--- a/src/partiql/parser.rs
+++ b/src/partiql/parser.rs
@@ -195,7 +195,9 @@ pub fn parse(input: &str) -> Result<Statement, String> {
         "INSERT" => parse_insert(&mut tokenizer),
         "UPDATE" => parse_update(&mut tokenizer),
         "DELETE" => parse_delete(&mut tokenizer),
-        other => Err(format!("Unsupported statement type: {other}")),
+        // A statement that does not begin with a DML keyword is not valid
+        // PartiQL; DynamoDB reports this as "Expected data manipulation".
+        _ => Err("Expected data manipulation".to_string()),
     }
 }
 

--- a/tests/partiql.rs
+++ b/tests/partiql.rs
@@ -1454,11 +1454,37 @@ fn test_batch_parse_error_uses_short_validation_code() {
         .as_ref()
         .expect("the malformed member errors");
     assert_eq!(err.code, "ValidationError");
+    assert_eq!(
+        err.message,
+        "Statement wasn't well formed, can't be processed: Expected data manipulation"
+    );
     assert!(
         resp.responses[1].error.is_none(),
         "the valid sibling executes"
     );
     assert!(resp.responses[1].item.is_some());
+}
+
+#[test]
+fn test_execute_statement_parse_error_message() {
+    let db = Database::memory().unwrap();
+    create_test_table(&db, "Users");
+
+    // A single malformed statement rejects with the same envelope and detail.
+    let err = db
+        .execute_statement(ExecuteStatementRequest {
+            statement: "SLECT * FROM \"Users\"".to_string(),
+            parameters: None,
+            ..Default::default()
+        })
+        .unwrap_err();
+    match err {
+        DynoxideError::ValidationException(msg) => assert_eq!(
+            msg,
+            "Statement wasn't well formed, can't be processed: Expected data manipulation"
+        ),
+        other => panic!("expected ValidationException, got {other:?}"),
+    }
 }
 
 #[test]


### PR DESCRIPTION
## What this changes

PartiQL parse errors now match DynamoDB's message wording. The envelope becomes `Statement wasn't well formed, can't be processed: <detail>` (previously `... got error: ...`), and a statement that does not begin with a DML keyword reports `Expected data manipulation`. This applies to `ExecuteStatement`, `BatchExecuteStatement`, and `ExecuteTransaction`.

## Checklist

- [x] Tests added or updated
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` pass locally
- [x] `CHANGELOG.md` updated if this is a user-visible change
- [x] Linked issue, discussion, or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms (MIT License and Apache License, Version 2.0)

## DynamoDB compatibility note

Confirmed against real DynamoDB (eu-west-2). This aligns the parse-error envelope across `ExecuteStatement`, `BatchExecuteStatement`, and `ExecuteTransaction`, and produces DynamoDB's exact message for a statement that is not a DML statement.
