### PR TITLE
fix: template the CI runner description from the run that produced the numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For Rust projects, there's also an **embedded mode** - direct API calls via `Dat
 
 #### CI (GitHub Actions)
 
-Numbers from `ubuntu-latest` (2-core AMD EPYC 7763, 8GB RAM). Commit <!-- bench:ci_commit_link_root -->[`bc2a16c`](../../commit/bc2a16c5c91d2a3649617e54d84d639d2a94e502)<!-- /bench -->.
+Numbers from `ubuntu-latest` (<!-- prose:ci_runner_hardware -->4-core AMD EPYC 9V74, 16GB RAM<!-- /bench -->). Commit <!-- bench:ci_commit_link_root -->[`bc2a16c`](../../commit/bc2a16c5c91d2a3649617e54d84d639d2a94e502)<!-- /bench -->.
 
 | Metric | Dynoxide (embedded) | Dynoxide (HTTP) | DynamoDB Local | LocalStack (all services) |
 |---|---|---|---|---|

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -106,7 +106,7 @@ Results from a Mac Studio (M-series). These reflect the experience of a develope
 
 ## Results: CI (GitHub Actions)
 
-Results from `ubuntu-latest` (2-core AMD EPYC 7763, 8GB RAM). Commit <!-- bench:ci_commit_link_benchmarks -->[`bc2a16c`](../../../commit/bc2a16c5c91d2a3649617e54d84d639d2a94e502)<!-- /bench -->. Absolute wall-clock numbers vary between runners; ratios are stable across runs.
+Results from `ubuntu-latest` (<!-- prose:ci_runner_hardware -->4-core AMD EPYC 9V74, 16GB RAM<!-- /bench -->). Commit <!-- bench:ci_commit_link_benchmarks -->[`bc2a16c`](../../../commit/bc2a16c5c91d2a3649617e54d84d639d2a94e502)<!-- /bench -->. Absolute wall-clock numbers vary between runners; ratios are stable across runs.
 
 ### Cold Startup
 
@@ -195,7 +195,7 @@ Docker idle memory is the mean of 3 samples taken 10s apart, 30s after first suc
 
 Local development (Apple Silicon) shows ~17x speedup for embedded CI pipeline; GitHub Actions shows ~7x. This is expected:
 
-- Apple Silicon has significantly faster single-thread performance than the 2-core EPYC VM
+- Apple Silicon has significantly faster single-thread performance than the shared CI runner
 - Dynoxide is CPU-bound (native code, in-process SQLite), so it scales roughly linearly with CPU speed
 - DynamoDB Local is JVM-overhead-bound (class loading, JIT compilation, GC), so it benefits less from faster CPUs on cold start
 - The net effect: faster hardware widens the gap between native code and JVM overhead

--- a/benchmarks/scripts/update_readme_benchmarks.py
+++ b/benchmarks/scripts/update_readme_benchmarks.py
@@ -162,6 +162,35 @@ def fmt_criterion_ns(ns):
     return "{:.0f}ms".format(ms)
 
 
+def fmt_runner_hardware(system_info):
+    """Describe the runner a CI run landed on, like '4-core AMD EPYC 9V74, 16GB RAM'.
+
+    GitHub's hosted pool is not uniform: runs have landed on 7763, 9V45 and
+    9V74 hosts, and the vCPU allocation has changed over time too. Templating
+    this from the run's own system_info keeps the prose honest, since the
+    benchmarks README asks the reader to weigh which runner produced the
+    numbers.
+    """
+    model = (system_info.get("cpu_model") or "").strip()
+    if not model:
+        return None
+
+    # cpu_model carries the host part's own core count ("AMD EPYC 9V74 80-Core
+    # Processor"), which reads oddly beside the VM's much smaller vCPU count.
+    model = re.sub(r"\s+\d+-Core Processor$", "", model).strip()
+
+    cores = system_info.get("cpu_cores")
+    desc = "{}-core {}".format(cores, model) if cores else model
+
+    ram = system_info.get("total_ram_gb")
+    if ram:
+        try:
+            desc += ", {:.0f}GB RAM".format(float(ram))
+        except (TypeError, ValueError):
+            pass
+    return desc
+
+
 def fmt_prose_startup_range(mean_ms, stddev_ms):
     """Format a prose startup range like '3\u20134 seconds'."""
     low_s = max(0, (mean_ms - stddev_ms)) / 1000
