### PR TITLE
docs: bring the docs tree in line with 0.12.0

### DIFF
--- a/docs/compatibility-summary.md
+++ b/docs/compatibility-summary.md
@@ -150,7 +150,7 @@ DynamoDB Local fails a share of the suite that real DynamoDB passes, clustered i
 
 | Capability | Notes |
 |---|---|
-| MCP server (33 tools, stdio + HTTP) | Exposes all DynamoDB operations as tools for coding agents |
+| MCP server (34 tools, stdio + HTTP) | Exposes all DynamoDB operations as tools for coding agents |
 | Embedded mode (direct Rust API) | `Database::memory()` - no HTTP, no serialisation overhead |
 | Snapshots + auto-snapshot before destructive ops | Point-in-time save/restore for safe experimentation |
 | OneTable data model integration | `--data-model` loads entity schemas for agent context |

--- a/docs/import.md
+++ b/docs/import.md
@@ -2,6 +2,11 @@
 
 Import data from DynamoDB Export (JSON Lines format) into a Dynoxide database, with optional anonymisation.
 
+Import runs in one of two mutually exclusive modes. **File mode** (`--output`)
+writes a SQLite file, vacuums it, and optionally compresses it. **Serve mode**
+(`--serve` or `--mcp`) imports into an in-memory database and starts a server
+on top of it, leaving nothing on disk.
+
 ## Basic import
 
 ```sh
@@ -98,4 +103,37 @@ dynoxide import --source ./export/ --schema schema.json --output snapshot.db --c
 dynoxide import --source ./export/ --schema schema.json --output snapshot.db --compress
 # Produces snapshot.db.zst
 ```
+
+## Serve mode
+
+Import straight into memory and serve it, with no file written. Useful for a
+throwaway environment seeded from a production export, where you want the data
+to disappear when the process does.
+
+```sh
+# HTTP server on the imported data
+dynoxide import --source ./export/ --schema schema.json --serve --port 8000
+
+# stdio MCP server on the imported data
+dynoxide import --source ./export/ --schema schema.json --mcp
+
+# Both: HTTP on --port, MCP over HTTP on --mcp-port
+dynoxide import --source ./export/ --schema schema.json --serve --mcp --mcp-port 8100
+```
+
+`--serve` and `--mcp` both conflict with `--output`. Used alone, `--mcp` starts
+a stdio MCP server; combined with `--serve` it starts an HTTP MCP server
+instead.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--serve` | off | Start an HTTP server on the imported data |
+| `--host` | `127.0.0.1` | Bind address (requires `--serve`) |
+| `--port` | `8000` | HTTP port (requires `--serve`) |
+| `--mcp` | off | Start an MCP server on the imported data |
+| `--mcp-port` | `8100` | MCP HTTP port, used with `--serve --mcp` |
+| `--mcp-read-only` | off | Reject write operations over MCP (requires `--mcp`) |
+
+Anonymisation applies the same way in serve mode: pass `--rules` and the data
+is masked before it reaches the in-memory database.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -52,11 +52,25 @@ cargo install dynoxide-rs --no-default-features --features encrypted-full
 ```toml
 [dependencies]
 # Minimal - just the embedded database, no server or CLI dependencies
-dynoxide-rs = { version = "0.10", default-features = false, features = ["native-sqlite"] }
+dynoxide-rs = { version = "0.12", default-features = false, features = ["native-sqlite"] }
 
 # Or with encryption:
-# dynoxide-rs = { version = "0.10", default-features = false, features = ["encryption"] }
+# dynoxide-rs = { version = "0.12", default-features = false, features = ["encryption"] }
 ```
+
+## Upgrading to 0.12.x
+
+Source-breaking for library consumers only. The DynamoDB wire API and the
+CLI, server and MCP surfaces are unchanged, so anyone running the binary can
+upgrade without reading further.
+
+**Depending on the `dynoxide-rs` crate?** Two public types gained fields and
+became `#[non_exhaustive]`:
+
+- **`partiql::parser::Statement`** - the `Update` and `Delete` variants carry a
+  `returning` field. Code that constructs or exhaustively matches them needs `..`.
+- **`actions::batch_execute_statement::BatchStatementResponse`** - gained a
+  `table_name` field, same treatment.
 
 ## Upgrading from 0.9.x
 
@@ -75,7 +89,7 @@ dynoxide-rs = { version = "0.10", default-features = false, features = ["native-
 ## GitHub Actions
 
 ```yaml
-- uses: nubo-db/dynoxide/action@v0.10.0
+- uses: nubo-db/dynoxide/action@v0.12.0
   with:
     snapshot-url: https://example.com/test-data.db.zst  # optional
     port: 8000

--- a/docs/library.md
+++ b/docs/library.md
@@ -89,7 +89,7 @@ No Docker. No port conflicts. No table name prefixes. Tests run in parallel with
 `native-sqlite` and `encryption` are **mutually exclusive** - they select different SQLite backends. To use encryption:
 
 ```toml
-dynoxide-rs = { version = "0.10", default-features = false, features = ["encryption"] }
+dynoxide-rs = { version = "0.12", default-features = false, features = ["encryption"] }
 ```
 
 **Workspace note:** Cargo unifies features across a workspace. If any crate depends on `dynoxide-rs` with default features (getting `native-sqlite`) and another uses `encryption`, both activate and the build fails. Use `default-features = false` on all `dynoxide-rs` dependencies in the workspace.


### PR DESCRIPTION
## What this changes

Brings the docs tree in line with what 0.12.0 ships, ahead of the release. The crate pins had drifted two minors behind, the capability summary still said 33 MCP tools against 34 in the binary, and `docs/import.md` never documented the `--serve`/`--mcp` modes that run an import straight into memory. Adds the 0.12.0 upgrade note: `partiql::parser::Statement`'s `Update` and `Delete` variants and `BatchStatementResponse` gained fields and became `#[non_exhaustive]`, which is source-breaking for crate consumers and invisible to anyone running the binary.

Land this before the version-bump commit, so the tagged commit carries correct docs and the README published to crates.io is accurate.

## Checklist

- ~~Tests added or updated~~ - documentation only.
- ~~`cargo fmt --check` and `cargo clippy -- -D warnings` pass locally~~ - no Rust changed.
- ~~`CHANGELOG.md` updated~~ - corrects docs to match behaviour already recorded in the Unreleased section; no new entry needed.
- [x] A short note explaining the motivation (above)
- [x] I agree my contribution is licensed under the project's terms (MIT License and Apache License, Version 2.0)
