### PR TITLE
fix(partiql): UPDATE on a non-existent key fails ConditionalCheckFailed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - PartiQL `UPDATE` now performs real list-index writes. `SET tags[0] = :v` updates the list element (appending when the index is at or beyond the end) and `REMOVE tags[0]` deletes it and shifts the rest, where dynoxide previously treated `tags[0]` as a literal map key so both the stored item and a `RETURNING MODIFIED` projection over it diverged from DynamoDB. A `RETURNING MODIFIED` projection over list-index paths now packs the changed elements into a dense list in ascending index order (`SET a[0], a[2]` yields `{a: [v0, v2]}`), matching DynamoDB.
 - `BatchExecuteStatement` now echoes `TableName` on each successful member response, and a member that fails to parse now carries the short-form `ValidationError` code (matching a per-statement execution error) instead of the long-form `ValidationException`. Both match DynamoDB.
+- PartiQL `UPDATE` on a non-existent key now fails with `ConditionalCheckFailedException` (`The conditional request failed`) and creates nothing, where dynoxide upserted the item. `UPDATE` is not an upsert: the target must already exist, matching DynamoDB.
 - PartiQL parse errors now use DynamoDB's message wording: `Statement wasn't well formed, can't be processed: <detail>` (previously `... got error: ...`), and a statement that does not begin with a DML keyword reports `Expected data manipulation`. Applies to `ExecuteStatement`, `BatchExecuteStatement`, and `ExecuteTransaction`.
 
 ## [0.11.4] - 2026-07-17

--- a/src/partiql/executor.rs
+++ b/src/partiql/executor.rs
@@ -430,11 +430,11 @@ async fn execute_update<S: StorageBackend>(
 
     let old_item = item.clone();
 
-    // Non-key WHERE predicates act as a condition on the existing item, like a
-    // conditional write. When the item exists but the condition is false, AWS
-    // raises ConditionalCheckFailedException; a missing item is not a condition
-    // failure and falls through to the existing create/no-op behaviour below.
-    if existing_json.is_some() && !matches_where(&old_item, where_clause, parameters) {
+    // PartiQL UPDATE is not an upsert: the target item must already exist, so a
+    // missing item fails ConditionalCheckFailedException and creates nothing.
+    // Non-key WHERE predicates act as a further condition on the existing item;
+    // if that predicate is false the update fails the same way. Neither writes.
+    if existing_json.is_none() || !matches_where(&old_item, where_clause, parameters) {
         return Err(DynoxideError::ConditionalCheckFailedException(
             "The conditional request failed".to_string(),
             None,

--- a/tests/partiql.rs
+++ b/tests/partiql.rs
@@ -281,6 +281,39 @@ fn test_update_adds_new_attribute() {
     );
 }
 
+#[test]
+fn test_update_on_missing_key_is_not_an_upsert() {
+    let db = Database::memory().unwrap();
+    create_test_table(&db, "Users");
+    // The key is deliberately not seeded.
+
+    // PartiQL UPDATE requires the item to exist: a missing key fails
+    // ConditionalCheckFailedException rather than creating the item. This holds
+    // with or without a RETURNING clause.
+    for statement in [
+        "UPDATE \"Users\" SET data = 'new' WHERE pk = 'ghost'",
+        "UPDATE \"Users\" SET data = 'new' WHERE pk = 'ghost' RETURNING ALL OLD *",
+    ] {
+        let err = db
+            .execute_statement(ExecuteStatementRequest {
+                statement: statement.to_string(),
+                parameters: None,
+                ..Default::default()
+            })
+            .unwrap_err();
+        match err {
+            DynoxideError::ConditionalCheckFailedException(msg, _) => {
+                assert_eq!(msg, "The conditional request failed", "for `{statement}`")
+            }
+            other => panic!("expected ConditionalCheckFailedException, got {other:?}"),
+        }
+    }
+
+    // The rejected updates did not create the item.
+    let sel = exec(&db, "SELECT * FROM \"Users\" WHERE pk = 'ghost'");
+    assert!(sel.items.unwrap().is_empty());
+}
+
 // -----------------------------------------------------------------------
 // DELETE
 // -----------------------------------------------------------------------


### PR DESCRIPTION
## What this changes

PartiQL `UPDATE` is not an upsert: a statement whose target key does not exist now fails `ConditionalCheckFailedException` (`The conditional request failed`) and creates nothing, where dynoxide created the item. The target must already exist, matching DynamoDB. The existence check is independent of any `RETURNING` clause and joins the existing non-key WHERE predicate check, so neither a missing item nor a false predicate writes.

## Checklist

- [x] Tests added or updated
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` pass locally
- [x] `CHANGELOG.md` updated if this is a user-visible change
- [x] Linked issue, discussion, or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms (MIT License and Apache License, Version 2.0)

## DynamoDB compatibility note

Confirmed against real DynamoDB (eu-west-2): a PartiQL `UPDATE` on a non-existent key raises `ConditionalCheckFailedException` and does not create the item. This is the implicit existence condition a PartiQL `UPDATE` carries, unlike the classic `UpdateItem`, which upserts.