@@ -252,6 +281,11 @@ def build_value_mapping(run_summary, memory_rows):
     if short_sha:
         values["ci_commit_link_root"] = "[`{}`](../../commit/{})".format(short_sha, sha)
         values["ci_commit_link_benchmarks"] = "[`{}`](../../../commit/{})".format(short_sha, sha)
+
+    # --- Runner hardware ---
+    runner_hardware = fmt_runner_hardware(system_info)
+    if runner_hardware:
+        values["ci_runner_hardware"] = runner_hardware
 
     # --- Startup (main README simplified + benchmarks README detailed) ---
     emb = find_startup(results, "dynoxide_embedded")
@@ -653,7 +687,7 @@ def classify_key(key):
 
     Returns: 'ratio', 'latency', 'memory', or 'skip'.
     """
-    if key.startswith("ci_commit"):
+    if key.startswith("ci_commit") or key == "ci_runner_hardware":
         return "skip"
     if "_ratio" in key or key.endswith("_ratio"):
         return "ratio"


### PR DESCRIPTION
## What this changes

The runner hardware in both READMEs was static prose reading "2-core AMD EPYC 7763, 8GB RAM". It hasn't matched a run since March: the vCPU allocation moved to 4 cores and 16GB in April, and GitHub's hosted pool has since served 7763, 9V45 and 9V74 parts. `benchmarks/README.md` asks the reader to weigh which runner produced the numbers, so naming the wrong one undercuts the page.

This templates it from the run's own `system_info.json` behind a new `prose:ci_runner_hardware` marker, so it tracks whatever machine the refresh actually landed on.

Verified against all thirteen runs stored on `benchmark-data`. The March entries reproduce the original wording exactly, which checks the formatter against the convention it replaces rather than inventing a new one:

```
runs/2026-03-24-17db926  -> 2-core AMD EPYC 7763, 8GB RAM
runs/2026-04-02-ec7253a  -> 4-core AMD EPYC 7763, 16GB RAM
runs/2026-04-24-aefc68a  -> 4-core AMD EPYC 9V74, 16GB RAM
runs/2026-07-24-f7e7d96  -> 4-core AMD EPYC 9V45, 16GB RAM
runs/2026-07-30-bc2a16c  -> 4-core AMD EPYC 9V74, 16GB RAM
```

Re-running the updater over the committed result reports `Updated 0 values`, so what's in the tree is what the script generates. A missing `cpu_model` leaves the marker unpopulated rather than writing a half-formed string, and a malformed `total_ram_gb` drops the RAM clause instead of throwing.

`benchmarks/README.md` also had "the 2-core EPYC VM" in the local-vs-CI explanation; that now refers to the shared CI runner without asserting a core count.

## Checklist

- ~~Tests added or updated~~ - nothing covers `benchmarks/scripts/` today. Verified by running the formatter across all thirteen stored runs, including the malformed-input cases, and by a full round-trip of the updater.
- ~~`cargo fmt --check` and `cargo clippy -- -D warnings` pass locally~~ - no Rust changed.
- ~~`CHANGELOG.md` updated if this is a user-visible change~~ - docs and benchmark tooling only.
- [x] Linked issue, discussion, or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms (MIT License and Apache License, Version 2.0)

Related to #167. The figures this line describes were set by the same run that poisoned the comparison baseline, though the stale hardware text predates that by months.
