### PR TITLE
fix: baseline criterion comparisons on a median of recent runs

### DIFF
--- a/.github/workflows/benchmark-refresh.yml
+++ b/.github/workflows/benchmark-refresh.yml
@@ -148,6 +148,9 @@ jobs:
           "
 
       - name: Run criterion baseline
+        # shell: bash adds -o pipefail, so a bench that dies partway fails here
+        # rather than storing a truncated baseline for every later comparison.
+        shell: bash
         run: |
           cd benchmarks
           cargo bench --bench embedded_micro -- --output-format bencher | tee criterion_output.txt

--- a/.github/workflows/benchmark-refresh.yml
+++ b/.github/workflows/benchmark-refresh.yml
@@ -167,79 +167,36 @@ jobs:
 
       - name: Build PR body from comparison
         run: |
-          python3 <<'PY' > /tmp/pr_body.md
-          import json, os, subprocess, sys
+          git fetch origin benchmark-data:benchmark-data 2>/dev/null || true
 
-          with open('benchmarks/results/criterion_baseline.json') as f:
-              current = json.load(f)
+          RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          {
+            echo "## Benchmark refresh"
+            echo
+            echo "Run: [${GITHUB_RUN_ID}](${RUN_URL})"
+            echo
+          } > /tmp/pr_body.md
 
-          baseline = {}
-          try:
-              subprocess.run(
-                  ['git', 'fetch', 'origin', 'benchmark-data:benchmark-data'],
-                  check=True, stderr=subprocess.DEVNULL,
-              )
-              ls = subprocess.run(
-                  ['git', 'ls-tree', '--name-only', 'benchmark-data', 'runs/'],
-                  capture_output=True, text=True, check=True,
-              )
-              dirs = sorted([d for d in ls.stdout.strip().split('\n') if d], reverse=True)
-              if dirs:
-                  show = subprocess.run(
-                      ['git', 'show', f'benchmark-data:{dirs[0]}/criterion_baseline.json'],
-                      capture_output=True, text=True,
-                  )
-                  if show.returncode == 0:
-                      baseline = json.loads(show.stdout)
-          except Exception as e:
-              print(f"baseline fetch failed: {e}", file=sys.stderr)
+          # This runs before the store step below, so the current run is not
+          # yet part of the history it is compared against.
+          set +e
+          python3 benchmarks/scripts/compare_criterion.py \
+            --current-json benchmarks/results/criterion_baseline.json \
+            --output /tmp/comparison.md
+          status=$?
+          set -e
 
-          names = sorted(set(current) | set(baseline))
-          rows = []
-          regressions = []
-          threshold = 1.50  # matches benchmark-regression.yml
-          for name in names:
-              c = current.get(name)
-              b = baseline.get(name)
-              if c is not None and b is not None and b != 0:
-                  ratio = c / b
-                  pct = (ratio - 1) * 100
-                  change = f"{'+' if pct >= 0 else ''}{pct:.1f}%"
-                  if ratio > threshold:
-                      regressions.append(name)
-                      change += " :warning:"
-              elif c is not None:
-                  change = "new"
-              else:
-                  change = "removed"
-              rows.append((name, b, c, change))
+          if [ "$status" -ne 0 ] && [ "$status" -ne 3 ]; then
+            echo "::warning::criterion comparison failed (exit $status)"
+            echo "_Criterion comparison unavailable; see the run log._" >> /tmp/pr_body.md
+          else
+            cat /tmp/comparison.md >> /tmp/pr_body.md
+          fi
 
-          run_id = os.environ.get('GITHUB_RUN_ID', '')
-          repo = os.environ.get('GITHUB_REPOSITORY', 'nubo-db/dynoxide')
-          run_url = f"https://github.com/{repo}/actions/runs/{run_id}"
-
-          print("## Benchmark refresh")
-          print()
-          print(f"Run: [{run_id}]({run_url})")
-          print()
-          print("### Criterion comparison vs previous run")
-          print()
-          print("| Benchmark | Baseline (ns/iter) | Current (ns/iter) | Change |")
-          print("|-----------|-------------------:|------------------:|--------|")
-          for name, b, c, change in rows:
-              bs = f"{b:,}" if b else "—"
-              cs = f"{c:,}" if c else "—"
-              print(f"| {name} | {bs} | {cs} | {change} |")
-          print()
-          if regressions:
-              print(f"> :warning: {len(regressions)} benchmark(s) exceeded the 50% threshold. Wall-clock runners are noisy; variance up to 3x between runs on shared hardware is common. iai-callgrind provides deterministic regression detection in PR checks.")
-          elif baseline:
-              print("> All benchmarks within 50% of prior baseline.")
-          else:
-              print("> No prior baseline; this run establishes one.")
-          print()
-          print("Before merging, eyeball the numbers and re-run this workflow if any look like noise rather than real change.")
-          PY
+          {
+            echo
+            echo "Before merging, eyeball the numbers and re-run this workflow if any look like noise rather than real change."
+          } >> /tmp/pr_body.md
 
       - name: Store results in benchmark-data branch
         run: |

--- a/.github/workflows/benchmark-refresh.yml
+++ b/.github/workflows/benchmark-refresh.yml
@@ -204,8 +204,14 @@ jobs:
       - name: Store results in benchmark-data branch
         run: |
           SHA=$(git rev-parse --short HEAD)
-          DATE=$(date -u +%Y-%m-%d)
-          RUN_DIR="runs/${DATE}-${SHA}"
+          # Second-resolution, not date-only: two dispatches on the same day at
+          # the same commit used to land in one directory, so the later run
+          # replaced the earlier instead of adding a sample. The comparison
+          # averages the last N runs, so a silent overwrite quietly shrinks N.
+          # The T also keeps same-day runs in chronological order under a plain
+          # lexical sort, which a date-only name could not do.
+          STAMP=$(date -u +%Y-%m-%dT%H%M%SZ)
+          RUN_DIR="runs/${STAMP}-${SHA}"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -221,7 +227,7 @@ jobs:
             echo "# Benchmark History" > README.md
             echo "" >> README.md
             echo "This branch stores historical benchmark results." >> README.md
-            echo "Each run is stored in \`runs/YYYY-MM-DD-<commit_sha>/\`." >> README.md
+            echo "Each run is stored in \`runs/YYYY-MM-DDTHHMMSSZ-<commit_sha>/\`." >> README.md
             git add README.md
             git commit -m "Initialise benchmark-data branch"
             cd -

--- a/.github/workflows/benchmark-regression.yml
+++ b/.github/workflows/benchmark-regression.yml
@@ -22,6 +22,10 @@ jobs:
             benchmarks
 
       - name: Run criterion micro-benchmarks
+        # shell: bash adds -o pipefail. Without it the exit status of the pipe
+        # is tee's, so a bench that dies partway leaves a truncated file and
+        # still reports success.
+        shell: bash
         run: cd benchmarks && cargo bench --bench embedded_micro -- --output-format bencher | tee criterion_output.txt
 
       - name: Compare against recent baselines

--- a/.github/workflows/benchmark-regression.yml
+++ b/.github/workflows/benchmark-regression.yml
@@ -36,14 +36,31 @@ jobs:
           set +e
           python3 benchmarks/scripts/compare_criterion.py \
             --current-output benchmarks/criterion_output.txt \
-            --output comparison.md
+            --output comparison.md 2> compare_stderr.txt
           status=$?
           set -e
+          cat compare_stderr.txt
 
-          # 3 means something exceeded the threshold, which is advisory here.
-          # Anything else non-zero means the comparison could not be made, and
-          # a check that could not run must not read as a check that passed.
+          # Exit 3 means a benchmark came in over the threshold. That is
+          # advisory: the step stays green and the warning is the whole signal,
+          # because wall-clock timings on shared runners move on their own.
+          #
+          # Any other non-zero means no comparison happened at all. That fails
+          # the step, since a check that could not run must not look like one
+          # that passed. It still does not block merge -- this job is not a
+          # required check, and iai-callgrind is the gate that is.
           if [ "$status" -ne 0 ] && [ "$status" -ne 3 ]; then
+            {
+              echo "## Criterion Benchmark Results"
+              echo
+              echo "> :x: The comparison could not be made (exit ${status}), so this"
+              echo "> run says nothing about performance either way."
+              echo
+              echo '```'
+              cat compare_stderr.txt
+              echo '```'
+            } > comparison.md
+            echo "regressed=false" >> "$GITHUB_OUTPUT"
             echo "::error::criterion comparison failed (exit $status)"
             exit "$status"
           fi
@@ -55,13 +72,23 @@ jobs:
           fi
 
       - name: Post comparison to the PR
+        # always(), so a failed comparison still carries its reason into the PR
+        # rather than leaving a red check with nothing to explain it.
+        if: always()
         uses: actions/github-script@v8
         env:
           REGRESSED: ${{ steps.compare.outputs.regressed }}
         with:
           script: |
             const fs = require('fs');
-            const body = fs.readFileSync('comparison.md', 'utf8');
+            let body;
+            try {
+              body = fs.readFileSync('comparison.md', 'utf8');
+            } catch {
+              body = '## Criterion Benchmark Results\n\n'
+                   + '> :x: The benchmark job did not get as far as producing a '
+                   + 'comparison. See the run log.\n';
+            }
 
             // GITHUB_STEP_SUMMARY is always visible in the Actions tab
             await core.summary.addRaw(body).write();
@@ -73,7 +100,7 @@ jobs:
               body
             });
 
-            // Wall-clock regressions are advisory only -- don't block merge
+            // A threshold breach is advisory and never blocks merge
             if (process.env.REGRESSED === 'true') {
               core.warning('Wall-clock regression detected -- see PR comment for details');
             }

--- a/.github/workflows/benchmark-regression.yml
+++ b/.github/workflows/benchmark-regression.yml
@@ -24,105 +24,44 @@ jobs:
       - name: Run criterion micro-benchmarks
         run: cd benchmarks && cargo bench --bench embedded_micro -- --output-format bencher | tee criterion_output.txt
 
-      - name: Compare results and post summary
+      - name: Compare against recent baselines
+        id: compare
+        run: |
+          git fetch origin benchmark-data:benchmark-data 2>/dev/null || true
+
+          set +e
+          python3 benchmarks/scripts/compare_criterion.py \
+            --current-output benchmarks/criterion_output.txt \
+            --output comparison.md
+          status=$?
+          set -e
+
+          # 3 means something exceeded the threshold, which is advisory here.
+          # Anything else non-zero means the comparison could not be made, and
+          # a check that could not run must not read as a check that passed.
+          if [ "$status" -ne 0 ] && [ "$status" -ne 3 ]; then
+            echo "::error::criterion comparison failed (exit $status)"
+            exit "$status"
+          fi
+
+          if [ "$status" -eq 3 ]; then
+            echo "regressed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "regressed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post comparison to the PR
         uses: actions/github-script@v8
+        env:
+          REGRESSED: ${{ steps.compare.outputs.regressed }}
         with:
           script: |
             const fs = require('fs');
-            const { execSync } = require('child_process');
+            const body = fs.readFileSync('comparison.md', 'utf8');
 
-            // Parse current criterion output (bencher format: "test name ... bench: NNN ns/iter (+/- NNN)")
-            const currentOutput = fs.readFileSync('benchmarks/criterion_output.txt', 'utf8');
-            const currentResults = {};
-            for (const line of currentOutput.split('\n')) {
-              const match = line.match(/^test\s+(.+?)\s+\.\.\.\s+bench:\s+([\d,]+)\s+ns\/iter/);
-              if (match) {
-                currentResults[match[1]] = parseInt(match[2].replace(/,/g, ''));
-              }
-            }
-
-            if (Object.keys(currentResults).length === 0) {
-              console.log('No criterion results parsed -- skipping regression check');
-              return;
-            }
-
-            // Try to fetch baseline from benchmark-data branch
-            let baselineResults = {};
-            let hasBaseline = false;
-            try {
-              execSync('git fetch origin benchmark-data:benchmark-data 2>/dev/null', { stdio: 'pipe' });
-              const latestDir = execSync(
-                'git ls-tree --name-only benchmark-data runs/ | sort -r | head -1',
-                { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
-              ).trim();
-
-              if (latestDir) {
-                const baselineFile = execSync(
-                  `git show benchmark-data:${latestDir}/criterion_baseline.json 2>/dev/null || echo "{}"`,
-                  { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
-                ).trim();
-                baselineResults = JSON.parse(baselineFile);
-                hasBaseline = Object.keys(baselineResults).length > 0;
-              }
-            } catch (e) {
-              console.log('No benchmark-data branch found -- will post results without comparison');
-            }
-
-            const sanitize = (s) => s.replace(/[|`\[\]<>]/g, '\\$&');
-
-            // Build comparison for all benchmarks
-            const allNames = [...new Set([...Object.keys(currentResults), ...Object.keys(baselineResults)])].sort();
-            const rows = [];
-            const regressions = [];
-            const threshold = 1.50; // 50% -- wall-clock on shared runners is noisy
-
-            for (const name of allNames) {
-              const current = currentResults[name];
-              const baseline = baselineResults[name];
-              let changeStr = '';
-
-              if (current && baseline) {
-                const ratio = current / baseline;
-                const pct = ((ratio - 1) * 100).toFixed(1);
-                changeStr = ratio >= 1 ? `+${pct}%` : `${pct}%`;
-                if (ratio > threshold) {
-                  regressions.push({ name, baseline, current, change: `+${pct}%` });
-                }
-              } else if (current && !baseline) {
-                changeStr = 'new';
-              } else if (!current && baseline) {
-                changeStr = 'removed';
-              }
-
-              rows.push({
-                name,
-                baseline: baseline ? baseline.toLocaleString() : '—',
-                current: current ? current.toLocaleString() : '—',
-                change: changeStr
-              });
-            }
-
-            // Build markdown body
-            let body = '## Criterion Benchmark Results\n\n';
-            body += '| Benchmark | Baseline (ns/iter) | Current (ns/iter) | Change |\n';
-            body += '|-----------|-------------------|-------------------|--------|\n';
-            for (const r of rows) {
-              const flag = regressions.some(reg => reg.name === r.name) ? ' :warning:' : '';
-              body += `| ${sanitize(r.name)} | ${r.baseline} | ${r.current} | ${sanitize(r.change)}${flag} |\n`;
-            }
-
-            if (regressions.length > 0) {
-              body += `\n> :warning: ${regressions.length} benchmark(s) regressed >50%. Wall-clock benchmarks on shared CI runners can vary up to 3x between runs due to noisy neighbours. iai-callgrind provides deterministic regression detection.\n`;
-            } else if (hasBaseline) {
-              body += '\n> All benchmarks within 50% of baseline.\n';
-            } else {
-              body += '\n> No baseline available for comparison. Baseline is recorded on push to `main`.\n';
-            }
-
-            // Post to GITHUB_STEP_SUMMARY (always visible in Actions tab)
+            // GITHUB_STEP_SUMMARY is always visible in the Actions tab
             await core.summary.addRaw(body).write();
 
-            // Post as PR comment
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -131,8 +70,8 @@ jobs:
             });
 
             // Wall-clock regressions are advisory only -- don't block merge
-            if (regressions.length > 0) {
-              core.warning(`Wall-clock regression detected in ${regressions.length} benchmark(s) -- see PR comment for details`);
+            if (process.env.REGRESSED === 'true') {
+              core.warning('Wall-clock regression detected -- see PR comment for details');
             }
 
   iai-benchmarks:

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ tests/external/results/
 .kos
 # Built MCPB bundle for Smithery; rebuild with: mcpb pack mcpb mcpb/dynoxide.mcpb
 /mcpb/*.mcpb
+# Bytecode cache from the benchmark helper scripts
+__pycache__/
+*.pyc

--- a/benchmarks/scripts/compare_criterion.py
+++ b/benchmarks/scripts/compare_criterion.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Compare criterion results against recent runs stored on the benchmark-data branch.
+
+The baseline is the per-benchmark median of the last N stored runs, not the
+single newest one. Wall-clock numbers on GitHub's hosted runners move with
+whatever host a job lands on, so any one run can sit well outside the usual
+spread. Taking the newest run as the reference lets a single anomalous run
+become the baseline for every comparison until the next refresh, which both
+floods PRs with false regressions and hides real ones behind the offset.
+
+Reads either criterion's bencher-format output or an already-parsed
+criterion_baseline.json, writes a markdown comparison table, and exits 2 when
+something exceeds the threshold so the caller can decide whether that blocks.
+
+Usage:
+    python3 benchmarks/scripts/compare_criterion.py \
+        --current-output benchmarks/criterion_output.txt \
+        --output comparison.md
+
+    python3 benchmarks/scripts/compare_criterion.py \
+        --current-json benchmarks/results/criterion_baseline.json \
+        --window 5 --output comparison.md
+"""
+
+import argparse
+import json
+import re
+import statistics
+import subprocess
+import sys
+
+
+# criterion --output-format bencher: "test NAME ... bench: N,NNN ns/iter (+/- N)"
+BENCHER_RE = re.compile(r"^test\s+(.+?)\s+\.\.\.\s+bench:\s+([\d,]+)\s+ns/iter")
+
+EXIT_OK = 0
+EXIT_ERROR = 1
+# Not 2: argparse exits 2 on a usage error, and a caller branching on the
+# regression signal must not read a mistyped flag as a regression.
+EXIT_REGRESSED = 3
+
+
+def parse_bencher(text):
+    """Parse criterion bencher-format output into {benchmark_name: ns}."""
+    results = {}
+    for line in text.splitlines():
+        match = BENCHER_RE.match(line)
+        if match:
+            results[match.group(1)] = int(match.group(2).replace(",", ""))
+    return results
+
+
+def git(*args):
+    """Run a git command, returning stdout or None if it failed."""
+    proc = subprocess.run(
+        ("git",) + args, capture_output=True, text=True
+    )
+    if proc.returncode != 0:
+        return None
+    return proc.stdout
+
+
+def load_history(ref, window):
+    """Load up to `window` most recent stored runs from `ref`.
+
+    Returns a list of (run_dir, {benchmark: ns}), oldest first. Run
+    directories are named runs/YYYY-MM-DD-<sha>, so a lexical sort is
+    chronological. Directories without a criterion_baseline.json are skipped
+    rather than counted against the window, since early runs predate it.
+    """
+    listing = git("ls-tree", "--name-only", ref, "runs/")
+    if listing is None:
+        return []
+
+    run_dirs = sorted(d for d in listing.split() if d)
+    history = []
+    for run_dir in reversed(run_dirs):
+        if len(history) >= window:
+            break
+        raw = git("show", "{}:{}/criterion_baseline.json".format(ref, run_dir))
+        if raw is None:
+            continue
+        try:
+            history.append((run_dir, json.loads(raw)))
+        except json.JSONDecodeError:
+            continue
+    history.reverse()
+    return history
+
+
+def build_baseline(history):
+    """Reduce history to {benchmark: (median, low, high, sample_count)}."""
+    samples = {}
+    for _, run in history:
+        for name, value in run.items():
+            samples.setdefault(name, []).append(value)
+    return {
+        name: (statistics.median(vals), min(vals), max(vals), len(vals))
+        for name, vals in samples.items()
+    }
+
+
+def sanitize(text):
+    """Escape markdown table metacharacters in a benchmark name."""
+    return re.sub(r"([|`\[\]<>])", r"\\\1", text)
+
+
+def build_report(current, baseline, history, threshold):
+    """Render the markdown comparison. Returns (markdown, regressions)."""
+    regressions = []
+    rows = []
+
+    for name in sorted(set(current) | set(baseline)):
+        now = current.get(name)
+        stats = baseline.get(name)
+
+        if now is not None and stats:
+            median, low, high, _ = stats
+            ratio = now / median if median else None
+            if ratio is None:
+                change = "—"
+            else:
+                pct = (ratio - 1) * 100
+                change = "{}{:.1f}%".format("+" if pct >= 0 else "", pct)
+                if ratio > threshold:
+                    regressions.append(name)
+                    change += " :warning:"
+            rows.append((
+                name,
+                "{:,}".format(round(median)),
+                "{:,} - {:,}".format(low, high),
+                "{:,}".format(now),
+                change,
+            ))
+        elif now is not None:
+            rows.append((name, "—", "—", "{:,}".format(now), "new"))
+        else:
+            median, low, high, _ = stats
+            rows.append((
+                name,
+                "{:,}".format(round(median)),
+                "{:,} - {:,}".format(low, high),
+                "—",
+                "removed",
+            ))
+
+    window = len(history)
+    lines = ["## Criterion Benchmark Results", ""]
+
+    if window:
+        lines.append(
+            "Baseline is the per-benchmark median of the last {} stored {}, "
+            "so one unusually fast or slow runner cannot skew the comparison. "
+            "The range column is the spread across those runs.".format(
+                window, "run" if window == 1 else "runs"
+            )
+        )
+        lines.append("")
+
+    lines.append("| Benchmark | Baseline (ns/iter) | Range | Current | Change |")
+    lines.append("|-----------|-------------------:|------:|--------:|--------|")
+    for name, median, spread, now, change in rows:
+        lines.append("| {} | {} | {} | {} | {} |".format(
+            sanitize(name), median, spread, now, sanitize(change)
+        ))
+    lines.append("")
+
+    if not window:
+        lines.append(
+            "> No stored runs to compare against. Baselines are recorded by "
+            "the benchmark refresh workflow."
+        )
+    elif regressions:
+        lines.append(
+            "> :warning: {} benchmark(s) came in more than {:.0%} above the "
+            "{}-run median. Check whether the current value falls outside the "
+            "range column before treating it as real; iai-callgrind gives a "
+            "deterministic instruction-count answer.".format(
+                len(regressions), threshold - 1, window
+            )
+        )
+    else:
+        lines.append(
+            "> All benchmarks within {:.0%} of the {}-run median.".format(
+                threshold - 1, window
+            )
+        )
+
+    if window:
+        lines.append("")
+        lines.append("<details><summary>Runs in the baseline</summary>")
+        lines.append("")
+        for run_dir, _ in history:
+            lines.append("- `{}`".format(run_dir))
+        lines.append("")
+        lines.append("</details>")
+
+    return "\n".join(lines) + "\n", regressions
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--current-output",
+                        help="criterion bencher-format output to compare")
+    source.add_argument("--current-json",
+                        help="already-parsed criterion results JSON")
+    parser.add_argument("--ref", default="benchmark-data",
+                        help="git ref holding stored runs (default: benchmark-data)")
+    parser.add_argument("--window", type=int, default=5,
+                        help="how many recent runs the median spans (default: 5)")
+    parser.add_argument("--threshold", type=float, default=1.50,
+                        help="flag above this multiple of the median (default: 1.50)")
+    parser.add_argument("--output",
+                        help="write markdown here instead of stdout")
+    args = parser.parse_args()
+
+    if args.window < 1:
+        parser.error("--window must be at least 1")
+
+    try:
+        if args.current_output:
+            with open(args.current_output) as handle:
+                current = parse_bencher(handle.read())
+        else:
+            with open(args.current_json) as handle:
+                current = json.load(handle)
+    except (OSError, json.JSONDecodeError) as exc:
+        print("could not read current results: {}".format(exc), file=sys.stderr)
+        return EXIT_ERROR
+
+    if not current:
+        print("no criterion results parsed, nothing to compare", file=sys.stderr)
+        return EXIT_ERROR
+
+    history = load_history(args.ref, args.window)
+    if not history:
+        print("no stored runs found on '{}'".format(args.ref), file=sys.stderr)
+
+    markdown, regressions = build_report(
+        current, build_baseline(history), history, args.threshold
+    )
+
+    if args.output:
+        with open(args.output, "w") as handle:
+            handle.write(markdown)
+    else:
+        sys.stdout.write(markdown)
+
+    if regressions:
+        print("exceeded threshold: {}".format(", ".join(regressions)),
+              file=sys.stderr)
+        return EXIT_REGRESSED
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/scripts/compare_criterion.py
+++ b/benchmarks/scripts/compare_criterion.py
@@ -9,8 +9,13 @@ become the baseline for every comparison until the next refresh, which both
 floods PRs with false regressions and hides real ones behind the offset.
 
 Reads either criterion's bencher-format output or an already-parsed
-criterion_baseline.json, writes a markdown comparison table, and exits 2 when
-something exceeds the threshold so the caller can decide whether that blocks.
+criterion_baseline.json and writes a markdown comparison table. Both workflows
+branch on the exit code, so it is a contract:
+
+    0  clean, nothing over the threshold
+    1  could not compare
+    2  usage error (argparse's own)
+    3  threshold exceeded, advisory
 
 Usage:
     python3 benchmarks/scripts/compare_criterion.py \
@@ -63,16 +68,24 @@ def git(*args):
 def load_history(ref, window):
     """Load up to `window` most recent stored runs from `ref`.
 
-    Returns a list of (run_dir, {benchmark: ns}), oldest first. Run
-    directories are named runs/YYYY-MM-DD-<sha>, so a lexical sort is
-    chronological. Directories without a criterion_baseline.json are skipped
-    rather than counted against the window, since early runs predate it.
+    Returns a list of (run_dir, {benchmark: ns}), oldest first, or None when the
+    ref could not be read at all. None and [] are deliberately different: a ref
+    we cannot read means no comparison happened, which must not be reported as a
+    comparison that found nothing wrong.
+
+    Run directories are named runs/YYYY-MM-DD-<sha>. Sorting them lexically
+    orders by date but not within a date, where the trailing short SHA decides;
+    that only matters at the window boundary when two runs share a date.
+
+    Runs without a criterion_baseline.json, or with an empty or unparseable one,
+    are skipped rather than counted against the window. An empty file otherwise
+    consumes a slot and shrinks the sample the median rests on.
     """
     listing = git("ls-tree", "--name-only", ref, "runs/")
     if listing is None:
-        return []
+        return None
 
-    run_dirs = sorted(d for d in listing.split() if d)
+    run_dirs = sorted(d for d in listing.splitlines() if d)
     history = []
     for run_dir in reversed(run_dirs):
         if len(history) >= window:
@@ -81,9 +94,12 @@ def load_history(ref, window):
         if raw is None:
             continue
         try:
-            history.append((run_dir, json.loads(raw)))
+            parsed = json.loads(raw)
         except json.JSONDecodeError:
             continue
+        if not parsed:
+            continue
+        history.append((run_dir, parsed))
     history.reverse()
     return history
 
@@ -101,13 +117,19 @@ def build_baseline(history):
 
 
 def sanitize(text):
-    """Escape markdown table metacharacters in a benchmark name."""
-    return re.sub(r"([|`\[\]<>])", r"\\\1", text)
+    """Escape markdown table metacharacters in a benchmark name.
+
+    The backslash is escaped first (it leads the character class), otherwise a
+    name containing a literal \\| would emerge as \\\\| and the pipe would still
+    read as a real cell delimiter.
+    """
+    return re.sub(r"([\\|`\[\]<>])", r"\\\1", text)
 
 
 def build_report(current, baseline, history, threshold):
     """Render the markdown comparison. Returns (markdown, regressions)."""
     regressions = []
+    missing = []
     rows = []
 
     for name in sorted(set(current) | set(baseline)):
@@ -115,19 +137,26 @@ def build_report(current, baseline, history, threshold):
         stats = baseline.get(name)
 
         if now is not None and stats:
-            median, low, high, _ = stats
+            median, low, high, count = stats
             ratio = now / median if median else None
             if ratio is None:
                 change = "—"
             else:
                 pct = (ratio - 1) * 100
                 change = "{}{:.1f}%".format("+" if pct >= 0 else "", pct)
-                if ratio > threshold:
+                # A single sample is not a median. Flagging against it is the
+                # same one-run comparison this script exists to replace, so a
+                # benchmark new to the window reports its change without the
+                # warning until a second run backs it up.
+                if ratio > threshold and count > 1:
                     regressions.append(name)
                     change += " :warning:"
+            baseline_cell = "{:,}".format(round(median))
+            if count < len(history):
+                baseline_cell += " (n={})".format(count)
             rows.append((
                 name,
-                "{:,}".format(round(median)),
+                baseline_cell,
                 "{:,} - {:,}".format(low, high),
                 "{:,}".format(now),
                 change,
@@ -136,6 +165,7 @@ def build_report(current, baseline, history, threshold):
             rows.append((name, "—", "—", "{:,}".format(now), "new"))
         else:
             median, low, high, _ = stats
+            missing.append(name)
             rows.append((
                 name,
                 "{:,}".format(round(median)),
@@ -179,6 +209,14 @@ def build_report(current, baseline, history, threshold):
                 len(regressions), threshold - 1, window
             )
         )
+    elif missing:
+        lines.append(
+            "> :warning: {} benchmark(s) in the baseline produced no result in "
+            "this run: {}. A partial bench run reports the rest as clean, so "
+            "treat this as a failed comparison rather than a pass.".format(
+                len(missing), ", ".join(sanitize(n) for n in missing)
+            )
+        )
     else:
         lines.append(
             "> All benchmarks within {:.0%} of the {}-run median.".format(
@@ -191,7 +229,7 @@ def build_report(current, baseline, history, threshold):
         lines.append("<details><summary>Runs in the baseline</summary>")
         lines.append("")
         for run_dir, _ in history:
-            lines.append("- `{}`".format(run_dir))
+            lines.append("- `{}`".format(sanitize(run_dir)))
         lines.append("")
         lines.append("</details>")
 
@@ -199,7 +237,8 @@ def build_report(current, baseline, history, threshold):
 
 
 def main():
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(
+        description="Compare criterion results against recent stored runs")
     source = parser.add_mutually_exclusive_group(required=True)
     source.add_argument("--current-output",
                         help="criterion bencher-format output to compare")
@@ -234,6 +273,10 @@ def main():
         return EXIT_ERROR
 
     history = load_history(args.ref, args.window)
+    if history is None:
+        print("could not read run history from '{}'; no comparison was made"
+              .format(args.ref), file=sys.stderr)
+        return EXIT_ERROR
     if not history:
         print("no stored runs found on '{}'".format(args.ref), file=sys.stderr)
 

--- a/benchmarks/scripts/compare_criterion.py
+++ b/benchmarks/scripts/compare_criterion.py
@@ -73,9 +73,10 @@ def load_history(ref, window):
     we cannot read means no comparison happened, which must not be reported as a
     comparison that found nothing wrong.
 
-    Run directories are named runs/YYYY-MM-DD-<sha>. Sorting them lexically
-    orders by date but not within a date, where the trailing short SHA decides;
-    that only matters at the window boundary when two runs share a date.
+    Run directories are named runs/YYYY-MM-DDTHHMMSSZ-<sha>, so sorting them
+    lexically is chronological. Runs stored before that naming landed are
+    date-only; they sort before same-day timestamped runs, which is the right
+    order since they are older.
 
     Runs without a criterion_baseline.json, or with an empty or unparseable one,
     are skipped rather than counted against the window. An empty file otherwise


### PR DESCRIPTION
Fixes #167.

## What this changes

The criterion comparison took whichever stored run was newest as its baseline, with nothing checking that the run was representative. One anomalous run on 24 July came in at 0.51x the median of the eleven before it and became the reference for every PR until the next refresh, flagging all twelve benchmarks on changes that touched nothing relevant.

The false alarms were the visible half. The worse half is that a skewed baseline carries no information at all: with that run as the reference, a real 0%, 20%, 40% and 80% slowdown all produce the same twelve-way warning, so there is no way to tell a genuine regression from the offset.

The baseline is now the per-benchmark median of the last five stored runs, with the spread across those runs shown next to it. The comparison also lived twice, as inline JavaScript in `benchmark-regression.yml` and inline Python in `benchmark-refresh.yml`, with the same underlying bug in both. Both now call `benchmarks/scripts/compare_criterion.py`.

Reviewing the first commit turned up three ways the check could report success without having compared anything, which is the same shape as the bug it set out to fix:

- An unreadable history ref returned the same empty result as a genuinely empty one, so a failed fetch exited 0 and the check went green.
- A bench run that died partway still exited 0 through the `tee`, and the benchmarks it never reached rendered as `removed` rows under a clean footer. Zero results failed loudly; two of twelve passed quietly.
- A stored run with an empty results file consumed a window slot, shrinking the sample the median rests on. Demonstrated on the real stored data: three empty runs plus the 24 July anomaly collapses the median to a two-value mean and reports +25.7% to +41.3% across the board.

A fourth was the same false-alarm class the change exists to remove: a benchmark with only one prior measurement could still be flagged, since a median of one sample is just that sample. The per-benchmark count was already being computed and discarded at both call sites; it is now shown when a benchmark is new to the window, and a single sample no longer raises a warning.

The last commit covers two things a failed comparison got wrong. It skipped the PR comment entirely, so the check went red with nothing to explain it, and stored runs were keyed on date and commit alone, so a second refresh on the same day at the same commit replaced the first instead of adding a sample. Run directories now carry a second-resolution timestamp, which also keeps same-day runs in order under the lexical sort the comparison relies on.

Criterion stays advisory and iai-callgrind stays the blocking gate, unchanged. A red benchmark check now means no comparison happened, not that a regression was found.

## Verification

Backtested against all thirteen runs stored on `benchmark-data`: nothing flagged, where the old rule flags twelve on the run immediately after the anomaly. Sensitivity is unchanged, so it still catches real slowdowns:

```
+30%  ->  0/12 flagged
+50%  ->  3/12
+60%  ->  6/12
+100% -> 12/12
```

The exit-code contract both workflows branch on was exercised directly: 0 clean, 1 could not compare, 2 argparse usage error, 3 threshold exceeded. `actionlint` reports the same two pre-existing findings before and after.

The regression workflow tests itself here, since `pull_request` uses the workflow file from the branch. This PR changes no Rust, so the comment below should show a clean median-of-five table rather than a twelve-way regression.

## Not covered by this PR's own CI

`benchmark-refresh.yml` only runs on `workflow_dispatch`, so the timestamped run directory and the `pipefail` change on its bench step land untested. Worth dispatching one refresh after merge and confirming it creates a `runs/YYYY-MM-DDTHHMMSSZ-<sha>` directory rather than a date-only one, since that step writes to `benchmark-data` permanently.

Two follow-ups are known and not included here. The bencher-parsing regex now exists in three files, and the copy that writes stored data is separate from the copy that reads it, so drift would silently drop benchmarks from the comparison. And `build_report` interleaves data reduction, threshold judgement and rendering, so the threshold rule can only be asserted by reading strings out of markdown.

## Checklist

- ~~Tests added or updated~~ - nothing covers `benchmarks/scripts/` today, and establishing a Python suite for one CI helper in a Rust repo is its own decision. Verified by backtest across the real stored history, a synthetic sensitivity sweep, direct exercise of all four exit codes, and the empty-history, single-sample, partial-run and unreadable-ref paths.
- ~~`cargo fmt --check` and `cargo clippy -- -D warnings` pass locally~~ - no Rust changed.
- ~~`CHANGELOG.md` updated if this is a user-visible change~~ - CI tooling only.
- [x] Linked issue, discussion, or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms (MIT License and Apache License, Version 2.0)
