### PR TITLE
fix: report per-index ConsumedCapacity on transactional and PartiQL writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `BatchExecuteStatement` accepts `ReturnConsumedCapacity` and reports capacity, which it previously had no way to do at all. Per-table entries with index arms, aggregated across the batch. A failed statement is still charged the write it attempted, sized on the larger of the row already stored and the item it carried; a batch in which nothing succeeds reports no capacity, and a table whose statements all failed is omitted entirely. Captured against eu-west-2.
+
+### Changed
+
+- **Breaking (behaviour):** `BatchExecuteStatement` and `ExecuteTransaction` now reject two request shapes they used to accept, matching DynamoDB. A batch or transaction may not mix reads and writes, and may not name the same item twice, reads included. Both are rejected up front with a top-level `ValidationException` before any statement runs; a request that previously succeeded in either shape now fails. An unparseable member is unaffected and still reports against itself while the rest of the batch runs. Captured against eu-west-2.
+
+  The four checks cost about 7% on a 25-statement `BatchExecuteStatement`, measured against `958e340`.
+
+- **Breaking (Rust API):** `actions::batch_execute_statement::BatchStatementRequest` is now `#[non_exhaustive]`. It is still short of DynamoDB's shape, lacking `ConsistentRead` and `ReturnValuesOnConditionCheckFailure`, so it will gain fields again and the attribute is there to stop that breaking anyone twice. Library consumers that construct it must build from `Default` and assign, or deserialise it. `BatchExecuteStatementRequest` is deliberately not marked: with `ReturnConsumedCapacity` on it, that type now matches DynamoDB exactly. This is a source-breaking change for the crate's public API, so the next release is a minor bump. The DynamoDB wire API and the CLI/server/MCP surfaces are unaffected.
+
 ### Fixed
 
 - `ConsumedCapacity` under `INDEXES` charges index writes on the change to what an index stores, not on the item the write leaves behind ([#176](https://github.com/nubo-db/dynoxide/issues/176)). Each index used to be charged a unit whenever the finished item belonged to it, which is right for a plain insert and wrong for most else:
@@ -26,10 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Enabling `wasm-sqlite` alongside the default features now fails with a message that says so. Cargo adds the default features to whatever a manifest lists, so `dynoxide-rs = { version = "0.13", features = ["wasm-sqlite"] }` also enabled the native backend and the CLI, and the build stopped on three type errors naming neither the feature nor the conflict. The combination was never valid and still is not; what was missing was the diagnosis. Enable the wasm backend with `default-features = false`.
 
+- `TransactWriteItems`, `ExecuteStatement`, `ExecuteTransaction` and `BatchExecuteStatement` report per-index `ConsumedCapacity` under `INDEXES`, where they used to report a `Table` arm and nothing else ([#178](https://github.com/nubo-db/dynoxide/issues/178)). The transactional 2x factor applies to the base table arm alone: an index arm inside a transaction costs what the same write costs outside one. Index units fold into the total, so totals grow on an indexed table under `TOTAL` as well.
+
+- The transactional table arm is sized on the larger of the item's before and after images rather than on the request payload. `Delete` and `ConditionCheck` carry a key and no item, so both used to be sized on the key: deleting a 3KB item reported 2 units against DynamoDB's 6. Invisible below 1KB. A `ConditionCheck` writes nothing and is still charged on the image it read.
+
+- A same-token `TransactWriteItems` or `ExecuteTransaction` replay is charged against the images the first call was sized on, at 4KB read granularity. It used to recompute from the request, which carries no item for a `Delete` or a `ConditionCheck`, so a replayed delete of a 9KB item reported 2 against DynamoDB's 6.
+
 ### Notes
 
-- `TransactWriteItems` and PartiQL writes are untouched by all of the above, and the gap is wider than a missing breakdown. They report no per-index arms under `INDEXES`, where real DynamoDB reports them, and the table figure they do report is still sized on the finished item rather than on the larger of the two images. `TransactWriteItems` is further out: it sizes an update from the request's key and expression values, so it never sees either image. Recorded in [docs/compatibility-summary.md](docs/compatibility-summary.md).
-- Enabling `wasm-sqlite` alongside the default features now fails with a message that says so. Cargo adds the default features to whatever a manifest lists, so `dynoxide-rs = { version = "0.13", features = ["wasm-sqlite"] }` also enabled the native backend and the CLI, and the build stopped on three type errors naming neither the feature nor the conflict. The combination was never valid and still is not; what was missing was the diagnosis. Enable the wasm backend with `default-features = false`.
+- A PartiQL `SELECT` against an index still scans the base table and drops its `WHERE` clause, returning rows the index does not contain and accepting an index name that does not exist ([#179](https://github.com/nubo-db/dynoxide/issues/179)). Unrelated to the capacity work above and unchanged by it.
 
 ## [0.13.0] - 2026-07-30
 

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -1143,7 +1143,7 @@ dependencies = [
 
 [[package]]
 name = "dynoxide-rs"
-version = "0.11.3"
+version = "0.13.0"
 dependencies = [
  "axum",
  "base64",

--- a/benchmarks/benches/embedded_micro.rs
+++ b/benchmarks/benches/embedded_micro.rs
@@ -379,33 +379,67 @@ fn bench_transact_write_items(c: &mut Criterion) {
 // ---------------------------------------------------------------------------
 // BatchExecuteStatement (25 PartiQL statements)
 //
-// The PartiQL surfaces had no benchmark of any kind until this one. The batch
-// path is the interesting one: it walks its statement list three times before
-// executing anything, once to classify reads against writes, once to reject
-// duplicate targets, and once to run them, and the middle pass loads table
-// metadata per statement.
+// The PartiQL surfaces had no benchmark of any kind until this one, so a change
+// to their hot path could not be measured at all.
+//
+// Two things learned the hard way here, for whoever measures against it next.
+//
+// Assert the workload succeeded. This benchmark's first version inserted a
+// string into a sort key declared `N`, so all 25 statements were rejected. The
+// call still returns `Ok`, because a batch reports member failures inside a
+// successful response, so nothing complained. Every figure taken from it was a
+// measurement of the rejection path, and the conclusions drawn from those
+// figures were wrong in ways no amount of care in the arithmetic would have
+// caught. That is what the check outside the timing loop below is for.
+//
+// Know the noise floor before explaining a small difference. Repeat runs of
+// identical code here have differed by around 6 per cent. A change smaller
+// than that is not evidence of anything, whatever mechanism suggests itself.
 // ---------------------------------------------------------------------------
+
+fn batch_of_25(counter: usize) -> Vec<BatchStatementRequest> {
+    (0..25)
+        .map(|i| {
+            let mut stmt = BatchStatementRequest::default();
+            // `sk` is declared N on the bench table, so it has to be a number.
+            // A string here is rejected per statement and the batch as a whole
+            // still returns Ok, which measures the rejection path instead.
+            stmt.statement = format!(
+                "INSERT INTO \"{}\" VALUE {{'pk':'bench-{}','sk':{}}}",
+                BENCH_TABLE,
+                counter + i,
+                counter + i
+            );
+            stmt
+        })
+        .collect()
+}
 
 fn bench_batch_execute_statement(c: &mut Criterion) {
     c.bench_function("batch_execute_statement_25", |b| {
         let db = setup_database(PRE_POPULATED_COUNT, ItemSize::Medium);
         let mut counter = PRE_POPULATED_COUNT;
+
+        // BatchExecuteStatement reports member failures inside a successful
+        // response, so `unwrap` proves nothing about the workload. Check once,
+        // outside the timing loop, that every statement actually runs.
+        let check = db
+            .batch_execute_statement(BatchExecuteStatementRequest {
+                statements: batch_of_25(counter),
+                return_consumed_capacity: None,
+            })
+            .unwrap();
+        assert!(
+            check.responses.iter().all(|r| r.error.is_none()),
+            "benchmark workload is failing, so this measures rejection: {:?}",
+            check.responses.iter().find_map(|r| r.error.as_ref())
+        );
+        counter += 25;
+
         b.iter(|| {
             counter += 25;
-            let statements: Vec<BatchStatementRequest> = (0..25)
-                .map(|i| {
-                    let mut stmt = BatchStatementRequest::default();
-                    stmt.statement = format!(
-                        "INSERT INTO \"{}\" VALUE {{'pk':'bench-{}','sk':'s'}}",
-                        BENCH_TABLE,
-                        counter + i
-                    );
-                    stmt
-                })
-                .collect();
-
             db.batch_execute_statement(BatchExecuteStatementRequest {
-                statements,
+                statements: batch_of_25(counter),
                 return_consumed_capacity: None,
             })
             .unwrap();

--- a/benchmarks/benches/embedded_micro.rs
+++ b/benchmarks/benches/embedded_micro.rs
@@ -1,4 +1,7 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use dynoxide::actions::batch_execute_statement::{
+    BatchExecuteStatementRequest, BatchStatementRequest,
+};
 use dynoxide::actions::batch_get_item::{BatchGetItemRequest, KeysAndAttributes};
 use dynoxide::actions::batch_write_item::{BatchWriteItemRequest, PutRequest, WriteRequest};
 use dynoxide::actions::delete_item::DeleteItemRequest;
@@ -373,6 +376,43 @@ fn bench_transact_write_items(c: &mut Criterion) {
 // Criterion configuration
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// BatchExecuteStatement (25 PartiQL statements)
+//
+// The PartiQL surfaces had no benchmark of any kind until this one. The batch
+// path is the interesting one: it walks its statement list three times before
+// executing anything, once to classify reads against writes, once to reject
+// duplicate targets, and once to run them, and the middle pass loads table
+// metadata per statement.
+// ---------------------------------------------------------------------------
+
+fn bench_batch_execute_statement(c: &mut Criterion) {
+    c.bench_function("batch_execute_statement_25", |b| {
+        let db = setup_database(PRE_POPULATED_COUNT, ItemSize::Medium);
+        let mut counter = PRE_POPULATED_COUNT;
+        b.iter(|| {
+            counter += 25;
+            let statements: Vec<BatchStatementRequest> = (0..25)
+                .map(|i| {
+                    let mut stmt = BatchStatementRequest::default();
+                    stmt.statement = format!(
+                        "INSERT INTO \"{}\" VALUE {{'pk':'bench-{}','sk':'s'}}",
+                        BENCH_TABLE,
+                        counter + i
+                    );
+                    stmt
+                })
+                .collect();
+
+            db.batch_execute_statement(BatchExecuteStatementRequest {
+                statements,
+                return_consumed_capacity: None,
+            })
+            .unwrap();
+        });
+    });
+}
+
 criterion_group! {
     name = embedded_micro;
     config = Criterion::default()
@@ -388,6 +428,7 @@ criterion_group! {
         bench_delete_item,
         bench_batch_write_item,
         bench_batch_get_item,
+        bench_batch_execute_statement,
         bench_transact_write_items
 }
 

--- a/benchmarks/benches/iai_core.rs
+++ b/benchmarks/benches/iai_core.rs
@@ -10,6 +10,10 @@
 #[cfg(feature = "iai-callgrind")]
 use dynoxide::Database;
 #[cfg(feature = "iai-callgrind")]
+use dynoxide::actions::batch_execute_statement::{
+    BatchExecuteStatementRequest, BatchStatementRequest,
+};
+#[cfg(feature = "iai-callgrind")]
 use dynoxide::actions::delete_item::DeleteItemRequest;
 #[cfg(feature = "iai-callgrind")]
 use dynoxide::actions::get_item::GetItemRequest;
@@ -190,6 +194,39 @@ fn bench_delete_item((db, request): (Database, DeleteItemRequest)) {
     black_box(db.delete_item(request).unwrap());
 }
 
+/// A 25-statement PartiQL batch.
+///
+/// The PartiQL surfaces had no instruction-count coverage at all, so a change
+/// to their hot path could not be measured by the gate that blocks a merge.
+/// This one walks its statement list more than once before executing anything,
+/// which is precisely the kind of cost the wall-clock suite is too noisy to
+/// resolve.
+#[cfg(feature = "iai-callgrind")]
+fn setup_batch_execute_statement() -> (Database, BatchExecuteStatementRequest) {
+    let db = setup_database(1000, ItemSize::Medium);
+    let statements = (0..25)
+        .map(|i| {
+            let mut stmt = BatchStatementRequest::default();
+            stmt.statement = format!(
+                "INSERT INTO \"{BENCH_TABLE}\" VALUE {{'pk':'bench-{i}','sk':'s'}}"
+            );
+            stmt
+        })
+        .collect();
+    let request = BatchExecuteStatementRequest {
+        statements,
+        ..Default::default()
+    };
+    (db, request)
+}
+
+#[cfg(feature = "iai-callgrind")]
+#[library_benchmark]
+#[bench::batch25(setup_batch_execute_statement())]
+fn bench_batch_execute_statement((db, request): (Database, BatchExecuteStatementRequest)) {
+    black_box(db.batch_execute_statement(request).unwrap());
+}
+
 // ---- Group and harness registration ----
 
 #[cfg(feature = "iai-callgrind")]
@@ -201,7 +238,8 @@ library_benchmark_group!(
         bench_query,
         bench_scan,
         bench_update_item,
-        bench_delete_item
+        bench_delete_item,
+        bench_batch_execute_statement
 );
 
 #[cfg(feature = "iai-callgrind")]

--- a/benchmarks/benches/iai_core.rs
+++ b/benchmarks/benches/iai_core.rs
@@ -204,20 +204,36 @@ fn bench_delete_item((db, request): (Database, DeleteItemRequest)) {
 #[cfg(feature = "iai-callgrind")]
 fn setup_batch_execute_statement() -> (Database, BatchExecuteStatementRequest) {
     let db = setup_database(1000, ItemSize::Medium);
-    let statements = (0..25)
-        .map(|i| {
-            let mut stmt = BatchStatementRequest::default();
-            stmt.statement = format!(
-                "INSERT INTO \"{BENCH_TABLE}\" VALUE {{'pk':'bench-{i}','sk':'s'}}"
-            );
-            stmt
-        })
-        .collect();
-    let request = BatchExecuteStatementRequest {
-        statements,
-        ..Default::default()
+    let build = || -> BatchExecuteStatementRequest {
+        let statements = (0..25)
+            .map(|i| {
+                let mut stmt = BatchStatementRequest::default();
+                // `sk` is declared N on the bench table. A string here is
+                // rejected per statement while the batch still returns Ok, so
+                // the benchmark would silently measure the rejection path.
+                stmt.statement =
+                    format!("INSERT INTO \"{BENCH_TABLE}\" VALUE {{'pk':'bench-{i}','sk':{i}}}");
+                stmt
+            })
+            .collect();
+        BatchExecuteStatementRequest {
+            statements,
+            ..Default::default()
+        }
     };
-    (db, request)
+
+    // Setup is excluded from measurement, so prove the workload runs here
+    // rather than trusting an outer Ok that member errors do not disturb.
+    let check = db.batch_execute_statement(build()).unwrap();
+    assert!(
+        check.responses.iter().all(|r| r.error.is_none()),
+        "benchmark workload is failing, so this measures rejection"
+    );
+
+    // A fresh database, so the measured call inserts rather than duplicating
+    // what the check above just wrote.
+    let db = setup_database(1000, ItemSize::Medium);
+    (db, build())
 }
 
 #[cfg(feature = "iai-callgrind")]

--- a/docs/compatibility-summary.md
+++ b/docs/compatibility-summary.md
@@ -109,14 +109,23 @@ moving an index key costs two writes, and removing one costs a single delete.
 Sizing is on the projected index entry, so an attribute the index does not
 project costs it nothing.
 
-`TransactWriteItems` and PartiQL writes are the exception, and in two ways. Neither
-reports a per-index breakdown under `INDEXES`, where real DynamoDB reports one. The
-table figure they do report is also still sized on the finished item rather than on
-the larger of the item's before and after images, so a write that shrinks an item
-under-reports on these surfaces while `PutItem` and `UpdateItem` now get it right.
-`TransactWriteItems` sizes an update from the request's key and expression values,
-so it sees neither image. The sizing gaps are invisible below 1KB, where everything
-rounds to the same unit; the missing breakdown shows at any size.
+Every write surface reports the breakdown: `PutItem`, `UpdateItem`, `DeleteItem`,
+`BatchWriteItem`, `TransactWriteItems`, `ExecuteStatement`, `ExecuteTransaction`
+and `BatchExecuteStatement`.
+
+The transactional 2x factor applies to the base table arm alone. An index arm
+inside a `TransactWriteItems` or `ExecuteTransaction` costs what the same write
+costs outside a transaction, so a GSI key move charges the index the same either
+way while the table arm doubles.
+
+A transactional table arm is sized on the larger of the item's before and after
+images, which covers a `ConditionCheck` too: it writes nothing and is still
+charged on the image it read. A same-token replay is charged against those same
+images at 4KB read granularity.
+
+One read-side gap remains: a PartiQL `SELECT` served from an index reports its
+units against the base table arm, because the index qualifier is not honoured at
+all ([#179](https://github.com/nubo-db/dynoxide/issues/179)).
 
 ---
 
@@ -139,6 +148,12 @@ Supports `SELECT`, `INSERT`, `UPDATE`, `DELETE` with full WHERE clause support:
 Parameter placeholders (`?`) supported in all positions including nested list/map values.
 
 **`RETURNING`:** honoured on `ExecuteStatement` (`DELETE ALL OLD *`, and `UPDATE` in all four `ALL`/`MODIFIED` × `OLD`/`NEW` variants, with `MODIFIED` excluding the key) and on `BatchExecuteStatement`; rejected inside `ExecuteTransaction` with a `ValidationException`. `DELETE` accepts only `RETURNING ALL OLD *` and rejects the other variants, matching DynamoDB.
+
+**Batch and transaction shape:** `BatchExecuteStatement` and `ExecuteTransaction` reject a request that mixes reads with writes, and one that names the same item twice, reads included. Both raise a top-level `ValidationException` before any statement runs, each with its own message. A member that does not parse is reported against itself and does not stop the rest of a batch. Captured against eu-west-2.
+
+**`ReturnConsumedCapacity`:** accepted on all three PartiQL surfaces. `BatchExecuteStatement` aggregates per table across the batch and charges a failed statement the write it attempted, sized on the row already stored.
+
+`BatchStatementRequest` does not yet carry `ConsistentRead` or `ReturnValuesOnConditionCheckFailure`, so a batch member setting either is parsed as though it had not.
 
 ---
 

--- a/src/actions/batch_execute_statement.rs
+++ b/src/actions/batch_execute_statement.rs
@@ -233,10 +233,10 @@ struct Prepared {
 /// resolution does, so the parsing was the larger half of the overhead by more
 /// than two to one.
 ///
-/// Target resolution shares one key-schema lookup per table. That saves little
-/// on the native backend, where table metadata is already cached in memory, and
-/// more on the wasm backend, which has no such cache and pays a bridge crossing
-/// for every lookup.
+/// Target resolution is not shared and not cheap: it loads the table's metadata
+/// and parses its key schema per statement, and the executor does both again a
+/// moment later. Sharing that is a separate change from this one, and it is
+/// worth more on the wasm backend, which caches no metadata at all.
 async fn prepare<S: StorageBackend>(
     storage: &S,
     statements: &[BatchStatementRequest],

--- a/src/actions/batch_execute_statement.rs
+++ b/src/actions/batch_execute_statement.rs
@@ -1,4 +1,4 @@
-use crate::actions::index_capacity::{WriteCapacity, aggregate_by_table};
+use crate::actions::index_capacity::{WriteCapacity, aggregate_by_table, per_table_capacity};
 use crate::errors::{DynoxideError, Result};
 use crate::partiql;
 use crate::storage_backend::StorageBackend;
@@ -293,34 +293,29 @@ fn build_capacity(
             crate::types::read_capacity_units_with_consistency(*size, false);
     }
 
-    // The surcharge lands on the total without reaching the Table arm, so it is
-    // added after the arms are built rather than folded into them. A table whose
-    // statements all failed gets no entry at all: captured against a two-table
-    // batch where the failing table was omitted entirely and only the
-    // succeeding one was reported.
+    let mut entries = per_table_capacity(
+        &by_table,
+        mode,
+        crate::types::consumed_capacity_with_secondary_indexes,
+    )?;
+
+    // The surcharge is applied here rather than inside the shared fold, because
+    // it is the one rule of the three that differs and it has already been got
+    // wrong once. A failed statement lands on the total without reaching the
+    // Table arm or any index arm, so it cannot be folded into the units the
+    // builder sees. A table whose statements all failed has no entry to attach
+    // it to and gets none: captured against a two-table batch where the failing
+    // table was omitted entirely and only the succeeding one was reported.
     let mut surcharge: HashMap<&str, f64> = HashMap::new();
     for (table, units) in failures {
         *surcharge.entry(table.as_str()).or_default() += units;
     }
+    for entry in &mut entries {
+        entry.capacity_units += surcharge
+            .get(entry.table_name.as_str())
+            .copied()
+            .unwrap_or(0.0);
+    }
 
-    let mut tables: Vec<&String> = by_table.keys().collect();
-    tables.sort();
-
-    Some(
-        tables
-            .into_iter()
-            .filter_map(|table| {
-                let units = by_table.get(table)?;
-                let mut capacity = crate::types::consumed_capacity_with_secondary_indexes(
-                    table,
-                    units.table_units,
-                    &units.gsi_units,
-                    &units.lsi_units,
-                    mode,
-                )?;
-                capacity.capacity_units += surcharge.get(table.as_str()).copied().unwrap_or(0.0);
-                Some(capacity)
-            })
-            .collect(),
-    )
+    Some(entries)
 }

--- a/src/actions/batch_execute_statement.rs
+++ b/src/actions/batch_execute_statement.rs
@@ -80,39 +80,36 @@ pub async fn execute<S: StorageBackend>(
         ));
     }
 
+    // Parse once, and carry the resolved target alongside. Statements that fail
+    // to parse keep their error for the per-statement path below: a batch
+    // holding one is not rejected outright, it reports `ValidationError` against
+    // that member and runs the rest. Parse failure and an unresolvable target
+    // are different things, which is why they are a `Result` and an `Option`
+    // rather than one fallible value.
+    let prepared = prepare(storage, &request.statements).await;
+
     // A batch is all-read or all-write. AWS rejects a mixed one up front,
-    // before any statement runs, rather than per statement. Statements that do
-    // not parse are left to the per-statement error path below and take no part
-    // in the classification.
-    let kinds: Vec<bool> = request
-        .statements
-        .iter()
-        .filter_map(|s| partiql::parser::parse(&s.statement).ok())
-        .map(|stmt| matches!(stmt, partiql::parser::Statement::Select { .. }))
-        .collect();
-    if kinds.iter().any(|is_read| *is_read) && kinds.iter().any(|is_read| !is_read) {
+    // before any statement runs, rather than per statement. A statement that
+    // did not parse takes no part in the classification, and its presence does
+    // not stop the check firing on the ones that did.
+    let kinds = prepared.iter().filter_map(|p| p.stmt.as_ref().ok());
+    let (reads, writes): (Vec<_>, Vec<_>) =
+        kinds.partition(|stmt| matches!(stmt, partiql::parser::Statement::Select { .. }));
+    if !reads.is_empty() && !writes.is_empty() {
         return Err(DynoxideError::ValidationException(
             "Read and write requests together in the same batch is not supported.".to_string(),
         ));
     }
 
-    // Two statements against one item are rejected up front. A statement whose
-    // key cannot be read off the request is skipped here and left to fail on
-    // its own terms below.
+    // Two statements against one item are rejected up front, reads included. A
+    // statement whose key cannot be read off the request has no target and is
+    // left to fail on its own terms below.
     let mut seen_targets = HashSet::new();
-    for stmt_req in &request.statements {
-        let Ok(stmt) = partiql::parser::parse(&stmt_req.statement) else {
-            continue;
-        };
-        let params = stmt_req.parameters.as_deref().unwrap_or_default();
-        // Written as nested ifs rather than a let-chain, which would raise the
-        // crate's declared MSRV.
-        if let Some(target) = partiql::executor::statement_target(storage, &stmt, params).await {
-            if !seen_targets.insert(target) {
-                return Err(DynoxideError::ValidationException(
-                    "Provided list of item keys contains duplicates".to_string(),
-                ));
-            }
+    for target in prepared.iter().filter_map(|p| p.target.as_ref()) {
+        if !seen_targets.insert(target) {
+            return Err(DynoxideError::ValidationException(
+                "Provided list of item keys contains duplicates".to_string(),
+            ));
         }
     }
 
@@ -121,7 +118,7 @@ pub async fn execute<S: StorageBackend>(
     let mut read_units: Vec<(String, usize)> = Vec::new();
     let mut failures: Vec<(String, f64)> = Vec::new();
 
-    for stmt_req in &request.statements {
+    for (stmt_req, prepared) in request.statements.iter().zip(prepared) {
         // A COUNT projection is rejected before parsing with the bare message
         // captured on ExecuteStatement, carried here under the same
         // per-statement ValidationError code a parse failure uses.
@@ -137,9 +134,7 @@ pub async fn execute<S: StorageBackend>(
             continue;
         }
 
-        let parsed = partiql::parser::parse(&stmt_req.statement);
-
-        let response = match parsed {
+        let response = match prepared.stmt {
             Err(e) => BatchStatementResponse {
                 error: Some(BatchStatementError {
                     // A per-statement parse failure carries the short-form
@@ -217,6 +212,51 @@ pub async fn execute<S: StorageBackend>(
         ),
         responses,
     })
+}
+
+/// One statement, parsed once and resolved once.
+struct Prepared {
+    /// The parse result. An `Err` is a per-statement error, not a request-level
+    /// one: AWS reports `ValidationError` against that member and runs the rest.
+    stmt: std::result::Result<partiql::parser::Statement, String>,
+    /// The item this statement targets, for duplicate detection. `None` when it
+    /// does not resolve to one, which covers a partition-spanning `SELECT` and
+    /// anything whose key cannot be read off the request.
+    target: Option<(String, String, String)>,
+}
+
+/// Parse every statement and resolve its target, once each.
+///
+/// The statement text was previously parsed three times per call: to classify
+/// reads against writes, to find duplicate targets, and to execute. Measured on
+/// a 25-statement batch, each pass costs about as much as everything the target
+/// resolution does, so the parsing was the larger half of the overhead by more
+/// than two to one.
+///
+/// Target resolution shares one key-schema lookup per table. That saves little
+/// on the native backend, where table metadata is already cached in memory, and
+/// more on the wasm backend, which has no such cache and pays a bridge crossing
+/// for every lookup.
+async fn prepare<S: StorageBackend>(
+    storage: &S,
+    statements: &[BatchStatementRequest],
+) -> Vec<Prepared> {
+    let mut prepared = Vec::with_capacity(statements.len());
+    for stmt_req in statements {
+        let parsed = partiql::parser::parse(&stmt_req.statement);
+        let target = match parsed {
+            Ok(ref stmt) => {
+                let params = stmt_req.parameters.as_deref().unwrap_or_default();
+                partiql::executor::statement_target(storage, stmt, params).await
+            }
+            Err(_) => None,
+        };
+        prepared.push(Prepared {
+            stmt: parsed,
+            target,
+        });
+    }
+    prepared
 }
 
 /// The write units a failed statement is charged.

--- a/src/actions/batch_execute_statement.rs
+++ b/src/actions/batch_execute_statement.rs
@@ -1,13 +1,17 @@
+use crate::actions::index_capacity::{WriteCapacity, aggregate_by_table};
 use crate::errors::{DynoxideError, Result};
 use crate::partiql;
 use crate::storage_backend::StorageBackend;
 use crate::types::{AttributeValue, Item};
 use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Default, Deserialize)]
 pub struct BatchExecuteStatementRequest {
     #[serde(rename = "Statements")]
     pub statements: Vec<BatchStatementRequest>,
+    #[serde(rename = "ReturnConsumedCapacity", default)]
+    pub return_consumed_capacity: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -22,6 +26,11 @@ pub struct BatchStatementRequest {
 pub struct BatchExecuteStatementResponse {
     #[serde(rename = "Responses")]
     pub responses: Vec<BatchStatementResponse>,
+    /// Per-table capacity, aggregated across the statements in the batch. No
+    /// transactional factor applies. Absent when no mode was asked for, and also
+    /// when every statement failed, which is what AWS does.
+    #[serde(rename = "ConsumedCapacity", skip_serializing_if = "Option::is_none")]
+    pub consumed_capacity: Option<Vec<crate::types::ConsumedCapacity>>,
 }
 
 #[derive(Debug, Default, Serialize)]
@@ -62,7 +71,46 @@ pub async fn execute<S: StorageBackend>(
         ));
     }
 
+    // A batch is all-read or all-write. AWS rejects a mixed one up front,
+    // before any statement runs, rather than per statement. Statements that do
+    // not parse are left to the per-statement error path below and take no part
+    // in the classification.
+    let kinds: Vec<bool> = request
+        .statements
+        .iter()
+        .filter_map(|s| partiql::parser::parse(&s.statement).ok())
+        .map(|stmt| matches!(stmt, partiql::parser::Statement::Select { .. }))
+        .collect();
+    if kinds.iter().any(|is_read| *is_read) && kinds.iter().any(|is_read| !is_read) {
+        return Err(DynoxideError::ValidationException(
+            "Read and write requests together in the same batch is not supported.".to_string(),
+        ));
+    }
+
+    // Two statements against one item are rejected up front. A statement whose
+    // key cannot be read off the request is skipped here and left to fail on
+    // its own terms below.
+    let mut seen_targets = HashSet::new();
+    for stmt_req in &request.statements {
+        let Ok(stmt) = partiql::parser::parse(&stmt_req.statement) else {
+            continue;
+        };
+        let params = stmt_req.parameters.as_deref().unwrap_or_default();
+        // Written as nested ifs rather than a let-chain, which would raise the
+        // crate's declared MSRV.
+        if let Some(target) = partiql::executor::statement_target(storage, &stmt, params).await {
+            if !seen_targets.insert(target) {
+                return Err(DynoxideError::ValidationException(
+                    "Provided list of item keys contains duplicates".to_string(),
+                ));
+            }
+        }
+    }
+
     let mut responses = Vec::with_capacity(request.statements.len());
+    let mut records: Vec<WriteCapacity> = Vec::new();
+    let mut read_units: Vec<(String, usize)> = Vec::new();
+    let mut failures: Vec<(String, f64)> = Vec::new();
 
     for stmt_req in &request.statements {
         // A COUNT projection is rejected before parsing with the bare message
@@ -99,30 +147,51 @@ pub async fn execute<S: StorageBackend>(
                 // not on a per-statement error.
                 let table = partiql::parser::table_name(&stmt).map(str::to_string);
                 let params = stmt_req.parameters.as_deref().unwrap_or_default();
-                match partiql::executor::execute(storage, &stmt, params, None).await {
-                    Ok(Some(items)) => {
+                match partiql::executor::execute_page(storage, &stmt, params, None, None).await {
+                    Ok(page) => {
+                        match page.capacity {
+                            Some(capacity) => records.push(capacity),
+                            // A SELECT is charged read units against the rows it
+                            // returned, with no index arm on a base table read.
+                            None => {
+                                if let Some(ref name) = table {
+                                    read_units.push((name.clone(), page.size));
+                                }
+                            }
+                        }
                         // A SELECT yields its row here; a DELETE/UPDATE carrying a
                         // RETURNING clause yields the returned item. Batch surfaces
                         // a single item per statement, so take the first.
                         BatchStatementResponse {
                             error: None,
-                            item: items.into_iter().next(),
+                            item: page.items.and_then(|items| items.into_iter().next()),
                             table_name: table,
                         }
                     }
-                    Ok(None) => BatchStatementResponse {
-                        error: None,
-                        item: None,
-                        table_name: table,
-                    },
-                    Err(e) => BatchStatementResponse {
-                        error: Some(BatchStatementError {
-                            code: e.short_error_code().to_string(),
-                            message: e.to_string(),
-                        }),
-                        item: None,
-                        table_name: None,
-                    },
+                    Err(e) => {
+                        // A failed statement is charged the write it attempted,
+                        // added to its table's total while appearing in no arm.
+                        // Captured: a failing 3KB insert beside a small success
+                        // reports total 5 against arms summing to 2, and three
+                        // failures of 1, 1 and 3 units report total 7.
+                        //
+                        // Only an INSERT carries its item in the statement, so
+                        // that is the one kind whose attempt can be sized
+                        // without reading anything. Everything else falls back
+                        // to the one-unit minimum.
+                        if let Some(name) = table {
+                            let units = attempted_units(storage, &stmt, params).await;
+                            failures.push((name, units));
+                        }
+                        BatchStatementResponse {
+                            error: Some(BatchStatementError {
+                                code: e.short_error_code().to_string(),
+                                message: e.to_string(),
+                            }),
+                            item: None,
+                            table_name: None,
+                        }
+                    }
                 }
             }
         };
@@ -130,5 +199,119 @@ pub async fn execute<S: StorageBackend>(
         responses.push(response);
     }
 
-    Ok(BatchExecuteStatementResponse { responses })
+    Ok(BatchExecuteStatementResponse {
+        consumed_capacity: build_capacity(
+            &records,
+            &read_units,
+            &failures,
+            &request.return_consumed_capacity,
+        ),
+        responses,
+    })
+}
+
+/// The write units a failed statement is charged.
+///
+/// Sized on the larger of the item already stored at the target and the item
+/// the statement carried, which is the same rule a successful write follows.
+///
+/// The stored side is load-bearing rather than incidental. Captured: a batch of
+/// three failing inserts alongside one success reports 7 against arms summing
+/// to 2. Two of the failures name tiny items and cost 1 each; the third names a
+/// tiny item too, but the row already at that key is 3KB, and it costs 3. Sizing
+/// on the statement alone reports 5.
+async fn attempted_units<S: StorageBackend>(
+    storage: &S,
+    stmt: &partiql::parser::Statement,
+    parameters: &[AttributeValue],
+) -> f64 {
+    let stored_size = match partiql::executor::statement_target(storage, stmt, parameters).await {
+        Some((table, pk, sk)) => storage
+            .get_item(&table, &pk, &sk)
+            .await
+            .ok()
+            .flatten()
+            .and_then(|json| serde_json::from_str::<Item>(&json).ok())
+            .map(|item| crate::types::item_size(&item)),
+        None => None,
+    };
+
+    // Only an INSERT carries its item in the statement text.
+    let attempted_size = match stmt {
+        partiql::parser::Statement::Insert { item, .. } => {
+            let mut resolved = Item::new();
+            for (name, value) in item {
+                let av = match value {
+                    partiql::parser::PartiqlValue::Literal(av) => av.clone(),
+                    // An unresolvable parameter is why the statement failed, so
+                    // size on what did resolve.
+                    partiql::parser::PartiqlValue::Parameter(idx) => match parameters.get(*idx) {
+                        Some(av) => av.clone(),
+                        None => continue,
+                    },
+                };
+                resolved.insert(name.clone(), av);
+            }
+            Some(crate::types::item_size(&resolved))
+        }
+        _ => None,
+    };
+
+    crate::types::table_write_capacity_units(stored_size, attempted_size)
+}
+
+/// Fold the batch into one `ConsumedCapacity` per table.
+///
+/// No transactional factor applies. A batch in which nothing succeeded reports
+/// no capacity at all, which is what AWS does even though the same failure
+/// counts for a unit when another statement in the batch succeeds.
+fn build_capacity(
+    records: &[WriteCapacity],
+    read_units: &[(String, usize)],
+    failures: &[(String, f64)],
+    mode: &Option<String>,
+) -> Option<Vec<crate::types::ConsumedCapacity>> {
+    if !matches!(mode.as_deref(), Some("TOTAL") | Some("INDEXES")) {
+        return None;
+    }
+    if records.is_empty() && read_units.is_empty() {
+        return None;
+    }
+
+    let mut by_table = aggregate_by_table(records, 1.0);
+    for (table, size) in read_units {
+        by_table.entry(table.clone()).or_default().table_units +=
+            crate::types::read_capacity_units_with_consistency(*size, false);
+    }
+
+    // The surcharge lands on the total without reaching the Table arm, so it is
+    // added after the arms are built rather than folded into them. A table whose
+    // statements all failed gets no entry at all: captured against a two-table
+    // batch where the failing table was omitted entirely and only the
+    // succeeding one was reported.
+    let mut surcharge: HashMap<&str, f64> = HashMap::new();
+    for (table, units) in failures {
+        *surcharge.entry(table.as_str()).or_default() += units;
+    }
+
+    let mut tables: Vec<&String> = by_table.keys().collect();
+    tables.sort();
+
+    Some(
+        tables
+            .into_iter()
+            .filter_map(|table| {
+                let units = by_table.get(table)?;
+                let mut capacity = crate::types::consumed_capacity_with_secondary_indexes(
+                    table,
+                    units.table_units,
+                    &units.gsi_units,
+                    &units.lsi_units,
+                    mode,
+                )?;
+                capacity.capacity_units += surcharge.get(table.as_str()).copied().unwrap_or(0.0);
+                Some(capacity)
+            })
+            .collect(),
+    )
 }

--- a/src/actions/batch_execute_statement.rs
+++ b/src/actions/batch_execute_statement.rs
@@ -14,7 +14,16 @@ pub struct BatchExecuteStatementRequest {
     pub return_consumed_capacity: Option<String>,
 }
 
+/// One member of a batch.
+///
+/// `#[non_exhaustive]` because this type is short of DynamoDB's: it still lacks
+/// `ConsistentRead` and `ReturnValuesOnConditionCheckFailure`, so it will gain
+/// fields again. Construct one from `Default` and assign, or deserialise it.
+/// The enclosing `BatchExecuteStatementRequest` is deliberately not marked: it
+/// carries `Statements` and `ReturnConsumedCapacity`, which is the whole of
+/// DynamoDB's shape, so there is nothing left to add to it.
 #[derive(Debug, Default, Deserialize)]
+#[non_exhaustive]
 pub struct BatchStatementRequest {
     #[serde(rename = "Statement")]
     pub statement: String,

--- a/src/actions/execute_statement.rs
+++ b/src/actions/execute_statement.rs
@@ -75,25 +75,36 @@ pub async fn execute<S: StorageBackend>(
     let partiql::executor::StatementPage {
         items,
         size,
+        capacity,
         next_token,
-        ..
     } = page;
 
     // ConsumedCapacity is returned whenever ReturnConsumedCapacity is requested,
     // unlike some emulators that omit it. A SELECT is charged read units (an
-    // eventually consistent read unless ConsistentRead is set); INSERT, UPDATE
-    // and DELETE are charged write units. The unit (single object, not an array)
-    // comes from the shared `types.rs` helpers.
+    // eventually consistent read unless ConsistentRead is set) against the rows
+    // it returned. A write is charged the base table arm plus a per-index arm,
+    // with no transactional factor: a capture against real DynamoDB reports a
+    // PartiQL INSERT of an item in two indexes as total 3, table 1, one unit per
+    // index, exactly as the equivalent `PutItem`.
     let consumed_capacity = partiql::parser::table_name(&stmt).and_then(|table| {
-        let units = if matches!(stmt, partiql::parser::Statement::Select { .. }) {
-            crate::types::read_capacity_units_with_consistency(
+        let Some(capacity) = capacity else {
+            let units = crate::types::read_capacity_units_with_consistency(
                 size,
                 request.consistent_read.unwrap_or(false),
-            )
-        } else {
-            crate::types::write_capacity_units(size)
+            );
+            return crate::types::consumed_capacity(
+                table,
+                units,
+                &request.return_consumed_capacity,
+            );
         };
-        crate::types::consumed_capacity(table, units, &request.return_consumed_capacity)
+        crate::types::consumed_capacity_with_secondary_indexes(
+            table,
+            crate::types::table_write_capacity_units(capacity.old_size, capacity.new_size),
+            &capacity.gsi_units,
+            &capacity.lsi_units,
+            &request.return_consumed_capacity,
+        )
     });
 
     Ok(ExecuteStatementResponse {

--- a/src/actions/execute_transaction.rs
+++ b/src/actions/execute_transaction.rs
@@ -220,6 +220,13 @@ fn build_write_capacity(
     charges: &[StatementCharge],
     mode: &Option<String>,
 ) -> Option<Vec<crate::types::ConsumedCapacity>> {
+    // Checked before the clone, not just inside the shared builder. Most calls
+    // ask for no capacity, and `as_write` clones every record and its index
+    // maps before the builder could discard the lot.
+    if !matches!(mode.as_deref(), Some("TOTAL") | Some("INDEXES")) {
+        return None;
+    }
+
     let records: Vec<WriteCapacity> = charges.iter().map(StatementCharge::as_write).collect();
     let by_table = aggregate_by_table(&records, crate::types::TRANSACTIONAL_CAPACITY_FACTOR);
     per_table_capacity(

--- a/src/actions/execute_transaction.rs
+++ b/src/actions/execute_transaction.rs
@@ -1,5 +1,7 @@
 use crate::actions::helpers;
-use crate::actions::index_capacity::{WriteCapacity, aggregate_by_table};
+use crate::actions::index_capacity::{
+    WriteCapacity, aggregate_by_table, per_table_capacity, transactional_read_units,
+};
 use crate::errors::{CancellationReason, DynoxideError, Result};
 use crate::partiql;
 use crate::storage_backend::StorageBackend;
@@ -149,7 +151,7 @@ pub(crate) async fn execute_cached<S: StorageBackend>(
     let mode = &request.return_consumed_capacity;
     let consumed_capacity = if is_read_set(&parsed) {
         crate::types::build_transactional_capacity(
-            &read_table_units(&charges),
+            &transactional_read_units(&replay_sizes(&charges)),
             mode,
             crate::types::transactional_read_capacity,
         )
@@ -213,47 +215,17 @@ impl StatementCharge {
     }
 }
 
-/// Per-table read units for a read set: 2 RCU per statement at 4KB granularity.
-fn read_table_units(charges: &[StatementCharge]) -> HashMap<String, f64> {
-    let mut table_units: HashMap<String, f64> = HashMap::new();
-    for charge in charges {
-        *table_units
-            .entry(charge.table_name().to_string())
-            .or_default() += crate::types::TRANSACTIONAL_CAPACITY_FACTOR
-            * crate::types::read_capacity_units(charge.size());
-    }
-    table_units
-}
-
 /// Fold the per-statement records into one `ConsumedCapacity` per table.
 fn build_write_capacity(
     charges: &[StatementCharge],
     mode: &Option<String>,
 ) -> Option<Vec<crate::types::ConsumedCapacity>> {
-    if !matches!(mode.as_deref(), Some("TOTAL") | Some("INDEXES")) {
-        return None;
-    }
-
     let records: Vec<WriteCapacity> = charges.iter().map(StatementCharge::as_write).collect();
     let by_table = aggregate_by_table(&records, crate::types::TRANSACTIONAL_CAPACITY_FACTOR);
-    // Sorted so a multi-table transaction reports a stable order.
-    let mut tables: Vec<&String> = by_table.keys().collect();
-    tables.sort();
-
-    Some(
-        tables
-            .into_iter()
-            .filter_map(|table| {
-                let units = by_table.get(table)?;
-                crate::types::transactional_write_capacity_with_indexes(
-                    table,
-                    units.table_units,
-                    &units.gsi_units,
-                    &units.lsi_units,
-                    mode,
-                )
-            })
-            .collect(),
+    per_table_capacity(
+        &by_table,
+        mode,
+        crate::types::transactional_write_capacity_with_indexes,
     )
 }
 
@@ -277,19 +249,6 @@ fn is_read_set(parsed: &[(partiql::parser::Statement, Vec<AttributeValue>)]) -> 
         .all(|(stmt, _)| matches!(stmt, partiql::parser::Statement::Select { .. }))
 }
 
-/// Per-table read units for a same-token replay, from the sizes the first call
-/// recorded. A replay is charged as a transactional read at 4KB granularity
-/// against the image each statement touched, which the statement text alone
-/// cannot supply: a `DELETE` names a key, not the item it removed.
-fn replay_table_units(sizes: &[(String, usize)]) -> HashMap<String, f64> {
-    let mut table_units: HashMap<String, f64> = HashMap::new();
-    for (table, size) in sizes {
-        *table_units.entry(table.clone()).or_default() +=
-            crate::types::TRANSACTIONAL_CAPACITY_FACTOR * crate::types::read_capacity_units(*size);
-    }
-    table_units
-}
-
 /// Build the response for a same-token idempotent replay. The statements are
 /// identical to the first call (the idempotency hash matched), so `Responses`
 /// carry over from the cached first call and capacity is reported as a
@@ -306,7 +265,7 @@ pub(crate) fn replay_response(
         response: ExecuteTransactionResponse {
             responses: cached.response.responses.clone(),
             consumed_capacity: crate::types::build_transactional_capacity(
-                &replay_table_units(&cached.replay_sizes),
+                &transactional_read_units(&cached.replay_sizes),
                 mode,
                 crate::types::transactional_read_capacity,
             ),

--- a/src/actions/execute_transaction.rs
+++ b/src/actions/execute_transaction.rs
@@ -36,11 +36,18 @@ pub struct ExecuteTransactionResponse {
     pub responses: Option<Vec<ItemResponse>>,
     #[serde(rename = "ConsumedCapacity", skip_serializing_if = "Option::is_none")]
     pub consumed_capacity: Option<Vec<crate::types::ConsumedCapacity>>,
-    /// Per-statement `(table, image size)` from this call, kept so a same-token
-    /// replay can charge against the images each statement touched rather than
-    /// re-deriving them from the statement text, which cannot see a `DELETE`
-    /// target's size at all. Never serialised.
-    #[serde(skip)]
+}
+
+/// A first-call result together with what a same-token replay needs to bill it.
+///
+/// The replay is charged against the image each statement touched, which the
+/// statement text cannot supply: a `DELETE` names a key, not the row it
+/// removed. Those sizes are internal bookkeeping, so they live here, on the type
+/// the idempotency cache holds, rather than on the response type callers see.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct CachedTransaction {
+    pub(crate) response: ExecuteTransactionResponse,
+    /// Per-statement `(table, image size)`.
     pub(crate) replay_sizes: Vec<(String, usize)>,
 }
 
@@ -50,10 +57,21 @@ pub struct ItemResponse {
     pub item: Option<Item>,
 }
 
+/// Run a PartiQL transaction.
+///
+/// Callers driving idempotency want [`execute_cached`], which also hands back
+/// the sizes a replay is billed against.
 pub async fn execute<S: StorageBackend>(
     storage: &S,
     request: ExecuteTransactionRequest,
 ) -> Result<ExecuteTransactionResponse> {
+    Ok(execute_cached(storage, request).await?.response)
+}
+
+pub(crate) async fn execute_cached<S: StorageBackend>(
+    storage: &S,
+    request: ExecuteTransactionRequest,
+) -> Result<CachedTransaction> {
     let statements = &request.transact_statements;
 
     // Validate: must have between 1 and 100 statements
@@ -139,9 +157,11 @@ pub async fn execute<S: StorageBackend>(
         build_write_capacity(&charges, mode)
     };
 
-    Ok(ExecuteTransactionResponse {
-        responses: Some(responses),
-        consumed_capacity,
+    Ok(CachedTransaction {
+        response: ExecuteTransactionResponse {
+            responses: Some(responses),
+            consumed_capacity,
+        },
         replay_sizes: replay_sizes(&charges),
     })
 }
@@ -279,16 +299,18 @@ fn replay_table_units(sizes: &[(String, usize)]) -> HashMap<String, f64> {
 /// successfully on the first call, so an unexpected parse error just drops that
 /// statement from the estimate rather than failing the replay.
 pub(crate) fn replay_response(
-    cached: &ExecuteTransactionResponse,
+    cached: &CachedTransaction,
     mode: &Option<String>,
-) -> ExecuteTransactionResponse {
-    ExecuteTransactionResponse {
-        responses: cached.responses.clone(),
-        consumed_capacity: crate::types::build_transactional_capacity(
-            &replay_table_units(&cached.replay_sizes),
-            mode,
-            crate::types::transactional_read_capacity,
-        ),
+) -> CachedTransaction {
+    CachedTransaction {
+        response: ExecuteTransactionResponse {
+            responses: cached.response.responses.clone(),
+            consumed_capacity: crate::types::build_transactional_capacity(
+                &replay_table_units(&cached.replay_sizes),
+                mode,
+                crate::types::transactional_read_capacity,
+            ),
+        },
         replay_sizes: cached.replay_sizes.clone(),
     }
 }

--- a/src/actions/execute_transaction.rs
+++ b/src/actions/execute_transaction.rs
@@ -1,9 +1,11 @@
 use crate::actions::helpers;
+use crate::actions::index_capacity::{WriteCapacity, aggregate_by_table};
 use crate::errors::{CancellationReason, DynoxideError, Result};
 use crate::partiql;
 use crate::storage_backend::StorageBackend;
 use crate::types::{AttributeValue, Item};
 use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct ExecuteTransactionRequest {
@@ -34,6 +36,12 @@ pub struct ExecuteTransactionResponse {
     pub responses: Option<Vec<ItemResponse>>,
     #[serde(rename = "ConsumedCapacity", skip_serializing_if = "Option::is_none")]
     pub consumed_capacity: Option<Vec<crate::types::ConsumedCapacity>>,
+    /// Per-statement `(table, image size)` from this call, kept so a same-token
+    /// replay can charge against the images each statement touched rather than
+    /// re-deriving them from the statement text, which cannot see a `DELETE`
+    /// target's size at all. Never serialised.
+    #[serde(skip)]
+    pub(crate) replay_sizes: Vec<(String, usize)>,
 }
 
 #[derive(Debug, Clone, Default, Serialize)]
@@ -86,33 +94,155 @@ pub async fn execute<S: StorageBackend>(
         parsed.push((ast, params));
     }
 
+    // A transaction is all-read or all-write, and may not touch one item twice.
+    // AWS rejects both up front, before any statement runs.
+    let reads = parsed
+        .iter()
+        .filter(|(stmt, _)| matches!(stmt, partiql::parser::Statement::Select { .. }))
+        .count();
+    if reads > 0 && reads < parsed.len() {
+        return Err(DynoxideError::ValidationException(
+            "ExecuteTransaction API does not support both read and write operations in the same request."
+                .to_string(),
+        ));
+    }
+
+    let mut seen_targets = HashSet::new();
+    for (stmt, params) in &parsed {
+        if let Some(target) = partiql::executor::statement_target(storage, stmt, params).await {
+            if !seen_targets.insert(target) {
+                return Err(DynoxideError::ValidationException(
+                    "Transaction request cannot include multiple operations on one item"
+                        .to_string(),
+                ));
+            }
+        }
+    }
+
     // All statements run inside one SQLite transaction (all-or-nothing).
-    let responses =
+    let (responses, charges) =
         helpers::with_write_transaction(storage, execute_within_transaction(storage, &parsed))
             .await?;
 
     // Transactional capacity, split by statement kind: an all-SELECT read set
-    // reports read capacity, any INSERT/UPDATE/DELETE makes it a write set.
-    //
-    // TODO: capacity is charged a flat per-statement transactional unit, not an
-    // item-size computation, so it under-counts PartiQL items above 1KB (writes
-    // round at 1KB, reads at 4KB). Correct for the small items conformance pins;
-    // size-accurate rounding for large PartiQL statements is a tracked follow-up.
-    let builder = if is_read_set(&parsed) {
-        crate::types::transactional_read_capacity
+    // reports read capacity, any INSERT/UPDATE/DELETE makes it a write set. Both
+    // are sized on the items each statement touched, and the transactional
+    // factor reaches the base table arm only.
+    let mode = &request.return_consumed_capacity;
+    let consumed_capacity = if is_read_set(&parsed) {
+        crate::types::build_transactional_capacity(
+            &read_table_units(&charges),
+            mode,
+            crate::types::transactional_read_capacity,
+        )
     } else {
-        crate::types::transactional_write_capacity
+        build_write_capacity(&charges, mode)
     };
-    let consumed_capacity = crate::types::build_transactional_capacity(
-        &statement_table_units(parsed.iter().map(|(stmt, _)| stmt)),
-        &request.return_consumed_capacity,
-        builder,
-    );
 
     Ok(ExecuteTransactionResponse {
         responses: Some(responses),
         consumed_capacity,
+        replay_sizes: replay_sizes(&charges),
     })
+}
+
+/// What one statement contributed to the transaction's capacity.
+enum StatementCharge {
+    /// A `SELECT`, charged on the rows it returned at read granularity.
+    Read { table_name: String, size: usize },
+    /// A write, charged on its images and its per-index units.
+    Write(WriteCapacity),
+}
+
+impl StatementCharge {
+    fn table_name(&self) -> &str {
+        match self {
+            Self::Read { table_name, .. } => table_name,
+            Self::Write(capacity) => &capacity.table_name,
+        }
+    }
+
+    /// The image size this statement is charged on, for a replay.
+    fn size(&self) -> usize {
+        match self {
+            Self::Read { size, .. } => *size,
+            Self::Write(capacity) => capacity
+                .old_size
+                .unwrap_or(0)
+                .max(capacity.new_size.unwrap_or(0)),
+        }
+    }
+
+    /// The write record for this statement.
+    ///
+    /// A mixed set is rejected before execution, so a `Read` charge never
+    /// reaches the write path in practice. It maps to a table-only record
+    /// rather than panicking, so a future relaxation of that check degrades to
+    /// an over-estimate instead of a wrong shape.
+    fn as_write(&self) -> WriteCapacity {
+        match self {
+            Self::Write(capacity) => capacity.clone(),
+            Self::Read { table_name, size } => WriteCapacity::new(
+                table_name,
+                None,
+                Some(*size),
+                HashMap::new(),
+                HashMap::new(),
+            ),
+        }
+    }
+}
+
+/// Per-table read units for a read set: 2 RCU per statement at 4KB granularity.
+fn read_table_units(charges: &[StatementCharge]) -> HashMap<String, f64> {
+    let mut table_units: HashMap<String, f64> = HashMap::new();
+    for charge in charges {
+        *table_units
+            .entry(charge.table_name().to_string())
+            .or_default() += crate::types::TRANSACTIONAL_CAPACITY_FACTOR
+            * crate::types::read_capacity_units(charge.size());
+    }
+    table_units
+}
+
+/// Fold the per-statement records into one `ConsumedCapacity` per table.
+fn build_write_capacity(
+    charges: &[StatementCharge],
+    mode: &Option<String>,
+) -> Option<Vec<crate::types::ConsumedCapacity>> {
+    if !matches!(mode.as_deref(), Some("TOTAL") | Some("INDEXES")) {
+        return None;
+    }
+
+    let records: Vec<WriteCapacity> = charges.iter().map(StatementCharge::as_write).collect();
+    let by_table = aggregate_by_table(&records, crate::types::TRANSACTIONAL_CAPACITY_FACTOR);
+    // Sorted so a multi-table transaction reports a stable order.
+    let mut tables: Vec<&String> = by_table.keys().collect();
+    tables.sort();
+
+    Some(
+        tables
+            .into_iter()
+            .filter_map(|table| {
+                let units = by_table.get(table)?;
+                crate::types::transactional_write_capacity_with_indexes(
+                    table,
+                    units.table_units,
+                    &units.gsi_units,
+                    &units.lsi_units,
+                    mode,
+                )
+            })
+            .collect(),
+    )
+}
+
+/// The image size each statement was charged on, kept for a same-token replay.
+fn replay_sizes(charges: &[StatementCharge]) -> Vec<(String, usize)> {
+    charges
+        .iter()
+        .map(|charge| (charge.table_name().to_string(), charge.size()))
+        .collect()
 }
 
 /// A transaction is a read set only when every statement is a `SELECT`; any
@@ -127,19 +257,15 @@ fn is_read_set(parsed: &[(partiql::parser::Statement, Vec<AttributeValue>)]) -> 
         .all(|(stmt, _)| matches!(stmt, partiql::parser::Statement::Select { .. }))
 }
 
-/// Per-table transactional units for a set of parsed statements. Each statement
-/// costs the per-statement base (1 unit) doubled by the transactional factor,
-/// summed by target table (matching `TransactWriteItems`, which doubles per
-/// item). Item-size rounding is not applied here (see the TODO in `execute`).
-fn statement_table_units<'a>(
-    statements: impl Iterator<Item = &'a partiql::parser::Statement>,
-) -> std::collections::HashMap<String, f64> {
-    let mut table_units: std::collections::HashMap<String, f64> = std::collections::HashMap::new();
-    for stmt in statements {
-        if let Some(tbl) = partiql::parser::table_name(stmt) {
-            *table_units.entry(tbl.to_string()).or_default() +=
-                crate::types::TRANSACTIONAL_CAPACITY_FACTOR;
-        }
+/// Per-table read units for a same-token replay, from the sizes the first call
+/// recorded. A replay is charged as a transactional read at 4KB granularity
+/// against the image each statement touched, which the statement text alone
+/// cannot supply: a `DELETE` names a key, not the item it removed.
+fn replay_table_units(sizes: &[(String, usize)]) -> HashMap<String, f64> {
+    let mut table_units: HashMap<String, f64> = HashMap::new();
+    for (table, size) in sizes {
+        *table_units.entry(table.clone()).or_default() +=
+            crate::types::TRANSACTIONAL_CAPACITY_FACTOR * crate::types::read_capacity_units(*size);
     }
     table_units
 }
@@ -153,35 +279,43 @@ fn statement_table_units<'a>(
 /// successfully on the first call, so an unexpected parse error just drops that
 /// statement from the estimate rather than failing the replay.
 pub(crate) fn replay_response(
-    statements: &[ParameterizedStatement],
+    cached: &ExecuteTransactionResponse,
     mode: &Option<String>,
-    cached_responses: Option<Vec<ItemResponse>>,
 ) -> ExecuteTransactionResponse {
-    let parsed: Vec<partiql::parser::Statement> = statements
-        .iter()
-        .filter_map(|s| partiql::parser::parse(&s.statement).ok())
-        .collect();
     ExecuteTransactionResponse {
-        responses: cached_responses,
+        responses: cached.responses.clone(),
         consumed_capacity: crate::types::build_transactional_capacity(
-            &statement_table_units(parsed.iter()),
+            &replay_table_units(&cached.replay_sizes),
             mode,
             crate::types::transactional_read_capacity,
         ),
+        replay_sizes: cached.replay_sizes.clone(),
     }
 }
 
+/// Run every statement, returning the responses and what each contributed to
+/// `ConsumedCapacity`. The charges are only meaningful when the whole
+/// transaction commits; a cancellation returns an error and reports nothing.
 async fn execute_within_transaction<S: StorageBackend>(
     storage: &S,
     parsed: &[(partiql::parser::Statement, Vec<AttributeValue>)],
-) -> Result<Vec<ItemResponse>> {
+) -> Result<(Vec<ItemResponse>, Vec<StatementCharge>)> {
     let mut responses = Vec::with_capacity(parsed.len());
+    let mut charges: Vec<StatementCharge> = Vec::with_capacity(parsed.len());
     let mut cancellation_reasons: Vec<CancellationReason> = Vec::with_capacity(parsed.len());
 
     for (stmt, params) in parsed {
-        match partiql::executor::execute(storage, stmt, params, None).await {
-            Ok(result) => {
-                let item = result.and_then(|items| items.into_iter().next());
+        match partiql::executor::execute_page(storage, stmt, params, None, None).await {
+            Ok(page) => {
+                let table_name = partiql::parser::table_name(stmt).unwrap_or_default();
+                charges.push(match page.capacity {
+                    Some(capacity) => StatementCharge::Write(capacity),
+                    None => StatementCharge::Read {
+                        table_name: table_name.to_string(),
+                        size: page.size,
+                    },
+                });
+                let item = page.items.and_then(|items| items.into_iter().next());
                 responses.push(ItemResponse { item });
                 cancellation_reasons.push(CancellationReason {
                     code: "None".to_string(),
@@ -240,5 +374,5 @@ async fn execute_within_transaction<S: StorageBackend>(
         }
     }
 
-    Ok(responses)
+    Ok((responses, charges))
 }

--- a/src/actions/index_capacity.rs
+++ b/src/actions/index_capacity.rs
@@ -208,6 +208,71 @@ pub struct TableCapacity {
     pub lsi_units: HashMap<String, f64>,
 }
 
+/// Shapes one table's entry. The transactional surfaces mirror their units into
+/// a write axis; the single-statement and batch ones report `CapacityUnits`
+/// alone, so the two builders are not interchangeable.
+type CapacityBuilder = fn(
+    &str,
+    f64,
+    &HashMap<String, f64>,
+    &HashMap<String, f64>,
+    &Option<String>,
+) -> Option<crate::types::ConsumedCapacity>;
+
+/// Per-table units for a transactional read: 2 RCU per entry, rounded at 4KB
+/// read granularity before the factor, summed by table.
+///
+/// Serves both an all-read transaction and a same-token replay, which are the
+/// same arithmetic over the same `(table, image size)` pairs. The replay's
+/// sizes come from the first call, because the request cannot supply them for
+/// an action that carries only a key.
+pub fn transactional_read_units(sizes: &[(String, usize)]) -> HashMap<String, f64> {
+    let mut table_units: HashMap<String, f64> = HashMap::new();
+    for (table, size) in sizes {
+        *table_units.entry(table.clone()).or_default() +=
+            crate::types::TRANSACTIONAL_CAPACITY_FACTOR * crate::types::read_capacity_units(*size);
+    }
+    table_units
+}
+
+/// Turn per-table totals into one `ConsumedCapacity` per table.
+///
+/// Sorted by table name. Aggregation is a `HashMap`, which would otherwise hand
+/// back a different order on every call and leave a caller indexing into a
+/// shuffled array.
+///
+/// Returns `None` when no capacity was asked for, which is distinct from an
+/// empty vec: the response omits the field entirely rather than carrying an
+/// empty list.
+pub fn per_table_capacity(
+    by_table: &HashMap<String, TableCapacity>,
+    mode: &Option<String>,
+    builder: CapacityBuilder,
+) -> Option<Vec<crate::types::ConsumedCapacity>> {
+    if !matches!(mode.as_deref(), Some("TOTAL") | Some("INDEXES")) {
+        return None;
+    }
+
+    let mut tables: Vec<&String> = by_table.keys().collect();
+    tables.sort();
+
+    Some(
+        tables
+            .into_iter()
+            .filter_map(|table| {
+                let units = by_table.get(table)?;
+                builder(
+                    table,
+                    units.table_units,
+                    &units.gsi_units,
+                    &units.lsi_units,
+                    mode,
+                )
+            })
+            .collect(),
+    )
+}
+
 /// Fold per-action records into per-table totals.
 ///
 /// `factor` is the transactional multiplier: 2 for `TransactWriteItems` and

--- a/src/actions/index_capacity.rs
+++ b/src/actions/index_capacity.rs
@@ -211,7 +211,7 @@ pub struct TableCapacity {
 /// Shapes one table's entry. The transactional surfaces mirror their units into
 /// a write axis; the single-statement and batch ones report `CapacityUnits`
 /// alone, so the two builders are not interchangeable.
-type CapacityBuilder = fn(
+pub(crate) type CapacityBuilder = fn(
     &str,
     f64,
     &HashMap<String, f64>,
@@ -226,7 +226,7 @@ type CapacityBuilder = fn(
 /// same arithmetic over the same `(table, image size)` pairs. The replay's
 /// sizes come from the first call, because the request cannot supply them for
 /// an action that carries only a key.
-pub fn transactional_read_units(sizes: &[(String, usize)]) -> HashMap<String, f64> {
+pub(crate) fn transactional_read_units(sizes: &[(String, usize)]) -> HashMap<String, f64> {
     let mut table_units: HashMap<String, f64> = HashMap::new();
     for (table, size) in sizes {
         *table_units.entry(table.clone()).or_default() +=
@@ -244,7 +244,7 @@ pub fn transactional_read_units(sizes: &[(String, usize)]) -> HashMap<String, f6
 /// Returns `None` when no capacity was asked for, which is distinct from an
 /// empty vec: the response omits the field entirely rather than carrying an
 /// empty list.
-pub fn per_table_capacity(
+pub(crate) fn per_table_capacity(
     by_table: &HashMap<String, TableCapacity>,
     mode: &Option<String>,
     builder: CapacityBuilder,

--- a/src/actions/index_capacity.rs
+++ b/src/actions/index_capacity.rs
@@ -136,6 +136,7 @@ fn set_unchanged<T: Ord>(x: &[T], y: &[T]) -> bool {
 /// index arms come from the maintenance helpers, which have already applied the
 /// delta rules above. Holding the three apart until aggregation is what keeps
 /// the transactional factor off the index arms.
+#[derive(Debug, Clone, Default)]
 pub struct WriteCapacity {
     pub table_name: String,
     /// The item before the write, absent when nothing was there.

--- a/src/actions/index_capacity.rs
+++ b/src/actions/index_capacity.rs
@@ -24,7 +24,10 @@
 //! same rules as GSIs.
 
 use super::gsi::{IndexDef, build_index_item};
-use crate::types::{AttributeValue, Item, write_capacity_units};
+use crate::types::{
+    AttributeValue, Item, item_size, table_write_capacity_units, write_capacity_units,
+};
+use std::collections::HashMap;
 
 /// One index's stored view of an item.
 struct IndexEntry {
@@ -127,11 +130,119 @@ fn set_unchanged<T: Ord>(x: &[T], y: &[T]) -> bool {
     x == y
 }
 
+/// What one write contributes to `ConsumedCapacity`.
+///
+/// The base table arm is sized on the images either side of the write and the
+/// index arms come from the maintenance helpers, which have already applied the
+/// delta rules above. Holding the three apart until aggregation is what keeps
+/// the transactional factor off the index arms.
+pub struct WriteCapacity {
+    pub table_name: String,
+    /// The item before the write, absent when nothing was there.
+    pub old_size: Option<usize>,
+    /// The item after the write, absent on a delete.
+    pub new_size: Option<usize>,
+    pub gsi_units: HashMap<String, f64>,
+    pub lsi_units: HashMap<String, f64>,
+}
+
+impl WriteCapacity {
+    /// Build from the image sizes either side of a write and the per-index
+    /// units the maintenance helpers returned.
+    ///
+    /// Callers that already hold a size should pass it: the write paths compute
+    /// the new image's size to enforce the item-size limit, and walking the item
+    /// again here would be the same work twice.
+    pub fn new(
+        table_name: &str,
+        old_size: Option<usize>,
+        new_size: Option<usize>,
+        gsi_units: HashMap<String, f64>,
+        lsi_units: HashMap<String, f64>,
+    ) -> Self {
+        Self {
+            table_name: table_name.to_string(),
+            old_size,
+            new_size,
+            gsi_units,
+            lsi_units,
+        }
+    }
+
+    /// Build from the images themselves, for callers that do not already hold
+    /// their sizes.
+    pub fn from_items(
+        table_name: &str,
+        old_item: Option<&Item>,
+        new_item: Option<&Item>,
+        gsi_units: HashMap<String, f64>,
+        lsi_units: HashMap<String, f64>,
+    ) -> Self {
+        Self::new(
+            table_name,
+            old_item.map(item_size),
+            new_item.map(item_size),
+            gsi_units,
+            lsi_units,
+        )
+    }
+
+    /// A `ConditionCheck` writes nothing and touches no index, and DynamoDB
+    /// still charges it against the image it reads. `item` is `None` when the
+    /// target does not exist, which falls back to the one-unit minimum.
+    ///
+    /// The record carries no after-image, because the check leaves none behind.
+    /// `table_write_capacity_units` charges a present-then-absent pair on the
+    /// old image alone, which is the captured figure.
+    pub fn condition_check(table_name: &str, item: Option<&Item>) -> Self {
+        Self::from_items(table_name, item, None, HashMap::new(), HashMap::new())
+    }
+}
+
+/// One table's share of a multi-action operation.
+#[derive(Default)]
+pub struct TableCapacity {
+    pub table_units: f64,
+    pub gsi_units: HashMap<String, f64>,
+    pub lsi_units: HashMap<String, f64>,
+}
+
+/// Fold per-action records into per-table totals.
+///
+/// `factor` is the transactional multiplier: 2 for `TransactWriteItems` and
+/// `ExecuteTransaction`, 1 for the single-statement and batch surfaces. It
+/// reaches the base table arm only. A capture against real DynamoDB pins index
+/// arms at their single-write cost inside a transaction, so a GSI key move at
+/// 1517B per side costs 4 whether or not it happens transactionally, while the
+/// table arm on that same write doubles.
+///
+/// Each action's table units are rounded and multiplied before they are summed,
+/// so an item straddling a KB boundary is not undercharged by aggregating bytes
+/// first.
+pub fn aggregate_by_table(
+    records: &[WriteCapacity],
+    factor: f64,
+) -> HashMap<String, TableCapacity> {
+    let mut by_table: HashMap<String, TableCapacity> = HashMap::new();
+
+    for record in records {
+        let entry = by_table.entry(record.table_name.clone()).or_default();
+        entry.table_units += factor * table_write_capacity_units(record.old_size, record.new_size);
+        for (name, units) in &record.gsi_units {
+            *entry.gsi_units.entry(name.clone()).or_default() += units;
+        }
+        for (name, units) in &record.lsi_units {
+            *entry.lsi_units.entry(name.clone()).or_default() += units;
+        }
+    }
+
+    by_table
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::types::ProjectionType;
-    use std::collections::HashMap;
 
     /// The capture's GSI: HASH `gsiPk`, no sort key, projecting `INCLUDE [proj]`.
     fn gsi_include() -> IndexDef {
@@ -557,6 +668,256 @@ mod tests {
         let mut new = old.clone();
         new.insert("proj".to_string(), AttributeValue::N("1.0".to_string()));
         assert_eq!(units(Some(&old), Some(&new), &gsi_include()), Some(1.0));
+    }
+
+    fn units_map(pairs: &[(&str, f64)]) -> HashMap<String, f64> {
+        pairs
+            .iter()
+            .map(|(name, u)| ((*name).to_string(), *u))
+            .collect()
+    }
+
+    /// One table's aggregate, looked up by name.
+    fn table_of<'a>(agg: &'a HashMap<String, TableCapacity>, name: &str) -> &'a TableCapacity {
+        agg.get(name).expect("table missing from aggregate")
+    }
+
+    #[test]
+    fn record_takes_its_sizes_from_the_images() {
+        let new = item(&[("pk", "a"), ("sk", "1"), ("gsiPk", "g")]);
+        let insert =
+            WriteCapacity::from_items("t", None, Some(&new), HashMap::new(), HashMap::new());
+        assert_eq!(insert.old_size, None);
+        assert_eq!(insert.new_size, Some(crate::types::item_size(&new)));
+
+        let delete =
+            WriteCapacity::from_items("t", Some(&new), None, HashMap::new(), HashMap::new());
+        assert_eq!(delete.old_size, Some(crate::types::item_size(&new)));
+        assert_eq!(delete.new_size, None);
+    }
+
+    #[test]
+    fn record_carries_one_arm_per_index_kind() {
+        // Capture A3: a transactional put of an item in both indexes reports
+        // gsi 1 and lsi 1.
+        let new = item(&[("pk", "a3"), ("sk", "1"), ("gsiPk", "g"), ("lsiSk", "L")]);
+        let record = WriteCapacity::from_items(
+            "t",
+            None,
+            Some(&new),
+            units_map(&[("gsi-inc", 1.0)]),
+            units_map(&[("lsi-all", 1.0)]),
+        );
+        assert_eq!(record.gsi_units.len(), 1);
+        assert_eq!(record.lsi_units.len(), 1);
+    }
+
+    #[test]
+    fn identical_overwrite_keeps_its_sizes_and_drops_its_arms() {
+        // Capture K3: an identical overwrite of a 3037B item is charged table 6
+        // and no index arm. The table arm and the index arms are independent
+        // readings of the same write.
+        let same = item(&[
+            ("pk", "k3"),
+            ("sk", "1"),
+            ("gsiPk", "g"),
+            ("proj", &pad(3000)),
+        ]);
+        let record = WriteCapacity::from_items(
+            "t",
+            Some(&same),
+            Some(&same),
+            HashMap::new(),
+            HashMap::new(),
+        );
+        assert!(record.gsi_units.is_empty());
+        assert!(record.lsi_units.is_empty());
+
+        let agg = aggregate_by_table(&[record], crate::types::TRANSACTIONAL_CAPACITY_FACTOR);
+        assert_eq!(table_of(&agg, "t").table_units, 6.0);
+    }
+
+    #[test]
+    fn transactional_factor_reaches_the_table_arm_and_not_the_index_arms() {
+        // The finding this whole change rests on. Capture A1: a transactional put
+        // of a sub-1KB GSI member reports table 2 and gsi 1. The single-item
+        // equivalent reports table 1 and gsi 1, so the table arm doubles and the
+        // index arm does not move.
+        let new = item(&[("pk", "a1"), ("sk", "1"), ("gsiPk", "g")]);
+        let record = WriteCapacity::from_items(
+            "t",
+            None,
+            Some(&new),
+            units_map(&[("gsi-inc", 1.0)]),
+            units_map(&[("lsi-all", 1.0)]),
+        );
+
+        let agg = aggregate_by_table(&[record], crate::types::TRANSACTIONAL_CAPACITY_FACTOR);
+        let t = table_of(&agg, "t");
+        assert_eq!(t.table_units, 2.0);
+        assert_eq!(t.gsi_units.get("gsi-inc"), Some(&1.0));
+        assert_eq!(t.lsi_units.get("lsi-all"), Some(&1.0));
+    }
+
+    #[test]
+    fn factor_of_one_leaves_the_table_arm_undoubled() {
+        // Capture C1: the same write through ExecuteStatement carries no
+        // transactional factor and reports table 1.
+        let new = item(&[("pk", "c1"), ("sk", "1"), ("gsiPk", "g")]);
+        let record = WriteCapacity::from_items(
+            "t",
+            None,
+            Some(&new),
+            units_map(&[("gsi-inc", 1.0)]),
+            HashMap::new(),
+        );
+
+        let agg = aggregate_by_table(&[record], 1.0);
+        assert_eq!(table_of(&agg, "t").table_units, 1.0);
+        assert_eq!(table_of(&agg, "t").gsi_units.get("gsi-inc"), Some(&1.0));
+    }
+
+    #[test]
+    fn two_actions_against_one_table_sum_every_arm() {
+        // Capture A13: two transactional puts, both indexed, report total 8 with
+        // table 4, gsi 2 and lsi 2.
+        let a = item(&[("pk", "a13"), ("sk", "1"), ("gsiPk", "g"), ("lsiSk", "L")]);
+        let b = item(&[("pk", "a14"), ("sk", "1"), ("gsiPk", "g"), ("lsiSk", "L")]);
+        let records = vec![
+            WriteCapacity::from_items(
+                "t",
+                None,
+                Some(&a),
+                units_map(&[("gsi-inc", 1.0)]),
+                units_map(&[("lsi-all", 1.0)]),
+            ),
+            WriteCapacity::from_items(
+                "t",
+                None,
+                Some(&b),
+                units_map(&[("gsi-inc", 1.0)]),
+                units_map(&[("lsi-all", 1.0)]),
+            ),
+        ];
+
+        let agg = aggregate_by_table(&records, crate::types::TRANSACTIONAL_CAPACITY_FACTOR);
+        let t = table_of(&agg, "t");
+        assert_eq!(t.table_units, 4.0);
+        assert_eq!(t.gsi_units.get("gsi-inc"), Some(&2.0));
+        assert_eq!(t.lsi_units.get("lsi-all"), Some(&2.0));
+    }
+
+    #[test]
+    fn actions_against_different_tables_aggregate_separately() {
+        // Capture G1: one put per table reports one entry each, carrying only
+        // that table's arms.
+        let a = item(&[("pk", "g1"), ("sk", "1"), ("gsiPk", "g"), ("lsiSk", "L")]);
+        let b = item(&[("pk", "g1"), ("sk", "1"), ("gsiPk", "g")]);
+        let records = vec![
+            WriteCapacity::from_items(
+                "first",
+                None,
+                Some(&a),
+                units_map(&[("gsi-inc", 1.0)]),
+                units_map(&[("lsi-all", 1.0)]),
+            ),
+            WriteCapacity::from_items(
+                "second",
+                None,
+                Some(&b),
+                units_map(&[("gsi-inc", 1.0)]),
+                HashMap::new(),
+            ),
+        ];
+
+        let agg = aggregate_by_table(&records, crate::types::TRANSACTIONAL_CAPACITY_FACTOR);
+        assert_eq!(agg.len(), 2);
+        assert_eq!(table_of(&agg, "first").table_units, 2.0);
+        assert!(table_of(&agg, "first").lsi_units.contains_key("lsi-all"));
+        assert_eq!(table_of(&agg, "second").table_units, 2.0);
+        assert!(table_of(&agg, "second").lsi_units.is_empty());
+    }
+
+    #[test]
+    fn an_action_with_no_image_either_side_still_costs_the_minimum() {
+        // Capture K1 and K2: a transactional delete or condition check against a
+        // target that does not exist reports table 2, which is the one-unit
+        // minimum doubled.
+        let record = WriteCapacity::from_items("t", None, None, HashMap::new(), HashMap::new());
+        let agg = aggregate_by_table(&[record], crate::types::TRANSACTIONAL_CAPACITY_FACTOR);
+        assert_eq!(table_of(&agg, "t").table_units, 2.0);
+    }
+
+    #[test]
+    fn condition_check_against_a_missing_target_costs_the_minimum() {
+        // Capture K2: a condition check whose target does not exist reports
+        // table 2. Built through the constructor the action actually calls,
+        // rather than through an equivalent-looking `new`.
+        let record = WriteCapacity::condition_check("t", None);
+        assert_eq!(record.old_size, None);
+        assert_eq!(record.new_size, None);
+
+        let agg = aggregate_by_table(&[record], crate::types::TRANSACTIONAL_CAPACITY_FACTOR);
+        assert_eq!(table_of(&agg, "t").table_units, 2.0);
+    }
+
+    #[test]
+    fn condition_check_is_sized_on_the_image_it_reads() {
+        // Capture F1: a condition check against a 3023B item reports table 6,
+        // despite writing nothing. Sizing it on the key would report 2.
+        let existing = item(&[("pk", "f1"), ("sk", "1"), ("other", &pad(3000))]);
+        let record = WriteCapacity::condition_check("t", Some(&existing));
+        assert!(record.gsi_units.is_empty());
+        assert!(record.lsi_units.is_empty());
+
+        let agg = aggregate_by_table(&[record], crate::types::TRANSACTIONAL_CAPACITY_FACTOR);
+        assert_eq!(table_of(&agg, "t").table_units, 6.0);
+    }
+
+    #[test]
+    fn a_key_move_doubles_its_table_arm_and_leaves_its_index_arm_alone() {
+        // Capture B7: a GSI key move with 1517B on both sides reports table 4 and
+        // gsi 4. The two fours have different arithmetic behind them: the table is
+        // 2 x ceil(1.5KB base item) and the GSI is ceil(1517) + ceil(1517),
+        // undoubled. Doubling the index arm would report 8.
+        let old = item(&[
+            ("pk", "b7"),
+            ("sk", "1"),
+            ("gsiPk", "A"),
+            ("proj", &pad(1500)),
+        ]);
+        let new = item(&[
+            ("pk", "b7"),
+            ("sk", "1"),
+            ("gsiPk", "B"),
+            ("proj", &pad(1500)),
+        ]);
+        let arm = units(Some(&old), Some(&new), &gsi_include()).unwrap();
+        assert_eq!(arm, 4.0);
+
+        let record = WriteCapacity::from_items(
+            "t",
+            Some(&old),
+            Some(&new),
+            units_map(&[("gsi-inc", arm)]),
+            HashMap::new(),
+        );
+        let agg = aggregate_by_table(&[record], crate::types::TRANSACTIONAL_CAPACITY_FACTOR);
+        let t = table_of(&agg, "t");
+        assert_eq!(t.table_units, 4.0);
+        assert_eq!(t.gsi_units.get("gsi-inc"), Some(&4.0));
+    }
+
+    #[test]
+    fn a_shrinking_write_is_sized_on_the_image_it_replaced() {
+        // Capture B3: a transactional put shrinking a 3023B item to 18B reports
+        // table 6. Sizing on the request payload reports 2.
+        let old = item(&[("pk", "b3"), ("sk", "1"), ("other", &pad(3000))]);
+        let new = item(&[("pk", "b3"), ("sk", "1")]);
+        let record =
+            WriteCapacity::from_items("t", Some(&old), Some(&new), HashMap::new(), HashMap::new());
+        let agg = aggregate_by_table(&[record], crate::types::TRANSACTIONAL_CAPACITY_FACTOR);
+        assert_eq!(table_of(&agg, "t").table_units, 6.0);
     }
 
     #[test]

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -15,7 +15,9 @@ pub mod get_shard_iterator;
 pub(crate) mod gsi;
 pub(crate) mod helpers;
 pub mod import_items;
-pub(crate) mod index_capacity;
+// Public because `partiql::executor::StatementPage` carries a `WriteCapacity`
+// on a public field, and a consumer reading it has to be able to name the type.
+pub mod index_capacity;
 pub mod list_streams;
 pub mod list_tables;
 pub mod list_tags_of_resource;

--- a/src/actions/transact_write_items.rs
+++ b/src/actions/transact_write_items.rs
@@ -107,18 +107,36 @@ pub struct TransactWriteItemsResponse {
         skip_serializing_if = "Option::is_none"
     )]
     pub item_collection_metrics: Option<HashMap<String, Vec<crate::types::ItemCollectionMetrics>>>,
-    /// Per-action `(table, image size)` from this call, kept so a same-token
-    /// replay can charge against the images the write was sized on rather than
-    /// against the request payload, which carries no item for a `Delete` or a
-    /// `ConditionCheck`. Never serialised, so the wire shape is unaffected.
-    #[serde(skip)]
+}
+
+/// A first-call result together with what a same-token replay needs to bill it.
+///
+/// The replay is charged against the images each action was sized on, which the
+/// request cannot supply: a `Delete` or a `ConditionCheck` carries only a key.
+/// Those sizes are internal bookkeeping, so they live here, on the type the
+/// idempotency cache holds, rather than on the response type callers see.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct CachedWrite {
+    pub(crate) response: TransactWriteItemsResponse,
+    /// Per-action `(table, image size)`.
     pub(crate) replay_sizes: Vec<(String, usize)>,
 }
 
+/// Run a transactional write.
+///
+/// Callers driving idempotency want [`execute_cached`], which also hands back
+/// the sizes a replay is billed against.
 pub async fn execute<S: StorageBackend>(
     storage: &S,
     request: TransactWriteItemsRequest,
 ) -> Result<TransactWriteItemsResponse> {
+    Ok(execute_cached(storage, request).await?.response)
+}
+
+pub(crate) async fn execute_cached<S: StorageBackend>(
+    storage: &S,
+    request: TransactWriteItemsRequest,
+) -> Result<CachedWrite> {
     let items = &request.transact_items;
 
     // Validate: at least 1 action
@@ -167,9 +185,11 @@ pub async fn execute<S: StorageBackend>(
         helpers::with_write_transaction(storage, execute_within_transaction(storage, items))
             .await?;
 
-    Ok(TransactWriteItemsResponse {
-        consumed_capacity: build_write_capacity(&capacity, &request.return_consumed_capacity),
-        item_collection_metrics: None,
+    Ok(CachedWrite {
+        response: TransactWriteItemsResponse {
+            consumed_capacity: build_write_capacity(&capacity, &request.return_consumed_capacity),
+            item_collection_metrics: None,
+        },
         replay_sizes: replay_sizes(&capacity),
     })
 }
@@ -254,20 +274,18 @@ fn transact_read_table_units(sizes: &[(String, usize)]) -> HashMap<String, f64> 
 /// recorded rather than re-serving its write numbers, honouring the replay
 /// request's own `ReturnConsumedCapacity` mode (the original call's mode does
 /// not carry over). The read cost is computed at 4KB read granularity, which
-/// diverges from the first-call write magnitude above 1KB. `cached` is the
-/// stored first-call response, which carries both the image sizes and the item
-/// collection metrics.
-pub(crate) fn replay_response(
-    cached: &TransactWriteItemsResponse,
-    mode: &Option<String>,
-) -> TransactWriteItemsResponse {
-    TransactWriteItemsResponse {
-        consumed_capacity: crate::types::build_transactional_capacity(
-            &transact_read_table_units(&cached.replay_sizes),
-            mode,
-            crate::types::transactional_read_capacity,
-        ),
-        item_collection_metrics: cached.item_collection_metrics.clone(),
+/// diverges from the first-call write magnitude above 1KB. `cached` is what the
+/// first call stored: its response, and the image sizes to bill against.
+pub(crate) fn replay_response(cached: &CachedWrite, mode: &Option<String>) -> CachedWrite {
+    CachedWrite {
+        response: TransactWriteItemsResponse {
+            consumed_capacity: crate::types::build_transactional_capacity(
+                &transact_read_table_units(&cached.replay_sizes),
+                mode,
+                crate::types::transactional_read_capacity,
+            ),
+            item_collection_metrics: cached.response.item_collection_metrics.clone(),
+        },
         replay_sizes: cached.replay_sizes.clone(),
     }
 }

--- a/src/actions/transact_write_items.rs
+++ b/src/actions/transact_write_items.rs
@@ -1,4 +1,5 @@
 use crate::actions::helpers;
+use crate::actions::index_capacity::{WriteCapacity, aggregate_by_table};
 use crate::errors::{CancellationReason, DynoxideError, Result};
 use crate::storage_backend::StorageBackend;
 use crate::types::{self, AttributeValue, Item};
@@ -106,6 +107,12 @@ pub struct TransactWriteItemsResponse {
         skip_serializing_if = "Option::is_none"
     )]
     pub item_collection_metrics: Option<HashMap<String, Vec<crate::types::ItemCollectionMetrics>>>,
+    /// Per-action `(table, image size)` from this call, kept so a same-token
+    /// replay can charge against the images the write was sized on rather than
+    /// against the request payload, which carries no item for a `Delete` or a
+    /// `ConditionCheck`. Never serialised, so the wire shape is unaffected.
+    #[serde(skip)]
+    pub(crate) replay_sizes: Vec<(String, usize)>,
 }
 
 pub async fn execute<S: StorageBackend>(
@@ -156,84 +163,132 @@ pub async fn execute<S: StorageBackend>(
     }
 
     // All actions run inside one SQLite transaction (all-or-nothing).
-    helpers::with_write_transaction(storage, execute_within_transaction(storage, items)).await?;
+    let capacity =
+        helpers::with_write_transaction(storage, execute_within_transaction(storage, items))
+            .await?;
 
-    // Build consumed capacity per table
-    let consumed_capacity = crate::types::build_transactional_capacity(
-        &transact_write_table_units(items),
-        &request.return_consumed_capacity,
-        crate::types::transactional_write_capacity,
-    );
     Ok(TransactWriteItemsResponse {
-        consumed_capacity,
+        consumed_capacity: build_write_capacity(&capacity, &request.return_consumed_capacity),
         item_collection_metrics: None,
+        replay_sizes: replay_sizes(&capacity),
     })
 }
 
-/// Per-table transactional write units for a set of actions. AWS charges 2 WCU
-/// per item for a transactional write: each item is rounded up to whole write
-/// units first, then doubled by the transactional factor, then summed per table
-/// (aggregating sizes before rounding would undercharge items straddling a 1KB
-/// boundary). Backs `execute`'s first-call write capacity.
-pub(crate) fn transact_write_table_units(items: &[TransactWriteItem]) -> HashMap<String, f64> {
-    let mut table_units: HashMap<String, f64> = HashMap::new();
-    for item in items {
-        let (table, size) = get_action_table_and_size(item);
-        *table_units.entry(table).or_default() +=
-            crate::types::TRANSACTIONAL_CAPACITY_FACTOR * crate::types::write_capacity_units(size);
-    }
-    table_units
+/// The image size each action was charged on, kept for a same-token replay.
+///
+/// The write is sized on the larger of the two images, and a capture shows the
+/// replay charging against that same image, so the choice is made once here
+/// rather than twice with a chance of drifting apart.
+fn replay_sizes(capacity: &[WriteCapacity]) -> Vec<(String, usize)> {
+    capacity
+        .iter()
+        .map(|record| {
+            let larger = record
+                .old_size
+                .unwrap_or(0)
+                .max(record.new_size.unwrap_or(0));
+            (record.table_name.clone(), larger)
+        })
+        .collect()
 }
 
-/// Per-table transactional read units for a set of actions. Real AWS recomputes
-/// a same-token replay as a transactional read against each item's size: 2 RCU
-/// per item, rounded at 4KB read granularity before the transactional factor,
-/// summed per table. This differs from the write magnitude above 1KB, where
-/// writes round at 1KB and reads at 4KB. Backs `replay_response`.
-fn transact_read_table_units(items: &[TransactWriteItem]) -> HashMap<String, f64> {
+/// Fold the per-action records into one `ConsumedCapacity` per table.
+///
+/// The transactional factor reaches the base table arm only. Index arms are
+/// charged at their single-write cost, which is what a capture against real
+/// DynamoDB reports: a transactional put of an indexed item costs table 2 and
+/// gsi 1, where the same put outside a transaction costs table 1 and gsi 1.
+fn build_write_capacity(
+    capacity: &[WriteCapacity],
+    mode: &Option<String>,
+) -> Option<Vec<crate::types::ConsumedCapacity>> {
+    if !matches!(mode.as_deref(), Some("TOTAL") | Some("INDEXES")) {
+        return None;
+    }
+
+    let by_table = aggregate_by_table(capacity, crate::types::TRANSACTIONAL_CAPACITY_FACTOR);
+    // Sorted so a multi-table transaction reports its tables in a stable order.
+    // Aggregation is a HashMap, which would otherwise hand back a different
+    // order on every call and leave callers indexing into a shuffled array.
+    let mut tables: Vec<&String> = by_table.keys().collect();
+    tables.sort();
+
+    Some(
+        tables
+            .into_iter()
+            .filter_map(|table| {
+                let units = by_table.get(table)?;
+                crate::types::transactional_write_capacity_with_indexes(
+                    table,
+                    units.table_units,
+                    &units.gsi_units,
+                    &units.lsi_units,
+                    mode,
+                )
+            })
+            .collect(),
+    )
+}
+
+/// Per-table transactional read units for a same-token replay. AWS recomputes
+/// the replay as a transactional read against the image each action was sized
+/// on: 2 RCU per action, rounded at 4KB read granularity before the
+/// transactional factor, summed per table. This differs from the first call's
+/// write magnitude above 1KB, where writes round at 1KB and reads at 4KB.
+///
+/// The sizes come from the first call rather than from the request, because the
+/// request carries no item for a `Delete` or a `ConditionCheck`. Sizing those on
+/// their keys reports 2 against a 9KB item where AWS reports 6.
+fn transact_read_table_units(sizes: &[(String, usize)]) -> HashMap<String, f64> {
     let mut table_units: HashMap<String, f64> = HashMap::new();
-    for item in items {
-        let (table, size) = get_action_table_and_size(item);
-        *table_units.entry(table).or_default() +=
-            crate::types::TRANSACTIONAL_CAPACITY_FACTOR * crate::types::read_capacity_units(size);
+    for (table, size) in sizes {
+        *table_units.entry(table.clone()).or_default() +=
+            crate::types::TRANSACTIONAL_CAPACITY_FACTOR * crate::types::read_capacity_units(*size);
     }
     table_units
 }
 
 /// Build the response for a same-token idempotent replay. The items are
 /// identical to the first call (the idempotency hash matched), so capacity is
-/// recomputed as a transactional READ against the item sizes rather than
-/// re-serving the first call's write numbers, honouring the replay request's
-/// own `ReturnConsumedCapacity` mode (the original call's mode does not carry
-/// over). The read cost is computed at 4KB read granularity, which diverges
-/// from the first-call write magnitude above 1KB. `cached_metrics` carries the
-/// item collection metrics from the cached first-call response.
+/// recomputed as a transactional READ against the image sizes the first call
+/// recorded rather than re-serving its write numbers, honouring the replay
+/// request's own `ReturnConsumedCapacity` mode (the original call's mode does
+/// not carry over). The read cost is computed at 4KB read granularity, which
+/// diverges from the first-call write magnitude above 1KB. `cached` is the
+/// stored first-call response, which carries both the image sizes and the item
+/// collection metrics.
 pub(crate) fn replay_response(
-    items: &[TransactWriteItem],
+    cached: &TransactWriteItemsResponse,
     mode: &Option<String>,
-    cached_metrics: Option<HashMap<String, Vec<crate::types::ItemCollectionMetrics>>>,
 ) -> TransactWriteItemsResponse {
     TransactWriteItemsResponse {
         consumed_capacity: crate::types::build_transactional_capacity(
-            &transact_read_table_units(items),
+            &transact_read_table_units(&cached.replay_sizes),
             mode,
             crate::types::transactional_read_capacity,
         ),
-        item_collection_metrics: cached_metrics,
+        item_collection_metrics: cached.item_collection_metrics.clone(),
+        replay_sizes: cached.replay_sizes.clone(),
     }
 }
 
+/// Run every action, returning what each contributed to `ConsumedCapacity`.
+///
+/// The records are only meaningful when the whole transaction commits; a
+/// cancellation returns an error and reports no capacity at all.
 async fn execute_within_transaction<S: StorageBackend>(
     storage: &S,
     items: &[TransactWriteItem],
-) -> Result<()> {
+) -> Result<Vec<WriteCapacity>> {
     let mut cancellation_reasons: Vec<CancellationReason> = Vec::with_capacity(items.len());
+    let mut capacity: Vec<WriteCapacity> = Vec::with_capacity(items.len());
     let mut has_failure = false;
 
     for item in items {
         let reason = execute_single_action(storage, item).await;
         match reason {
-            Ok(()) => {
+            Ok(action_capacity) => {
+                capacity.push(action_capacity);
                 cancellation_reasons.push(CancellationReason {
                     code: "None".to_string(),
                     message: None,
@@ -280,13 +335,13 @@ async fn execute_within_transaction<S: StorageBackend>(
         ));
     }
 
-    Ok(())
+    Ok(capacity)
 }
 
 async fn execute_single_action<S: StorageBackend>(
     storage: &S,
     item: &TransactWriteItem,
-) -> Result<()> {
+) -> Result<WriteCapacity> {
     if let Some(ref put) = item.put {
         execute_put(storage, put).await
     } else if let Some(ref update) = item.update {
@@ -315,7 +370,7 @@ fn validate_eav_nesting(values: &Option<HashMap<String, AttributeValue>>) -> Res
     Ok(())
 }
 
-async fn execute_put<S: StorageBackend>(storage: &S, put: &TransactPut) -> Result<()> {
+async fn execute_put<S: StorageBackend>(storage: &S, put: &TransactPut) -> Result<WriteCapacity> {
     crate::validation::validate_table_name(&put.table_name)?;
     let meta = helpers::require_table_for_item_op(storage, &put.table_name).await?;
     let key_schema = helpers::parse_key_schema(&meta)?;
@@ -392,23 +447,30 @@ async fn execute_put<S: StorageBackend>(storage: &S, put: &TransactPut) -> Resul
         sk_attr: key_schema.sort_key.as_deref(),
     };
 
-    // Transactional capacity is computed per table from the item sizes, so the
-    // per-index units are discarded here.
-    let _ =
+    let gsi_units =
         super::gsi::maintain_gsis_after_write(storage, &meta, &target, old_item.as_ref(), &item)
             .await?;
 
-    let _ =
+    let lsi_units =
         super::lsi::maintain_lsis_after_write(storage, &meta, &target, old_item.as_ref(), &item)
             .await?;
 
     // Record stream event
     crate::streams::record_stream_event(storage, &meta, old_item.as_ref(), Some(&item)).await?;
 
-    Ok(())
+    Ok(WriteCapacity::new(
+        &put.table_name,
+        old_item.as_ref().map(types::item_size),
+        Some(size),
+        gsi_units,
+        lsi_units,
+    ))
 }
 
-async fn execute_update<S: StorageBackend>(storage: &S, update: &TransactUpdate) -> Result<()> {
+async fn execute_update<S: StorageBackend>(
+    storage: &S,
+    update: &TransactUpdate,
+) -> Result<WriteCapacity> {
     crate::validation::validate_table_name(&update.table_name)?;
     let meta = helpers::require_table_for_item_op(storage, &update.table_name).await?;
     let key_schema = helpers::parse_key_schema(&meta)?;
@@ -511,23 +573,34 @@ async fn execute_update<S: StorageBackend>(storage: &S, update: &TransactUpdate)
         sk_attr: key_schema.sort_key.as_deref(),
     };
 
-    // Transactional capacity is computed per table from the item sizes, so the
-    // per-index units are discarded here.
-    let _ =
+    let gsi_units =
         super::gsi::maintain_gsis_after_write(storage, &meta, &target, old_item.as_ref(), &item)
             .await?;
 
-    let _ =
+    let lsi_units =
         super::lsi::maintain_lsis_after_write(storage, &meta, &target, old_item.as_ref(), &item)
             .await?;
 
     // Record stream event
     crate::streams::record_stream_event(storage, &meta, old_item.as_ref(), Some(&item)).await?;
 
-    Ok(())
+    // `old_item` comes from the stored JSON rather than from the assembled item,
+    // which matters on an upsert: the assembled item carries the key attributes
+    // this function injected, and charging against that would read as a key move
+    // rather than an insert.
+    Ok(WriteCapacity::new(
+        &update.table_name,
+        old_item.as_ref().map(types::item_size),
+        Some(size),
+        gsi_units,
+        lsi_units,
+    ))
 }
 
-async fn execute_delete<S: StorageBackend>(storage: &S, delete: &TransactDelete) -> Result<()> {
+async fn execute_delete<S: StorageBackend>(
+    storage: &S,
+    delete: &TransactDelete,
+) -> Result<WriteCapacity> {
     crate::validation::validate_table_name(&delete.table_name)?;
     let meta = helpers::require_table_for_item_op(storage, &delete.table_name).await?;
     let key_schema = helpers::parse_key_schema(&meta)?;
@@ -582,11 +655,9 @@ async fn execute_delete<S: StorageBackend>(storage: &S, delete: &TransactDelete)
         sk_attr: key_schema.sort_key.as_deref(),
     };
 
-    // Transactional capacity is computed per table from the item sizes, so the
-    // per-index units are discarded here.
-    let _ =
+    let gsi_units =
         super::gsi::maintain_gsis_after_delete(storage, &meta, &target, old_item.as_ref()).await?;
-    let _ =
+    let lsi_units =
         super::lsi::maintain_lsis_after_delete(storage, &meta, &target, old_item.as_ref()).await?;
 
     // Record stream event
@@ -594,13 +665,19 @@ async fn execute_delete<S: StorageBackend>(storage: &S, delete: &TransactDelete)
         crate::streams::record_stream_event(storage, &meta, old_item.as_ref(), None).await?;
     }
 
-    Ok(())
+    Ok(WriteCapacity::from_items(
+        &delete.table_name,
+        old_item.as_ref(),
+        None,
+        gsi_units,
+        lsi_units,
+    ))
 }
 
 async fn execute_condition_check<S: StorageBackend>(
     storage: &S,
     check: &TransactConditionCheck,
-) -> Result<()> {
+) -> Result<WriteCapacity> {
     crate::validation::validate_table_name(&check.table_name)?;
     let meta = helpers::require_table_for_item_op(storage, &check.table_name).await?;
     let key_schema = helpers::parse_key_schema(&meta)?;
@@ -643,7 +720,12 @@ async fn execute_condition_check<S: StorageBackend>(
     )?;
 
     tracker.check_unused()?;
-    Ok(())
+    // A check writes nothing and touches no index, and is still charged against
+    // the image it read.
+    Ok(WriteCapacity::condition_check(
+        &check.table_name,
+        existing_json.is_some().then_some(&existing_item),
+    ))
 }
 
 fn check_condition_tracked(

--- a/src/actions/transact_write_items.rs
+++ b/src/actions/transact_write_items.rs
@@ -1,5 +1,7 @@
 use crate::actions::helpers;
-use crate::actions::index_capacity::{WriteCapacity, aggregate_by_table};
+use crate::actions::index_capacity::{
+    WriteCapacity, aggregate_by_table, per_table_capacity, transactional_read_units,
+};
 use crate::errors::{CancellationReason, DynoxideError, Result};
 use crate::storage_backend::StorageBackend;
 use crate::types::{self, AttributeValue, Item};
@@ -222,50 +224,12 @@ fn build_write_capacity(
     capacity: &[WriteCapacity],
     mode: &Option<String>,
 ) -> Option<Vec<crate::types::ConsumedCapacity>> {
-    if !matches!(mode.as_deref(), Some("TOTAL") | Some("INDEXES")) {
-        return None;
-    }
-
     let by_table = aggregate_by_table(capacity, crate::types::TRANSACTIONAL_CAPACITY_FACTOR);
-    // Sorted so a multi-table transaction reports its tables in a stable order.
-    // Aggregation is a HashMap, which would otherwise hand back a different
-    // order on every call and leave callers indexing into a shuffled array.
-    let mut tables: Vec<&String> = by_table.keys().collect();
-    tables.sort();
-
-    Some(
-        tables
-            .into_iter()
-            .filter_map(|table| {
-                let units = by_table.get(table)?;
-                crate::types::transactional_write_capacity_with_indexes(
-                    table,
-                    units.table_units,
-                    &units.gsi_units,
-                    &units.lsi_units,
-                    mode,
-                )
-            })
-            .collect(),
+    per_table_capacity(
+        &by_table,
+        mode,
+        crate::types::transactional_write_capacity_with_indexes,
     )
-}
-
-/// Per-table transactional read units for a same-token replay. AWS recomputes
-/// the replay as a transactional read against the image each action was sized
-/// on: 2 RCU per action, rounded at 4KB read granularity before the
-/// transactional factor, summed per table. This differs from the first call's
-/// write magnitude above 1KB, where writes round at 1KB and reads at 4KB.
-///
-/// The sizes come from the first call rather than from the request, because the
-/// request carries no item for a `Delete` or a `ConditionCheck`. Sizing those on
-/// their keys reports 2 against a 9KB item where AWS reports 6.
-fn transact_read_table_units(sizes: &[(String, usize)]) -> HashMap<String, f64> {
-    let mut table_units: HashMap<String, f64> = HashMap::new();
-    for (table, size) in sizes {
-        *table_units.entry(table.clone()).or_default() +=
-            crate::types::TRANSACTIONAL_CAPACITY_FACTOR * crate::types::read_capacity_units(*size);
-    }
-    table_units
 }
 
 /// Build the response for a same-token idempotent replay. The items are
@@ -280,7 +244,7 @@ pub(crate) fn replay_response(cached: &CachedWrite, mode: &Option<String>) -> Ca
     CachedWrite {
         response: TransactWriteItemsResponse {
             consumed_capacity: crate::types::build_transactional_capacity(
-                &transact_read_table_units(&cached.replay_sizes),
+                &transactional_read_units(&cached.replay_sizes),
                 mode,
                 crate::types::transactional_read_capacity,
             ),

--- a/src/actions/transact_write_items.rs
+++ b/src/actions/transact_write_items.rs
@@ -224,6 +224,13 @@ fn build_write_capacity(
     capacity: &[WriteCapacity],
     mode: &Option<String>,
 ) -> Option<Vec<crate::types::ConsumedCapacity>> {
+    // Checked before aggregating, not just inside the shared builder. Most
+    // calls ask for no capacity at all, and aggregation walks every action and
+    // allocates a map per table before the builder could discard it.
+    if !matches!(mode.as_deref(), Some("TOTAL") | Some("INDEXES")) {
+        return None;
+    }
+
     let by_table = aggregate_by_table(capacity, crate::types::TRANSACTIONAL_CAPACITY_FACTOR);
     per_table_capacity(
         &by_table,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,17 +143,17 @@ type TokenSlot<T> = (Instant, u64, Option<T>);
 /// Idempotency cache keyed by `ClientRequestToken`.
 type TokenCache<T> = HashMap<String, TokenSlot<T>>;
 
-/// Cached `TransactWriteItems` responses.
-type TransactWriteTokenCache =
-    TokenCache<actions::transact_write_items::TransactWriteItemsResponse>;
+/// Cached `TransactWriteItems` responses, alongside the image sizes a replay is
+/// billed against. Those sizes are cache bookkeeping, so they ride here rather
+/// than on the response type a caller sees.
+type TransactWriteTokenCache = TokenCache<actions::transact_write_items::CachedWrite>;
 
 /// Cached `ExecuteTransaction` responses. Separate from
 /// [`TransactWriteTokenCache`] because the response type differs and
 /// `ClientRequestToken` idempotency is scoped per API operation in AWS: a token
 /// reused across `TransactWriteItems` and `ExecuteTransaction` executes once in
 /// each, so the two caches are independent by design.
-type ExecuteTransactionTokenCache =
-    TokenCache<actions::execute_transaction::ExecuteTransactionResponse>;
+type ExecuteTransactionTokenCache = TokenCache<actions::execute_transaction::CachedTransaction>;
 
 /// The transactional idempotency caches one engine instance owns.
 ///
@@ -871,7 +871,10 @@ impl Database<RusqliteBackend> {
             &request.transact_items,
             || {
                 self.with_storage(|s| {
-                    pollster::block_on(actions::transact_write_items::execute(s, request.clone()))
+                    pollster::block_on(actions::transact_write_items::execute_cached(
+                        s,
+                        request.clone(),
+                    ))
                 })
             },
             |cached| {
@@ -885,6 +888,7 @@ impl Database<RusqliteBackend> {
                 )
             },
         )
+        .map(|cached| cached.response)
     }
 
     /// Execute a transactional read (up to 100 gets).
@@ -988,7 +992,10 @@ impl Database<RusqliteBackend> {
             &request.transact_statements,
             || {
                 self.with_storage(|s| {
-                    pollster::block_on(actions::execute_transaction::execute(s, request.clone()))
+                    pollster::block_on(actions::execute_transaction::execute_cached(
+                        s,
+                        request.clone(),
+                    ))
                 })
             },
             |cached| {
@@ -1000,6 +1007,7 @@ impl Database<RusqliteBackend> {
                 )
             },
         )
+        .map(|cached| cached.response)
     }
 
     /// Execute a batch of PartiQL statements.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -876,13 +876,12 @@ impl Database<RusqliteBackend> {
             },
             |cached| {
                 // The replay recomputes a transactional read cost against the
-                // item sizes (4KB read granularity, diverging from the first
-                // call's 1KB-granular write above 1KB) and carries over the
-                // cached item collection metrics.
+                // image sizes the first call recorded (4KB read granularity,
+                // diverging from that call's 1KB-granular write above 1KB) and
+                // carries over its item collection metrics.
                 actions::transact_write_items::replay_response(
-                    &request.transact_items,
+                    cached,
                     &request.return_consumed_capacity,
-                    cached.item_collection_metrics.clone(),
                 )
             },
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -992,12 +992,11 @@ impl Database<RusqliteBackend> {
                 })
             },
             |cached| {
-                // The replay reports transactional read capacity and carries
-                // over the cached first-call responses.
+                // The replay reports transactional read capacity against the
+                // sizes the first call recorded, and carries over its responses.
                 actions::execute_transaction::replay_response(
-                    &request.transact_statements,
+                    cached,
                     &request.return_consumed_capacity,
-                    cached.responses.clone(),
                 )
             },
         )

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1680,8 +1680,10 @@ impl McpServer {
             }
         }
 
-        let request =
-            crate::actions::batch_execute_statement::BatchExecuteStatementRequest { statements };
+        let request = crate::actions::batch_execute_statement::BatchExecuteStatementRequest {
+            statements,
+            ..Default::default()
+        };
         match self.db.batch_execute_statement(request) {
             Ok(resp) => json_result(&resp),
             Err(err) => Ok(to_tool_error(err)),

--- a/src/partiql/executor.rs
+++ b/src/partiql/executor.rs
@@ -2,6 +2,7 @@
 //!
 //! Maps parsed PartiQL statements to internal DynamoDB operations.
 
+use crate::actions::index_capacity::WriteCapacity;
 use crate::errors::{DynoxideError, Result};
 use crate::expressions::key_condition::{ResolvedSortKeyCondition, sk_conditions_to_sql};
 use crate::partiql::parser::{
@@ -28,9 +29,14 @@ pub async fn execute<S: StorageBackend>(
 }
 
 /// Like [`execute`], but also returns the total item byte size the statement
-/// touched, for `ConsumedCapacity` accounting. SELECT reports the summed size of
-/// the rows returned; INSERT/UPDATE/DELETE report the affected item's size (0
-/// when the statement was a no-op, e.g. a missing DELETE target).
+/// touched. SELECT reports the summed size of the rows returned;
+/// INSERT/UPDATE/DELETE report the affected item's size (0 when the statement
+/// was a no-op, e.g. a missing DELETE target).
+///
+/// This size alone no longer describes what the statement costs. A write is
+/// charged on the larger of the images either side of it plus a per-index arm,
+/// which [`execute_page`] carries on `StatementPage::capacity`. Prefer that for
+/// capacity; this remains for callers that only want the byte count.
 pub async fn execute_measured<S: StorageBackend>(
     storage: &S,
     stmt: &Statement,
@@ -53,6 +59,10 @@ pub struct StatementPage {
     pub items: Option<Vec<Item>>,
     /// Total item bytes touched, for `ConsumedCapacity`.
     pub size: usize,
+    /// What a write statement contributed to `ConsumedCapacity`: the images
+    /// either side and the per-index units. `None` for a `SELECT`, which is
+    /// charged from `size` at read granularity instead.
+    pub capacity: Option<WriteCapacity>,
     /// Where to resume, when more rows matched than this page returned.
     pub next_token: Option<String>,
 }
@@ -97,6 +107,7 @@ pub async fn execute_page<S: StorageBackend>(
             Ok(StatementPage {
                 items,
                 size,
+                capacity: None,
                 next_token: token,
             })
         }
@@ -105,11 +116,14 @@ pub async fn execute_page<S: StorageBackend>(
             item,
             if_not_exists,
         } => {
-            let size =
+            let capacity =
                 execute_insert(storage, table_name, item, parameters, *if_not_exists).await?;
             Ok(StatementPage {
                 items: None,
-                size,
+                // An insert is measured on the item it wrote, which is 0 when an
+                // `if_not_exists` duplicate made it a no-op.
+                size: capacity.new_size.unwrap_or(0),
+                capacity: Some(capacity),
                 ..Default::default()
             })
         }
@@ -120,7 +134,7 @@ pub async fn execute_page<S: StorageBackend>(
             where_clause,
             returning,
         } => {
-            let (projection, size) = execute_update(
+            let (projection, capacity) = execute_update(
                 storage,
                 table_name,
                 set_clauses,
@@ -143,7 +157,9 @@ pub async fn execute_page<S: StorageBackend>(
             });
             Ok(StatementPage {
                 items,
-                size,
+                // An update is measured on the item it left behind.
+                size: capacity.new_size.unwrap_or(0),
+                capacity: Some(capacity),
                 ..Default::default()
             })
         }
@@ -163,7 +179,7 @@ pub async fn execute_page<S: StorageBackend>(
                     )));
                 }
             }
-            let (old_item, size) =
+            let (old_item, capacity) =
                 execute_delete(storage, table_name, where_clause.as_ref(), parameters).await?;
             // RETURNING ALL OLD * always surfaces an Items array: the deleted
             // item on a hit, an empty array on a miss (a no-op success). This
@@ -176,7 +192,10 @@ pub async fn execute_page<S: StorageBackend>(
             };
             Ok(StatementPage {
                 items,
-                size,
+                // A delete is measured on the item it removed, which is 0 when
+                // the target was missing.
+                size: capacity.old_size.unwrap_or(0),
+                capacity: Some(capacity),
                 ..Default::default()
             })
         }
@@ -501,15 +520,72 @@ fn find_pk_condition<'a>(
     }
 }
 
-/// Returns the inserted item's size in bytes (0 when an `if_not_exists`
-/// duplicate makes the insert a no-op), for `ConsumedCapacity` accounting.
+/// The `(table, pk, sk)` a statement targets, for duplicate detection across a
+/// batch. `None` when the statement does not resolve to a single item, which
+/// covers a `SELECT` spanning a partition and anything whose key cannot be read
+/// off the statement.
+///
+/// A `SELECT` naming every key attribute does resolve, and AWS rejects a batch
+/// carrying two of them against one item just as it does for writes.
+///
+/// The result is a tuple rather than a joined string. Joining on a delimiter is
+/// not injective once a key value contains it: `pk='a#b', sk='c'` and
+/// `pk='a', sk='b#c'` render alike, and AWS accepts that pair as two distinct
+/// items.
+///
+/// Errors are swallowed deliberately. A statement whose key cannot be resolved,
+/// or whose table cannot be read, is left to fail on its own terms during
+/// execution rather than surfacing here as a duplicate-detection failure.
+pub async fn statement_target<S: StorageBackend>(
+    storage: &S,
+    stmt: &Statement,
+    parameters: &[AttributeValue],
+) -> Option<(String, String, String)> {
+    let table_name = crate::partiql::parser::table_name(stmt)?;
+    let meta = require_table(storage, table_name).await.ok()?;
+    let key_schema = crate::actions::helpers::parse_key_schema(&meta).ok()?;
+
+    let key_of = |source: &dyn Fn(&str) -> Option<AttributeValue>| -> Option<(String, String)> {
+        let pk = source(&key_schema.partition_key)?.to_key_string()?;
+        let sk = match key_schema.sort_key {
+            Some(ref name) => source(name)?.to_key_string()?,
+            None => String::new(),
+        };
+        Some((pk, sk))
+    };
+
+    let from_where = |where_clause: &Option<WhereClause>| -> Option<(String, String)> {
+        let wc = where_clause.as_ref()?;
+        key_of(&|name: &str| {
+            find_comparison_in_groups(&wc.groups, name)
+                .and_then(|cond| resolve_value(&cond.value, parameters).ok())
+        })
+    };
+
+    let (pk, sk) = match stmt {
+        Statement::Insert { item, .. } => key_of(&|name: &str| {
+            item.get(name)
+                .and_then(|v| resolve_value(v, parameters).ok())
+        })?,
+        Statement::Update { where_clause, .. }
+        | Statement::Delete { where_clause, .. }
+        // A SELECT resolves only when its WHERE pins every key attribute; one
+        // spanning a partition yields nothing and takes no part in the check.
+        | Statement::Select { where_clause, .. } => from_where(where_clause)?,
+    };
+
+    Some((table_name.to_string(), pk, sk))
+}
+
+/// Returns what the insert consumed. An `if_not_exists` duplicate makes it a
+/// no-op, which carries no images and no index units.
 async fn execute_insert<S: StorageBackend>(
     storage: &S,
     table_name: &str,
     item_template: &HashMap<String, PartiqlValue>,
     parameters: &[AttributeValue],
     if_not_exists: bool,
-) -> Result<usize> {
+) -> Result<WriteCapacity> {
     // Resolve any parameter placeholders in the item
     let mut item = HashMap::new();
     for (k, v) in item_template {
@@ -542,8 +618,16 @@ async fn execute_insert<S: StorageBackend>(
     let existing = storage.get_item(table_name, &pk, &sk).await?;
     if existing.is_some() {
         if if_not_exists {
-            // Silently succeed — no-op
-            return Ok(0);
+            // Silently succeed, writing nothing and touching no index. The
+            // table still has to be named, or the no-op lands in a bucket
+            // keyed on the empty string and surfaces as a nameless entry.
+            return Ok(WriteCapacity::new(
+                table_name,
+                None,
+                None,
+                HashMap::new(),
+                HashMap::new(),
+            ));
         }
         return Err(DynoxideError::DuplicateItemException(
             "Duplicate primary key exists in table".to_string(),
@@ -572,9 +656,7 @@ async fn execute_insert<S: StorageBackend>(
         sk_attr: key_schema.sort_key.as_deref(),
     };
 
-    // PartiQL reports capacity from the item size alone, so the per-index units
-    // are discarded here.
-    let _ = crate::actions::gsi::maintain_gsis_after_write(
+    let gsi_units = crate::actions::gsi::maintain_gsis_after_write(
         storage,
         &meta,
         &target,
@@ -583,7 +665,7 @@ async fn execute_insert<S: StorageBackend>(
     )
     .await?;
 
-    let _ = crate::actions::lsi::maintain_lsis_after_write(
+    let lsi_units = crate::actions::lsi::maintain_lsis_after_write(
         storage,
         &meta,
         &target,
@@ -595,13 +677,20 @@ async fn execute_insert<S: StorageBackend>(
     // Stream record
     crate::streams::record_stream_event(storage, &meta, old_item.as_ref(), Some(&item)).await?;
 
-    Ok(item_size)
+    // An INSERT rejects an existing key above, so there is never an old image
+    // here; `old_item` only ever comes back empty.
+    Ok(WriteCapacity::new(
+        table_name,
+        old_item.as_ref().map(crate::types::item_size),
+        Some(item_size),
+        gsi_units,
+        lsi_units,
+    ))
 }
 
 /// Applies an UPDATE and returns the `RETURNING` projection (or `None` when the
-/// statement carried no `RETURNING` clause) and the updated item's new size in
-/// bytes (0 when the update resolves to an empty item and is skipped), for
-/// `ConsumedCapacity` accounting.
+/// statement carried no `RETURNING` clause) and what the write consumed. An
+/// update that resolves to an empty item is skipped and carries no images.
 async fn execute_update<S: StorageBackend>(
     storage: &S,
     table_name: &str,
@@ -610,7 +699,7 @@ async fn execute_update<S: StorageBackend>(
     where_clause: Option<&WhereClause>,
     parameters: &[AttributeValue],
     returning: Option<ReturningVariant>,
-) -> Result<(Option<Item>, usize)> {
+) -> Result<(Option<Item>, WriteCapacity)> {
     let meta = require_table(storage, table_name).await?;
     let key_schema = crate::actions::helpers::parse_key_schema(&meta)?;
 
@@ -692,7 +781,10 @@ async fn execute_update<S: StorageBackend>(
 
     // Ensure keys are present
     if item.is_empty() {
-        return Ok((None, 0));
+        return Ok((
+            None,
+            WriteCapacity::new(table_name, None, None, HashMap::new(), HashMap::new()),
+        ));
     }
 
     // Validate attribute values after SET clauses applied
@@ -733,13 +825,13 @@ async fn execute_update<S: StorageBackend>(
         sk_attr: key_schema.sort_key.as_deref(),
     };
 
-    // PartiQL reports capacity from the item size alone, so the per-index units
-    // are discarded here.
-    let _ = crate::actions::gsi::maintain_gsis_after_write(storage, &meta, &target, old_ref, &item)
-        .await?;
+    let gsi_units =
+        crate::actions::gsi::maintain_gsis_after_write(storage, &meta, &target, old_ref, &item)
+            .await?;
 
-    let _ = crate::actions::lsi::maintain_lsis_after_write(storage, &meta, &target, old_ref, &item)
-        .await?;
+    let lsi_units =
+        crate::actions::lsi::maintain_lsis_after_write(storage, &meta, &target, old_ref, &item)
+            .await?;
 
     // Stream record
     crate::streams::record_stream_event(storage, &meta, old_ref, Some(&item)).await?;
@@ -757,7 +849,16 @@ async fn execute_update<S: StorageBackend>(
         project_returning(variant, &old_item, &item, &modified)
     });
 
-    Ok((projection, item_size))
+    Ok((
+        projection,
+        WriteCapacity::new(
+            table_name,
+            old_ref.map(crate::types::item_size),
+            Some(item_size),
+            gsi_units,
+            lsi_units,
+        ),
+    ))
 }
 
 /// Build the `RETURNING` projection for an UPDATE from the item's before/after
@@ -878,7 +979,7 @@ async fn execute_delete<S: StorageBackend>(
     table_name: &str,
     where_clause: Option<&WhereClause>,
     parameters: &[AttributeValue],
-) -> Result<(Option<Item>, usize)> {
+) -> Result<(Option<Item>, WriteCapacity)> {
     let meta = require_table(storage, table_name).await?;
     let key_schema = crate::actions::helpers::parse_key_schema(&meta)?;
 
@@ -960,13 +1061,11 @@ async fn execute_delete<S: StorageBackend>(
         sk_attr: key_schema.sort_key.as_deref(),
     };
 
-    // PartiQL reports capacity from the item size alone, so the per-index units
-    // are discarded here.
-    let _ =
+    let gsi_units =
         crate::actions::gsi::maintain_gsis_after_delete(storage, &meta, &target, old_item.as_ref())
             .await?;
 
-    let _ =
+    let lsi_units =
         crate::actions::lsi::maintain_lsis_after_delete(storage, &meta, &target, old_item.as_ref())
             .await?;
 
@@ -975,10 +1074,11 @@ async fn execute_delete<S: StorageBackend>(
         crate::streams::record_stream_event(storage, &meta, old_item.as_ref(), None).await?;
     }
 
-    // A delete is charged for the size of the item it removed; a no-op delete
-    // (missing target) reports 0.
-    let deleted_size = old_item.as_ref().map(crate::types::item_size).unwrap_or(0);
-    Ok((old_item, deleted_size))
+    // A delete is charged on the item it removed, so a no-op delete against a
+    // missing target carries no image and falls back to the one-unit minimum.
+    let capacity =
+        WriteCapacity::from_items(table_name, old_item.as_ref(), None, gsi_units, lsi_units);
+    Ok((old_item, capacity))
 }
 
 // ---------------------------------------------------------------------------

--- a/src/types.rs
+++ b/src/types.rs
@@ -1010,16 +1010,23 @@ pub fn build_transactional_capacity(
     mode: &Option<String>,
     builder: fn(&str, f64, &Option<String>) -> Option<ConsumedCapacity>,
 ) -> Option<Vec<ConsumedCapacity>> {
-    if matches!(mode.as_deref(), Some("TOTAL") | Some("INDEXES")) {
-        Some(
-            table_units
-                .iter()
-                .filter_map(|(table, &units)| builder(table, units, mode))
-                .collect(),
-        )
-    } else {
-        None
+    if !matches!(mode.as_deref(), Some("TOTAL") | Some("INDEXES")) {
+        return None;
     }
+
+    // Sorted by table name, matching the write path. Iterating the map handed
+    // back a different order per process, so a two-table read set or replay
+    // could report its tables either way round while the write half of the same
+    // response family was stable.
+    let mut tables: Vec<&String> = table_units.keys().collect();
+    tables.sort();
+
+    Some(
+        tables
+            .into_iter()
+            .filter_map(|table| builder(table, *table_units.get(table)?, mode))
+            .collect(),
+    )
 }
 
 /// Build a `ConsumedCapacity` for one table in a transactional write, with the

--- a/src/types.rs
+++ b/src/types.rs
@@ -816,6 +816,18 @@ pub fn table_write_capacity_units(old_size: Option<usize>, new_size: Option<usiz
     }
 }
 
+/// Read capacity units one write's images cost when charged as a read.
+///
+/// A same-token transactional replay is billed as a read against the image the
+/// original write was sized on, which is the larger of the before and after
+/// images, but rounded at 4KB rather than 1KB. Captured in eu-west-2: a replayed
+/// put that shrank a 9KB item to nothing reports 6, and so does the replay of
+/// the write that grew it, so neither side alone explains the figure.
+pub fn table_read_capacity_units(old_size: Option<usize>, new_size: Option<usize>) -> f64 {
+    let larger = old_size.unwrap_or(0).max(new_size.unwrap_or(0));
+    read_capacity_units(larger)
+}
+
 /// Calculate read capacity units assuming strongly consistent reads
 /// (1 RCU per 4KB, rounded up). Used when ConsistentRead is true or
 /// when the read type is not specified.
@@ -887,55 +899,71 @@ pub fn consumed_capacity_with_secondary_indexes(
     lsi_units: &HashMap<String, f64>,
     mode: &Option<String>,
 ) -> Option<ConsumedCapacity> {
-    let units_to_map = |units: &HashMap<String, f64>| -> Option<HashMap<String, CapacityDetail>> {
-        if units.is_empty() {
-            None
-        } else {
-            Some(
-                units
-                    .iter()
-                    .map(|(name, &u)| {
-                        (
-                            name.clone(),
-                            CapacityDetail {
-                                capacity_units: u,
-                                ..Default::default()
-                            },
-                        )
-                    })
-                    .collect(),
-            )
+    secondary_index_capacity(
+        table_name,
+        table_units,
+        gsi_units,
+        lsi_units,
+        mode,
+        CapacityAxis::None,
+    )
+}
+
+/// Whether a response mirrors its units into a named axis alongside
+/// `CapacityUnits`.
+///
+/// Single-item and PartiQL responses report `CapacityUnits` alone at every
+/// level. Transactional responses mirror the units into `WriteCapacityUnits`
+/// at every level, including each index arm. Both shapes are captured against
+/// real DynamoDB.
+#[derive(Clone, Copy, PartialEq)]
+enum CapacityAxis {
+    None,
+    Write,
+}
+
+impl CapacityAxis {
+    /// The `WriteCapacityUnits` value for a detail carrying `units`.
+    fn write_units(self, units: f64) -> Option<f64> {
+        match self {
+            Self::None => None,
+            Self::Write => Some(units),
         }
-    };
+    }
+}
+
+/// Shared body for the per-index capacity builders. `table_units` carries the
+/// transactional factor already, when one applies; the index maps never do.
+fn secondary_index_capacity(
+    table_name: &str,
+    table_units: f64,
+    gsi_units: &HashMap<String, f64>,
+    lsi_units: &HashMap<String, f64>,
+    mode: &Option<String>,
+    axis: CapacityAxis,
+) -> Option<ConsumedCapacity> {
+    let total = table_units + gsi_units.values().sum::<f64>() + lsi_units.values().sum::<f64>();
 
     match mode.as_deref().unwrap_or("NONE") {
-        "INDEXES" => {
-            let gsi_total: f64 = gsi_units.values().sum();
-            let lsi_total: f64 = lsi_units.values().sum();
-            Some(ConsumedCapacity {
-                table_name: table_name.to_string(),
-                capacity_units: table_units + gsi_total + lsi_total,
-                table: Some(CapacityDetail {
-                    capacity_units: table_units,
-                    ..Default::default()
-                }),
-                global_secondary_indexes: units_to_map(gsi_units),
-                local_secondary_indexes: units_to_map(lsi_units),
+        "INDEXES" => Some(ConsumedCapacity {
+            table_name: table_name.to_string(),
+            capacity_units: total,
+            write_capacity_units: axis.write_units(total),
+            table: Some(CapacityDetail {
+                capacity_units: table_units,
+                write_capacity_units: axis.write_units(table_units),
                 ..Default::default()
-            })
-        }
-        "TOTAL" => {
-            let gsi_total: f64 = gsi_units.values().sum();
-            let lsi_total: f64 = lsi_units.values().sum();
-            Some(ConsumedCapacity {
-                table_name: table_name.to_string(),
-                capacity_units: table_units + gsi_total + lsi_total,
-                table: None,
-                global_secondary_indexes: None,
-                local_secondary_indexes: None,
-                ..Default::default()
-            })
-        }
+            }),
+            global_secondary_indexes: capacity_detail_map(gsi_units, axis),
+            local_secondary_indexes: capacity_detail_map(lsi_units, axis),
+            ..Default::default()
+        }),
+        "TOTAL" => Some(ConsumedCapacity {
+            table_name: table_name.to_string(),
+            capacity_units: total,
+            write_capacity_units: axis.write_units(total),
+            ..Default::default()
+        }),
         _ => None,
     }
 }
@@ -992,6 +1020,60 @@ pub fn build_transactional_capacity(
     } else {
         None
     }
+}
+
+/// Build a `ConsumedCapacity` for one table in a transactional write, with the
+/// per-index breakdown.
+///
+/// `table_units` already carries the transactional 2x factor; the index maps do
+/// not. DynamoDB applies that factor to the base table arm alone, so an index
+/// arm inside a transaction costs what the same write costs outside one.
+///
+/// `CapacityUnits` and `WriteCapacityUnits` both report the table arm plus the
+/// index arms. The `Table` detail reports the table arm on its own, and every
+/// index arm carries the write axis too, which is where this shape differs from
+/// the single-item one.
+pub fn transactional_write_capacity_with_indexes(
+    table_name: &str,
+    table_units: f64,
+    gsi_units: &HashMap<String, f64>,
+    lsi_units: &HashMap<String, f64>,
+    mode: &Option<String>,
+) -> Option<ConsumedCapacity> {
+    secondary_index_capacity(
+        table_name,
+        table_units,
+        gsi_units,
+        lsi_units,
+        mode,
+        CapacityAxis::Write,
+    )
+}
+
+/// Turn per-index units into the response's detail map, or `None` when nothing
+/// was charged so the arm is absent rather than present and empty.
+fn capacity_detail_map(
+    units: &HashMap<String, f64>,
+    axis: CapacityAxis,
+) -> Option<HashMap<String, CapacityDetail>> {
+    if units.is_empty() {
+        return None;
+    }
+    Some(
+        units
+            .iter()
+            .map(|(name, &u)| {
+                (
+                    name.clone(),
+                    CapacityDetail {
+                        capacity_units: u,
+                        write_capacity_units: axis.write_units(u),
+                        ..Default::default()
+                    },
+                )
+            })
+            .collect(),
+    )
 }
 
 /// Build a `ConsumedCapacity` for one table in a transactional write

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -303,10 +303,11 @@ async fn execute_transaction<S: StorageBackend>(
         ctx.tokens.execute_transaction(),
         token.as_deref(),
         &statements,
-        actions::execute_transaction::execute(backend, request),
+        actions::execute_transaction::execute_cached(backend, request),
         |cached| actions::execute_transaction::replay_response(cached, &capacity_mode),
     )
-    .await?;
+    .await?
+    .response;
 
     serde_json::to_string(&response).map_err(|e| DynoxideError::InternalServerError(e.to_string()))
 }

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -304,13 +304,7 @@ async fn execute_transaction<S: StorageBackend>(
         token.as_deref(),
         &statements,
         actions::execute_transaction::execute(backend, request),
-        |cached| {
-            actions::execute_transaction::replay_response(
-                &statements,
-                &capacity_mode,
-                cached.responses.clone(),
-            )
-        },
+        |cached| actions::execute_transaction::replay_response(cached, &capacity_mode),
     )
     .await?;
 

--- a/tests/execute_transaction.rs
+++ b/tests/execute_transaction.rs
@@ -144,6 +144,8 @@ fn test_mixed_select_and_insert() {
     })
     .unwrap();
 
+    // Captured against real DynamoDB: a transaction is all-read or all-write,
+    // and a mixed set is rejected before any statement runs.
     let request = ExecuteTransactionRequest {
         transact_statements: vec![
             ParameterizedStatement {
@@ -159,22 +161,57 @@ fn test_mixed_select_and_insert() {
         return_consumed_capacity: None,
     };
 
-    let resp = db.execute_transaction(request).unwrap();
-    let responses = resp.responses.unwrap();
-    assert_eq!(responses.len(), 2);
-
-    // First response should have the selected item
-    let item = responses[0]
-        .item
-        .as_ref()
-        .expect("SELECT should return an item");
-    assert_eq!(
-        item.get("name"),
-        Some(&AttributeValue::S("Alice".to_string()))
+    let err = db
+        .execute_transaction(request)
+        .expect_err("a mixed read/write transaction is rejected");
+    assert!(
+        err.to_string()
+            .contains("does not support both read and write operations in the same request"),
+        "unexpected error: {err}"
     );
 
-    // Second response (INSERT) should have no item
-    assert!(responses[1].item.is_none());
+    // Nothing ran, so the INSERT left nothing behind.
+    let items = select_all(&db, "Users");
+    assert!(
+        !items.iter().any(|i| match i.get("pk") {
+            Some(AttributeValue::S(s)) => s == "u2",
+            _ => false,
+        }),
+        "a rejected transaction must not write"
+    );
+}
+
+// -----------------------------------------------------------------------
+// Two statements against one item are rejected, matching TransactWriteItems.
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_duplicate_target_rejected() {
+    let db = Database::memory().unwrap();
+    create_test_table(&db, "Users");
+
+    let request = ExecuteTransactionRequest {
+        transact_statements: vec![
+            ParameterizedStatement {
+                statement: "INSERT INTO \"Users\" VALUE {'pk': 'dup', 'name': 'One'}".to_string(),
+                parameters: None,
+            },
+            ParameterizedStatement {
+                statement: "UPDATE \"Users\" SET name = 'Two' WHERE pk = 'dup'".to_string(),
+                parameters: None,
+            },
+        ],
+        ..Default::default()
+    };
+
+    let err = db
+        .execute_transaction(request)
+        .expect_err("two statements against one item are rejected");
+    assert!(
+        err.to_string()
+            .contains("Transaction request cannot include multiple operations on one item"),
+        "unexpected error: {err}"
+    );
 }
 
 // -----------------------------------------------------------------------
@@ -400,7 +437,9 @@ fn test_parameterised_statements() {
     })
     .unwrap();
 
-    // Use parameterised WHERE in a transaction: update u1 and select u2
+    // Parameterised WHERE clauses in a transaction, updating both items. An
+    // all-write set, since a transaction mixing reads and writes is rejected
+    // (see test_mixed_select_and_insert).
     let request = ExecuteTransactionRequest {
         transact_statements: vec![
             ParameterizedStatement {
@@ -408,7 +447,7 @@ fn test_parameterised_statements() {
                 parameters: Some(vec![AttributeValue::S("u1".to_string())]),
             },
             ParameterizedStatement {
-                statement: "SELECT * FROM \"Users\" WHERE pk = ?".to_string(),
+                statement: "UPDATE \"Users\" SET name = 'Bob V2' WHERE pk = ?".to_string(),
                 parameters: Some(vec![AttributeValue::S("u2".to_string())]),
             },
         ],
@@ -419,23 +458,23 @@ fn test_parameterised_statements() {
     let responses = resp.responses.unwrap();
     assert_eq!(responses.len(), 2);
 
-    // First response (UPDATE) has no item
-    assert!(responses[0].item.is_none());
+    // Neither UPDATE carries a RETURNING clause, so neither yields an item.
+    assert!(responses.iter().all(|r| r.item.is_none()));
 
-    // Second response (SELECT) has Bob
-    let bob = responses[1].item.as_ref().unwrap();
-    assert_eq!(bob.get("name"), Some(&AttributeValue::S("Bob".to_string())));
-
-    // Verify the update took effect
+    // Both parameters resolved to the item they named.
     let items = select_all(&db, "Users");
-    let u1 = items.iter().find(|i| match i.get("pk") {
-        Some(AttributeValue::S(s)) => s == "u1",
-        _ => false,
-    });
-    match u1.unwrap().get("name") {
-        Some(AttributeValue::S(s)) => assert_eq!(s, "Alice V2"),
-        other => panic!("Expected updated name, got {:?}", other),
-    }
+    let name_of = |pk: &str| {
+        items
+            .iter()
+            .find(|i| matches!(i.get("pk"), Some(AttributeValue::S(s)) if s == pk))
+            .and_then(|i| i.get("name"))
+            .cloned()
+    };
+    assert_eq!(
+        name_of("u1"),
+        Some(AttributeValue::S("Alice V2".to_string()))
+    );
+    assert_eq!(name_of("u2"), Some(AttributeValue::S("Bob V2".to_string())));
 }
 
 // -----------------------------------------------------------------------

--- a/tests/partiql.rs
+++ b/tests/partiql.rs
@@ -12,6 +12,14 @@ use dynoxide::types::{
 };
 use std::collections::HashMap;
 
+/// `BatchStatementRequest` is `#[non_exhaustive]`, so a test outside the crate
+/// cannot use struct-literal syntax for it. This is the supported shape.
+fn batch_stmt(statement: String) -> BatchStatementRequest {
+    let mut req = BatchStatementRequest::default();
+    req.statement = statement;
+    req
+}
+
 fn create_test_table(db: &Database, table_name: &str) {
     let request = CreateTableRequest {
         table_name: table_name.to_string(),
@@ -1300,10 +1308,9 @@ fn test_batch_delete_returning_all_old_surfaces_item() {
     let resp = db
         .batch_execute_statement(BatchExecuteStatementRequest {
             return_consumed_capacity: None,
-            statements: vec![BatchStatementRequest {
-                statement: "DELETE FROM \"Users\" WHERE pk = 'b1' RETURNING ALL OLD *".to_string(),
-                parameters: None,
-            }],
+            statements: vec![batch_stmt(
+                "DELETE FROM \"Users\" WHERE pk = 'b1' RETURNING ALL OLD *".to_string(),
+            )],
         })
         .unwrap();
 
@@ -1339,11 +1346,9 @@ fn test_batch_update_returning_surfaces_projection() {
     let resp = db
         .batch_execute_statement(BatchExecuteStatementRequest {
             return_consumed_capacity: None,
-            statements: vec![BatchStatementRequest {
-                statement: "UPDATE \"Users\" SET data = 'new' WHERE pk = 'b1' RETURNING ALL NEW *"
-                    .to_string(),
-                parameters: None,
-            }],
+            statements: vec![batch_stmt(
+                "UPDATE \"Users\" SET data = 'new' WHERE pk = 'b1' RETURNING ALL NEW *".to_string(),
+            )],
         })
         .unwrap();
     let item = resp.responses[0]
@@ -1361,12 +1366,10 @@ fn test_batch_update_returning_surfaces_projection() {
     let resp = db
         .batch_execute_statement(BatchExecuteStatementRequest {
             return_consumed_capacity: None,
-            statements: vec![BatchStatementRequest {
-                statement:
-                    "UPDATE \"Users\" SET data = 'newer' WHERE pk = 'b1' RETURNING MODIFIED NEW *"
-                        .to_string(),
-                parameters: None,
-            }],
+            statements: vec![batch_stmt(
+                "UPDATE \"Users\" SET data = 'newer' WHERE pk = 'b1' RETURNING MODIFIED NEW *"
+                    .to_string(),
+            )],
         })
         .unwrap();
     let item = resp.responses[0]
@@ -1392,11 +1395,9 @@ fn test_batch_update_empty_modified_omits_item() {
     let resp = db
         .batch_execute_statement(BatchExecuteStatementRequest {
             return_consumed_capacity: None,
-            statements: vec![BatchStatementRequest {
-                statement: "UPDATE \"Users\" REMOVE data WHERE pk = 'b1' RETURNING MODIFIED NEW *"
-                    .to_string(),
-                parameters: None,
-            }],
+            statements: vec![batch_stmt(
+                "UPDATE \"Users\" REMOVE data WHERE pk = 'b1' RETURNING MODIFIED NEW *".to_string(),
+            )],
         })
         .unwrap();
     assert_eq!(resp.responses.len(), 1);
@@ -1421,12 +1422,10 @@ fn test_batch_update_list_index_modified_projects_changed_element() {
     let resp = db
         .batch_execute_statement(BatchExecuteStatementRequest {
             return_consumed_capacity: None,
-            statements: vec![BatchStatementRequest {
-                statement:
-                    "UPDATE \"Users\" SET tags[0] = 'x' WHERE pk = 'b1' RETURNING MODIFIED NEW *"
-                        .to_string(),
-                parameters: None,
-            }],
+            statements: vec![batch_stmt(
+                "UPDATE \"Users\" SET tags[0] = 'x' WHERE pk = 'b1' RETURNING MODIFIED NEW *"
+                    .to_string(),
+            )],
         })
         .unwrap();
     let item = resp.responses[0]
@@ -1452,10 +1451,9 @@ fn test_batch_plain_update_echoes_table_name() {
     let resp = db
         .batch_execute_statement(BatchExecuteStatementRequest {
             return_consumed_capacity: None,
-            statements: vec![BatchStatementRequest {
-                statement: "UPDATE \"Users\" SET data = 'new' WHERE pk = 'b1'".to_string(),
-                parameters: None,
-            }],
+            statements: vec![batch_stmt(
+                "UPDATE \"Users\" SET data = 'new' WHERE pk = 'b1'".to_string(),
+            )],
         })
         .unwrap();
     assert!(resp.responses[0].error.is_none());
@@ -1478,14 +1476,8 @@ fn test_batch_parse_error_uses_short_validation_code() {
         .batch_execute_statement(BatchExecuteStatementRequest {
             return_consumed_capacity: None,
             statements: vec![
-                BatchStatementRequest {
-                    statement: "SLECT * FROM \"Users\"".to_string(),
-                    parameters: None,
-                },
-                BatchStatementRequest {
-                    statement: "SELECT * FROM \"Users\" WHERE pk = 'b1'".to_string(),
-                    parameters: None,
-                },
+                batch_stmt("SLECT * FROM \"Users\"".to_string()),
+                batch_stmt("SELECT * FROM \"Users\" WHERE pk = 'b1'".to_string()),
             ],
         })
         .unwrap();
@@ -1538,11 +1530,9 @@ fn test_batch_invalid_delete_returning_variant_is_a_per_statement_error() {
     let resp = db
         .batch_execute_statement(BatchExecuteStatementRequest {
             return_consumed_capacity: None,
-            statements: vec![BatchStatementRequest {
-                statement: "DELETE FROM \"Users\" WHERE pk = 'b1' RETURNING MODIFIED OLD *"
-                    .to_string(),
-                parameters: None,
-            }],
+            statements: vec![batch_stmt(
+                "DELETE FROM \"Users\" WHERE pk = 'b1' RETURNING MODIFIED OLD *".to_string(),
+            )],
         })
         .unwrap();
     assert_eq!(resp.responses.len(), 1);
@@ -1904,16 +1894,8 @@ fn test_batch_execute_mixed_operations() {
         .batch_execute_statement(BatchExecuteStatementRequest {
             return_consumed_capacity: None,
             statements: vec![
-                BatchStatementRequest {
-                    statement: "INSERT INTO \"Users\" VALUE {'pk': 'u1', 'name': 'Alice'}"
-                        .to_string(),
-                    parameters: None,
-                },
-                BatchStatementRequest {
-                    statement: "INSERT INTO \"Users\" VALUE {'pk': 'u2', 'name': 'Bob'}"
-                        .to_string(),
-                    parameters: None,
-                },
+                batch_stmt("INSERT INTO \"Users\" VALUE {'pk': 'u1', 'name': 'Alice'}".to_string()),
+                batch_stmt("INSERT INTO \"Users\" VALUE {'pk': 'u2', 'name': 'Bob'}".to_string()),
             ],
         })
         .unwrap();
@@ -1939,15 +1921,8 @@ fn test_batch_execute_partial_failure() {
         .batch_execute_statement(BatchExecuteStatementRequest {
             return_consumed_capacity: None,
             statements: vec![
-                BatchStatementRequest {
-                    statement: "INSERT INTO \"Users\" VALUE {'pk': 'u1', 'name': 'Alice'}"
-                        .to_string(),
-                    parameters: None,
-                },
-                BatchStatementRequest {
-                    statement: "INSERT INTO \"NonExistent\" VALUE {'pk': 'u2'}".to_string(),
-                    parameters: None,
-                },
+                batch_stmt("INSERT INTO \"Users\" VALUE {'pk': 'u1', 'name': 'Alice'}".to_string()),
+                batch_stmt("INSERT INTO \"NonExistent\" VALUE {'pk': 'u2'}".to_string()),
             ],
         })
         .unwrap();
@@ -1969,14 +1944,8 @@ fn test_batch_execute_rejects_duplicate_item_keys() {
         .batch_execute_statement(BatchExecuteStatementRequest {
             return_consumed_capacity: None,
             statements: vec![
-                BatchStatementRequest {
-                    statement: "INSERT INTO \"Users\" VALUE {'pk': 'dup'}".to_string(),
-                    parameters: None,
-                },
-                BatchStatementRequest {
-                    statement: "UPDATE \"Users\" SET name='x' WHERE pk='dup'".to_string(),
-                    parameters: None,
-                },
+                batch_stmt("INSERT INTO \"Users\" VALUE {'pk': 'dup'}".to_string()),
+                batch_stmt("UPDATE \"Users\" SET name='x' WHERE pk='dup'".to_string()),
             ],
         })
         .expect_err("two statements against one item are rejected");
@@ -1998,14 +1967,8 @@ fn test_batch_execute_allows_distinct_item_keys() {
         .batch_execute_statement(BatchExecuteStatementRequest {
             return_consumed_capacity: None,
             statements: vec![
-                BatchStatementRequest {
-                    statement: "INSERT INTO \"Users\" VALUE {'pk': 'one'}".to_string(),
-                    parameters: None,
-                },
-                BatchStatementRequest {
-                    statement: "INSERT INTO \"Users\" VALUE {'pk': 'two'}".to_string(),
-                    parameters: None,
-                },
+                batch_stmt("INSERT INTO \"Users\" VALUE {'pk': 'one'}".to_string()),
+                batch_stmt("INSERT INTO \"Users\" VALUE {'pk': 'two'}".to_string()),
             ],
         })
         .unwrap();
@@ -2026,14 +1989,8 @@ fn test_batch_execute_rejects_mixed_read_and_write() {
         .batch_execute_statement(BatchExecuteStatementRequest {
             return_consumed_capacity: None,
             statements: vec![
-                BatchStatementRequest {
-                    statement: "SELECT * FROM \"Users\" WHERE pk = 'u1'".to_string(),
-                    parameters: None,
-                },
-                BatchStatementRequest {
-                    statement: "INSERT INTO \"Users\" VALUE {'pk': 'u2'}".to_string(),
-                    parameters: None,
-                },
+                batch_stmt("SELECT * FROM \"Users\" WHERE pk = 'u1'".to_string()),
+                batch_stmt("INSERT INTO \"Users\" VALUE {'pk': 'u2'}".to_string()),
             ],
         })
         .expect_err("a mixed batch is rejected");
@@ -2050,10 +2007,7 @@ fn test_batch_execute_exceeds_limit() {
     let db = Database::memory().unwrap();
 
     let stmts: Vec<BatchStatementRequest> = (0..26)
-        .map(|_| BatchStatementRequest {
-            statement: "SELECT * FROM \"T\"".to_string(),
-            parameters: None,
-        })
+        .map(|_| batch_stmt("SELECT * FROM \"T\"".to_string()))
         .collect();
 
     let result = db.batch_execute_statement(BatchExecuteStatementRequest {
@@ -3505,14 +3459,8 @@ fn test_count_is_rejected_per_statement_on_batch_execute() {
         .batch_execute_statement(BatchExecuteStatementRequest {
             return_consumed_capacity: None,
             statements: vec![
-                BatchStatementRequest {
-                    statement: "SELECT COUNT(*) FROM \"Users\"".to_string(),
-                    parameters: None,
-                },
-                BatchStatementRequest {
-                    statement: "SELECT * FROM \"Users\" WHERE pk = 'u1'".to_string(),
-                    parameters: None,
-                },
+                batch_stmt("SELECT COUNT(*) FROM \"Users\"".to_string()),
+                batch_stmt("SELECT * FROM \"Users\" WHERE pk = 'u1'".to_string()),
             ],
         })
         .unwrap();

--- a/tests/partiql.rs
+++ b/tests/partiql.rs
@@ -1299,6 +1299,7 @@ fn test_batch_delete_returning_all_old_surfaces_item() {
 
     let resp = db
         .batch_execute_statement(BatchExecuteStatementRequest {
+            return_consumed_capacity: None,
             statements: vec![BatchStatementRequest {
                 statement: "DELETE FROM \"Users\" WHERE pk = 'b1' RETURNING ALL OLD *".to_string(),
                 parameters: None,
@@ -1337,6 +1338,7 @@ fn test_batch_update_returning_surfaces_projection() {
     // ALL NEW: the full new item, key included.
     let resp = db
         .batch_execute_statement(BatchExecuteStatementRequest {
+            return_consumed_capacity: None,
             statements: vec![BatchStatementRequest {
                 statement: "UPDATE \"Users\" SET data = 'new' WHERE pk = 'b1' RETURNING ALL NEW *"
                     .to_string(),
@@ -1358,6 +1360,7 @@ fn test_batch_update_returning_surfaces_projection() {
     // MODIFIED NEW: only the changed attribute, no key.
     let resp = db
         .batch_execute_statement(BatchExecuteStatementRequest {
+            return_consumed_capacity: None,
             statements: vec![BatchStatementRequest {
                 statement:
                     "UPDATE \"Users\" SET data = 'newer' WHERE pk = 'b1' RETURNING MODIFIED NEW *"
@@ -1388,6 +1391,7 @@ fn test_batch_update_empty_modified_omits_item() {
     // entirely (the batch analogue of ExecuteStatement's Items: []), matching AWS.
     let resp = db
         .batch_execute_statement(BatchExecuteStatementRequest {
+            return_consumed_capacity: None,
             statements: vec![BatchStatementRequest {
                 statement: "UPDATE \"Users\" REMOVE data WHERE pk = 'b1' RETURNING MODIFIED NEW *"
                     .to_string(),
@@ -1416,6 +1420,7 @@ fn test_batch_update_list_index_modified_projects_changed_element() {
 
     let resp = db
         .batch_execute_statement(BatchExecuteStatementRequest {
+            return_consumed_capacity: None,
             statements: vec![BatchStatementRequest {
                 statement:
                     "UPDATE \"Users\" SET tags[0] = 'x' WHERE pk = 'b1' RETURNING MODIFIED NEW *"
@@ -1446,6 +1451,7 @@ fn test_batch_plain_update_echoes_table_name() {
     // A plain (no-RETURNING) member still echoes TableName, with no Item.
     let resp = db
         .batch_execute_statement(BatchExecuteStatementRequest {
+            return_consumed_capacity: None,
             statements: vec![BatchStatementRequest {
                 statement: "UPDATE \"Users\" SET data = 'new' WHERE pk = 'b1'".to_string(),
                 parameters: None,
@@ -1470,6 +1476,7 @@ fn test_batch_parse_error_uses_short_validation_code() {
     // per-statement execution error does), while a valid sibling still executes.
     let resp = db
         .batch_execute_statement(BatchExecuteStatementRequest {
+            return_consumed_capacity: None,
             statements: vec![
                 BatchStatementRequest {
                     statement: "SLECT * FROM \"Users\"".to_string(),
@@ -1530,6 +1537,7 @@ fn test_batch_invalid_delete_returning_variant_is_a_per_statement_error() {
     // per-statement error, not a thrown exception.
     let resp = db
         .batch_execute_statement(BatchExecuteStatementRequest {
+            return_consumed_capacity: None,
             statements: vec![BatchStatementRequest {
                 statement: "DELETE FROM \"Users\" WHERE pk = 'b1' RETURNING MODIFIED OLD *"
                     .to_string(),
@@ -1894,6 +1902,7 @@ fn test_batch_execute_mixed_operations() {
 
     let resp = db
         .batch_execute_statement(BatchExecuteStatementRequest {
+            return_consumed_capacity: None,
             statements: vec![
                 BatchStatementRequest {
                     statement: "INSERT INTO \"Users\" VALUE {'pk': 'u1', 'name': 'Alice'}"
@@ -1923,8 +1932,12 @@ fn test_batch_execute_partial_failure() {
     let db = Database::memory().unwrap();
     create_test_table(&db, "Users");
 
+    // An all-write batch: a batch mixing reads and writes is rejected up front
+    // (see test_batch_execute_rejects_mixed_read_and_write), so partial failure
+    // is exercised with a second write against a table that does not exist.
     let resp = db
         .batch_execute_statement(BatchExecuteStatementRequest {
+            return_consumed_capacity: None,
             statements: vec![
                 BatchStatementRequest {
                     statement: "INSERT INTO \"Users\" VALUE {'pk': 'u1', 'name': 'Alice'}"
@@ -1932,7 +1945,7 @@ fn test_batch_execute_partial_failure() {
                     parameters: None,
                 },
                 BatchStatementRequest {
-                    statement: "SELECT * FROM \"NonExistent\"".to_string(),
+                    statement: "INSERT INTO \"NonExistent\" VALUE {'pk': 'u2'}".to_string(),
                     parameters: None,
                 },
             ],
@@ -1941,7 +1954,95 @@ fn test_batch_execute_partial_failure() {
 
     assert_eq!(resp.responses.len(), 2);
     assert!(resp.responses[0].error.is_none()); // insert succeeded
-    assert!(resp.responses[1].error.is_some()); // select failed — table not found
+    assert!(resp.responses[1].error.is_some()); // insert failed, table not found
+}
+
+#[test]
+fn test_batch_execute_rejects_duplicate_item_keys() {
+    // Captured against real DynamoDB: two statements against one item are
+    // rejected before any of them runs, the same way a transaction rejects
+    // duplicate targets.
+    let db = Database::memory().unwrap();
+    create_test_table(&db, "Users");
+
+    let err = db
+        .batch_execute_statement(BatchExecuteStatementRequest {
+            return_consumed_capacity: None,
+            statements: vec![
+                BatchStatementRequest {
+                    statement: "INSERT INTO \"Users\" VALUE {'pk': 'dup'}".to_string(),
+                    parameters: None,
+                },
+                BatchStatementRequest {
+                    statement: "UPDATE \"Users\" SET name='x' WHERE pk='dup'".to_string(),
+                    parameters: None,
+                },
+            ],
+        })
+        .expect_err("two statements against one item are rejected");
+
+    assert!(
+        err.to_string()
+            .contains("Provided list of item keys contains duplicates"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_batch_execute_allows_distinct_item_keys() {
+    // The mirror of the case above: distinct keys in one batch are fine.
+    let db = Database::memory().unwrap();
+    create_test_table(&db, "Users");
+
+    let resp = db
+        .batch_execute_statement(BatchExecuteStatementRequest {
+            return_consumed_capacity: None,
+            statements: vec![
+                BatchStatementRequest {
+                    statement: "INSERT INTO \"Users\" VALUE {'pk': 'one'}".to_string(),
+                    parameters: None,
+                },
+                BatchStatementRequest {
+                    statement: "INSERT INTO \"Users\" VALUE {'pk': 'two'}".to_string(),
+                    parameters: None,
+                },
+            ],
+        })
+        .unwrap();
+
+    assert_eq!(resp.responses.len(), 2);
+    assert!(resp.responses.iter().all(|r| r.error.is_none()));
+}
+
+#[test]
+fn test_batch_execute_rejects_mixed_read_and_write() {
+    // Captured against real DynamoDB: a batch carrying both a read and a write
+    // is rejected before any statement runs, as a top-level ValidationException
+    // rather than a per-statement error.
+    let db = Database::memory().unwrap();
+    create_test_table(&db, "Users");
+
+    let err = db
+        .batch_execute_statement(BatchExecuteStatementRequest {
+            return_consumed_capacity: None,
+            statements: vec![
+                BatchStatementRequest {
+                    statement: "SELECT * FROM \"Users\" WHERE pk = 'u1'".to_string(),
+                    parameters: None,
+                },
+                BatchStatementRequest {
+                    statement: "INSERT INTO \"Users\" VALUE {'pk': 'u2'}".to_string(),
+                    parameters: None,
+                },
+            ],
+        })
+        .expect_err("a mixed batch is rejected");
+
+    assert!(
+        err.to_string()
+            .contains("Read and write requests together in the same batch is not supported"),
+        "unexpected error: {err}"
+    );
 }
 
 #[test]
@@ -1955,7 +2056,10 @@ fn test_batch_execute_exceeds_limit() {
         })
         .collect();
 
-    let result = db.batch_execute_statement(BatchExecuteStatementRequest { statements: stmts });
+    let result = db.batch_execute_statement(BatchExecuteStatementRequest {
+        statements: stmts,
+        return_consumed_capacity: None,
+    });
 
     assert!(result.is_err());
 }
@@ -1964,7 +2068,10 @@ fn test_batch_execute_exceeds_limit() {
 fn test_batch_execute_empty_statements_rejected() {
     let db = Database::memory().unwrap();
 
-    let result = db.batch_execute_statement(BatchExecuteStatementRequest { statements: vec![] });
+    let result = db.batch_execute_statement(BatchExecuteStatementRequest {
+        statements: vec![],
+        return_consumed_capacity: None,
+    });
 
     let err = result.unwrap_err();
     let msg = format!("{err}");
@@ -3396,6 +3503,7 @@ fn test_count_is_rejected_per_statement_on_batch_execute() {
 
     let resp = db
         .batch_execute_statement(BatchExecuteStatementRequest {
+            return_consumed_capacity: None,
             statements: vec![
                 BatchStatementRequest {
                     statement: "SELECT COUNT(*) FROM \"Users\"".to_string(),

--- a/tests/partiql.rs
+++ b/tests/partiql.rs
@@ -1933,6 +1933,76 @@ fn test_batch_execute_partial_failure() {
 }
 
 #[test]
+fn test_batch_execute_unparseable_statement_is_per_statement() {
+    // Captured against real DynamoDB: a batch holding an unparseable statement
+    // is not rejected outright. That member reports ValidationError and the
+    // rest run. This is the contract the single up-front parse has to preserve:
+    // collecting into Result<Vec<_>, _> rather than Vec<Result<_, _>> would turn
+    // a per-statement error into a request-level failure.
+    let db = Database::memory().unwrap();
+    create_test_table(&db, "Users");
+
+    let resp = db
+        .batch_execute_statement(BatchExecuteStatementRequest {
+            return_consumed_capacity: None,
+            statements: vec![
+                batch_stmt("THIS IS NOT SQL AT ALL".to_string()),
+                batch_stmt("INSERT INTO \"Users\" VALUE {'pk': 'ok1'}".to_string()),
+            ],
+        })
+        .expect("an unparseable member does not sink the request");
+
+    assert_eq!(resp.responses.len(), 2);
+    assert_eq!(
+        resp.responses[0].error.as_ref().map(|e| e.code.as_str()),
+        Some("ValidationError")
+    );
+    assert!(resp.responses[1].error.is_none(), "the rest still run");
+}
+
+#[test]
+fn test_batch_execute_unparseable_does_not_mask_the_top_level_checks() {
+    // Captured: an unparseable member takes no part in the read/write
+    // classification or duplicate detection, but neither does it stop those
+    // checks firing on the members that did parse. Both still reject top-level.
+    let db = Database::memory().unwrap();
+    create_test_table(&db, "Users");
+
+    let mixed = db
+        .batch_execute_statement(BatchExecuteStatementRequest {
+            return_consumed_capacity: None,
+            statements: vec![
+                batch_stmt("NOT SQL".to_string()),
+                batch_stmt("SELECT * FROM \"Users\" WHERE pk = 'a'".to_string()),
+                batch_stmt("INSERT INTO \"Users\" VALUE {'pk': 'b'}".to_string()),
+            ],
+        })
+        .expect_err("the mixed check still fires");
+    assert!(
+        mixed
+            .to_string()
+            .contains("Read and write requests together"),
+        "unexpected error: {mixed}"
+    );
+
+    let dup = db
+        .batch_execute_statement(BatchExecuteStatementRequest {
+            return_consumed_capacity: None,
+            statements: vec![
+                batch_stmt("NOT SQL".to_string()),
+                batch_stmt("INSERT INTO \"Users\" VALUE {'pk': 'same'}".to_string()),
+                batch_stmt("INSERT INTO \"Users\" VALUE {'pk': 'same'}".to_string()),
+            ],
+        })
+        .expect_err("the duplicate check still fires");
+    assert!(
+        dup.to_string()
+            .contains("Provided list of item keys contains duplicates"),
+        "unexpected error: {dup}"
+    );
+}
+
+#[test]
 fn test_batch_execute_rejects_duplicate_item_keys() {
     // Captured against real DynamoDB: two statements against one item are
     // rejected before any of them runs, the same way a transaction rejects

--- a/tests/partiql_index_consumed_capacity.rs
+++ b/tests/partiql_index_consumed_capacity.rs
@@ -706,6 +706,71 @@ fn u2_a_failed_statement_is_charged_on_the_item_already_stored() {
 }
 
 #[test]
+fn r3_a_table_whose_statements_all_failed_is_omitted() {
+    // Capture R3: a batch where one table's only statement fails and another
+    // table's succeeds reports just the succeeding table, with no surcharge
+    // anywhere. So the failure surcharge only ever lands on a table that also
+    // had a success, and a table with nothing to attach it to gets no entry.
+    let db = indexed_table();
+    db.create_table(serde_json::from_value(table_def(OTHER_TABLE)).unwrap())
+        .unwrap();
+    seed(
+        &db,
+        serde_json::json!({"pk": {"S": "x0"}, "sk": {"S": "1"}, "gsiPk": {"S": "g1"}}),
+    );
+
+    let entries = batch(
+        &db,
+        &[
+            // Fails: x0 already exists on TABLE.
+            &format!("INSERT INTO \"{TABLE}\" VALUE {{'pk':'x0','sk':'1','gsiPk':'g1'}}"),
+            &format!("INSERT INTO \"{OTHER_TABLE}\" VALUE {{'pk':'x1','sk':'1','gsiPk':'g1'}}"),
+        ],
+        "INDEXES",
+    )
+    .expect("the succeeding table reports capacity");
+
+    assert_eq!(entries.len(), 1, "the all-failed table is omitted entirely");
+    assert_eq!(entries[0].table_name, OTHER_TABLE);
+    assert_eq!(entries[0].capacity_units, 2.0);
+    assert_eq!(table_arm(&entries[0]), 1.0);
+    assert_eq!(gsi(&entries[0]), Some(1.0));
+}
+
+#[test]
+fn a_count_projection_rejection_keeps_its_place_in_the_response() {
+    // The execution loop pairs each request statement with what was parsed for
+    // it. `test_count_is_rejected_per_statement_on_batch_execute` already covers
+    // a rejection at the head of a batch; this one puts it in the middle, where
+    // a misalignment would be visible as the error landing on a neighbour.
+    //
+    // Nothing can misalign them today, because the pairing advances both sides
+    // together. The guard is against a later change that filters or reorders
+    // what the preparation pass returns, which would go unnoticed with the
+    // rejection first.
+    let db = indexed_table();
+    let req = serde_json::json!({
+        "Statements": [
+            {"Statement": format!("INSERT INTO \"{TABLE}\" VALUE {{'pk':'c1','sk':'1'}}")},
+            {"Statement": format!("SELECT COUNT(*) FROM \"{TABLE}\"")},
+            {"Statement": format!("INSERT INTO \"{TABLE}\" VALUE {{'pk':'c2','sk':'1'}}")}
+        ]
+    });
+    let resp = db
+        .batch_execute_statement(serde_json::from_value(req).unwrap())
+        .expect("a COUNT rejection is per-statement");
+
+    assert_eq!(resp.responses.len(), 3);
+    assert!(resp.responses[0].error.is_none());
+    assert_eq!(
+        resp.responses[1].error.as_ref().map(|e| e.code.as_str()),
+        Some("ValidationError"),
+        "the rejection stays on the statement that caused it"
+    );
+    assert!(resp.responses[2].error.is_none());
+}
+
+#[test]
 fn a_no_op_write_still_names_its_table() {
     // An `IF NOT EXISTS` duplicate writes nothing, and the entry it produces
     // must still carry the table. Building it from a defaulted record leaves

--- a/tests/partiql_index_consumed_capacity.rs
+++ b/tests/partiql_index_consumed_capacity.rs
@@ -1,0 +1,831 @@
+//! Per-index `ConsumedCapacity` on PartiQL writes.
+//!
+//! Every figure asserted here was measured against real DynamoDB in eu-west-2 on
+//! 13 August 2026, against a table keyed `pk`/`sk` with a GSI `gsi-inc` on
+//! `gsiPk` projecting `INCLUDE [proj]` and an LSI `lsi-all` on `pk`/`lsiSk`
+//! projecting `ALL`. Case labels (C1, D2, M4) refer to that capture.
+//!
+//! The three surfaces divide cleanly. `ExecuteStatement` and
+//! `BatchExecuteStatement` are charged exactly as the equivalent single-item
+//! write, with no transactional factor. `ExecuteTransaction` doubles the base
+//! table arm and leaves the index arms alone, matching `TransactWriteItems`.
+
+use dynoxide::Database;
+use dynoxide::types::{CapacityDetail, ConsumedCapacity};
+use std::collections::HashMap;
+
+const TABLE: &str = "pq_idx_wcu";
+const OTHER_TABLE: &str = "pq_idx_wcu_b";
+
+fn table_def(name: &str) -> serde_json::Value {
+    serde_json::json!({
+        "TableName": name,
+        "KeySchema": [
+            {"AttributeName": "pk", "KeyType": "HASH"},
+            {"AttributeName": "sk", "KeyType": "RANGE"}
+        ],
+        "AttributeDefinitions": [
+            {"AttributeName": "pk", "AttributeType": "S"},
+            {"AttributeName": "sk", "AttributeType": "S"},
+            {"AttributeName": "gsiPk", "AttributeType": "S"},
+            {"AttributeName": "lsiSk", "AttributeType": "S"}
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+        "GlobalSecondaryIndexes": [{
+            "IndexName": "gsi-inc",
+            "KeySchema": [{"AttributeName": "gsiPk", "KeyType": "HASH"}],
+            "Projection": {"ProjectionType": "INCLUDE", "NonKeyAttributes": ["proj"]}
+        }],
+        "LocalSecondaryIndexes": [{
+            "IndexName": "lsi-all",
+            "KeySchema": [
+                {"AttributeName": "pk", "KeyType": "HASH"},
+                {"AttributeName": "lsiSk", "KeyType": "RANGE"}
+            ],
+            "Projection": {"ProjectionType": "ALL"}
+        }]
+    })
+}
+
+fn indexed_table() -> Database {
+    let db = Database::memory().unwrap();
+    db.create_table(serde_json::from_value(table_def(TABLE)).unwrap())
+        .unwrap();
+    db
+}
+
+fn pad(n: usize) -> String {
+    "x".repeat(n)
+}
+
+fn seed(db: &Database, item: serde_json::Value) {
+    let req = serde_json::json!({"TableName": TABLE, "Item": item});
+    db.put_item(serde_json::from_value(req).unwrap()).unwrap();
+}
+
+/// Run one statement and return its capacity.
+fn statement(db: &Database, sql: &str) -> ConsumedCapacity {
+    let req = serde_json::json!({"Statement": sql, "ReturnConsumedCapacity": "INDEXES"});
+    db.execute_statement(serde_json::from_value(req).unwrap())
+        .unwrap()
+        .consumed_capacity
+        .expect("INDEXES mode reports capacity")
+}
+
+/// Run a PartiQL transaction and return its per-table capacity entries.
+fn transaction(db: &Database, sql: &[&str], mode: &str) -> Vec<ConsumedCapacity> {
+    let req = serde_json::json!({
+        "TransactStatements": sql.iter().map(|s| serde_json::json!({"Statement": s}))
+            .collect::<Vec<_>>(),
+        "ReturnConsumedCapacity": mode
+    });
+    db.execute_transaction(serde_json::from_value(req).unwrap())
+        .unwrap()
+        .consumed_capacity
+        .expect("TOTAL and INDEXES report capacity")
+}
+
+fn one_transaction(db: &Database, sql: &[&str]) -> ConsumedCapacity {
+    let mut entries = transaction(db, sql, "INDEXES");
+    assert_eq!(entries.len(), 1, "expected one table in the response");
+    entries.remove(0)
+}
+
+/// Run a batch and return its per-table capacity entries, if any.
+fn batch(db: &Database, sql: &[&str], mode: &str) -> Option<Vec<ConsumedCapacity>> {
+    let req = serde_json::json!({
+        "Statements": sql.iter().map(|s| serde_json::json!({"Statement": s}))
+            .collect::<Vec<_>>(),
+        "ReturnConsumedCapacity": mode
+    });
+    db.batch_execute_statement(serde_json::from_value(req).unwrap())
+        .unwrap()
+        .consumed_capacity
+}
+
+fn one_batch(db: &Database, sql: &[&str]) -> ConsumedCapacity {
+    let mut entries = batch(db, sql, "INDEXES").expect("INDEXES mode reports capacity");
+    assert_eq!(entries.len(), 1, "expected one table in the response");
+    entries.remove(0)
+}
+
+fn arm(map: &Option<HashMap<String, CapacityDetail>>, name: &str) -> Option<f64> {
+    map.as_ref()
+        .and_then(|m| m.get(name))
+        .map(|d| d.capacity_units)
+}
+
+fn gsi(cc: &ConsumedCapacity) -> Option<f64> {
+    arm(&cc.global_secondary_indexes, "gsi-inc")
+}
+
+fn lsi(cc: &ConsumedCapacity) -> Option<f64> {
+    arm(&cc.local_secondary_indexes, "lsi-all")
+}
+
+fn table_arm(cc: &ConsumedCapacity) -> f64 {
+    cc.table
+        .as_ref()
+        .expect("INDEXES reports a Table detail")
+        .capacity_units
+}
+
+// ---------------------------------------------------------------------------
+// ExecuteStatement. Capture round C, plus P.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn c1_insert_of_a_member_of_both_indexes_charges_both_arms() {
+    // Capture C1: total 3, table 1, gsi 1, lsi 1. No transactional factor, so
+    // this is the same bill as the equivalent PutItem.
+    let db = indexed_table();
+    let cc = statement(
+        &db,
+        &format!(
+            "INSERT INTO \"{TABLE}\" VALUE \
+             {{'pk':'c1','sk':'1','gsiPk':'g1','lsiSk':'L1','proj':'p','other':'o'}}"
+        ),
+    );
+
+    assert_eq!(cc.capacity_units, 3.0);
+    assert_eq!(table_arm(&cc), 1.0);
+    assert_eq!(gsi(&cc), Some(1.0));
+    assert_eq!(lsi(&cc), Some(1.0));
+}
+
+#[test]
+fn c2_update_outside_the_gsi_projection_charges_only_the_lsi() {
+    // Capture C2: total 2, table 1, lsi 1, no GSI arm.
+    let db = indexed_table();
+    seed(
+        &db,
+        serde_json::json!({
+            "pk": {"S": "c2"}, "sk": {"S": "1"},
+            "gsiPk": {"S": "g1"}, "lsiSk": {"S": "L1"}, "other": {"S": "o"}
+        }),
+    );
+
+    let cc = statement(
+        &db,
+        &format!("UPDATE \"{TABLE}\" SET other='o2' WHERE pk='c2' AND sk='1'"),
+    );
+    assert_eq!(cc.capacity_units, 2.0);
+    assert_eq!(table_arm(&cc), 1.0);
+    assert_eq!(gsi(&cc), None);
+    assert_eq!(lsi(&cc), Some(1.0));
+}
+
+#[test]
+fn c3_moving_a_gsi_key_charges_the_index_twice() {
+    // Capture C3: total 4, table 1, gsi 2, lsi 1.
+    let db = indexed_table();
+    seed(
+        &db,
+        serde_json::json!({
+            "pk": {"S": "c3"}, "sk": {"S": "1"},
+            "gsiPk": {"S": "g1"}, "lsiSk": {"S": "L1"}
+        }),
+    );
+
+    let cc = statement(
+        &db,
+        &format!("UPDATE \"{TABLE}\" SET gsiPk='g2' WHERE pk='c3' AND sk='1'"),
+    );
+    assert_eq!(cc.capacity_units, 4.0);
+    assert_eq!(table_arm(&cc), 1.0);
+    assert_eq!(gsi(&cc), Some(2.0));
+    assert_eq!(lsi(&cc), Some(1.0));
+}
+
+#[test]
+fn c4_delete_of_an_item_in_both_indexes_charges_both_arms() {
+    // Capture C4: total 3, table 1, gsi 1, lsi 1.
+    let db = indexed_table();
+    seed(
+        &db,
+        serde_json::json!({
+            "pk": {"S": "c4"}, "sk": {"S": "1"},
+            "gsiPk": {"S": "g1"}, "lsiSk": {"S": "L1"}
+        }),
+    );
+
+    let cc = statement(
+        &db,
+        &format!("DELETE FROM \"{TABLE}\" WHERE pk='c4' AND sk='1'"),
+    );
+    assert_eq!(cc.capacity_units, 3.0);
+    assert_eq!(table_arm(&cc), 1.0);
+    assert_eq!(gsi(&cc), Some(1.0));
+    assert_eq!(lsi(&cc), Some(1.0));
+}
+
+#[test]
+fn c5_insert_is_sized_on_the_projected_entry() {
+    // Capture C5: total 6, table 3, gsi 3. `proj` is projected, so it moves both
+    // the base item and the index entry.
+    let db = indexed_table();
+    let cc = statement(
+        &db,
+        &format!(
+            "INSERT INTO \"{}\" VALUE {{'pk':'c5','sk':'1','gsiPk':'g1','proj':'{}'}}",
+            TABLE,
+            pad(3000)
+        ),
+    );
+    assert_eq!(cc.capacity_units, 6.0);
+    assert_eq!(table_arm(&cc), 3.0);
+    assert_eq!(gsi(&cc), Some(3.0));
+}
+
+#[test]
+fn p1_a_shrinking_update_is_sized_on_the_image_it_replaced() {
+    // Capture P1: total 6, table 3, gsi 3. Sizing on the after image reports 2.
+    let db = indexed_table();
+    seed(
+        &db,
+        serde_json::json!({
+            "pk": {"S": "p1"}, "sk": {"S": "1"},
+            "gsiPk": {"S": "g1"}, "proj": {"S": pad(3000)}
+        }),
+    );
+
+    let cc = statement(
+        &db,
+        &format!("UPDATE \"{TABLE}\" SET proj='p' WHERE pk='p1' AND sk='1'"),
+    );
+    assert_eq!(cc.capacity_units, 6.0);
+    assert_eq!(table_arm(&cc), 3.0);
+    assert_eq!(gsi(&cc), Some(3.0));
+}
+
+#[test]
+fn p3_delete_is_sized_on_the_stored_image() {
+    // Capture P3: total 6, table 3, gsi 3.
+    let db = indexed_table();
+    seed(
+        &db,
+        serde_json::json!({
+            "pk": {"S": "p3"}, "sk": {"S": "1"},
+            "gsiPk": {"S": "g1"}, "proj": {"S": pad(3000)}
+        }),
+    );
+
+    let cc = statement(
+        &db,
+        &format!("DELETE FROM \"{TABLE}\" WHERE pk='p3' AND sk='1'"),
+    );
+    assert_eq!(cc.capacity_units, 6.0);
+    assert_eq!(table_arm(&cc), 3.0);
+    assert_eq!(gsi(&cc), Some(3.0));
+}
+
+#[test]
+fn p5_delete_of_a_missing_target_costs_the_minimum() {
+    // Capture P5: total 1, table 1, no arms.
+    let db = indexed_table();
+    let cc = statement(
+        &db,
+        &format!("DELETE FROM \"{TABLE}\" WHERE pk='p5' AND sk='1'"),
+    );
+    assert_eq!(cc.capacity_units, 1.0);
+    assert_eq!(table_arm(&cc), 1.0);
+    assert!(cc.global_secondary_indexes.is_none());
+}
+
+#[test]
+fn c6_reads_are_unchanged() {
+    // Capture C6 and I1: a keyed SELECT costs 0.5 eventually consistent and 1
+    // with ConsistentRead, with no index arms on a base table read.
+    let db = indexed_table();
+    seed(
+        &db,
+        serde_json::json!({
+            "pk": {"S": "c6"}, "sk": {"S": "1"}, "gsiPk": {"S": "g1"}
+        }),
+    );
+
+    let cc = statement(
+        &db,
+        &format!("SELECT * FROM \"{TABLE}\" WHERE pk='c6' AND sk='1'"),
+    );
+    assert_eq!(cc.capacity_units, 0.5);
+    assert!(cc.global_secondary_indexes.is_none());
+
+    let req = serde_json::json!({
+        "Statement": format!("SELECT * FROM \"{TABLE}\" WHERE pk='c6' AND sk='1'"),
+        "ConsistentRead": true,
+        "ReturnConsumedCapacity": "INDEXES"
+    });
+    let consistent = db
+        .execute_statement(serde_json::from_value(req).unwrap())
+        .unwrap()
+        .consumed_capacity
+        .unwrap();
+    assert_eq!(consistent.capacity_units, 1.0);
+}
+
+// ---------------------------------------------------------------------------
+// ExecuteTransaction. Capture round D, plus Q.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn d1_a_transactional_insert_doubles_the_table_arm_only() {
+    // Capture D1: total 4, table 2, gsi 1, lsi 1. The same statement through
+    // ExecuteStatement (C1) costs total 3 with table 1, so only the table arm
+    // moves.
+    let db = indexed_table();
+    let cc = one_transaction(
+        &db,
+        &[&format!(
+            "INSERT INTO \"{TABLE}\" VALUE \
+             {{'pk':'d1','sk':'1','gsiPk':'g1','lsiSk':'L1','proj':'p'}}"
+        )],
+    );
+
+    assert_eq!(cc.capacity_units, 4.0);
+    assert_eq!(table_arm(&cc), 2.0);
+    assert_eq!(gsi(&cc), Some(1.0));
+    assert_eq!(lsi(&cc), Some(1.0));
+}
+
+#[test]
+fn d2_a_transactional_insert_is_size_accurate() {
+    // Capture D2: total 9, table 6, gsi 3. A flat per-statement unit reports 2.
+    let db = indexed_table();
+    let cc = one_transaction(
+        &db,
+        &[&format!(
+            "INSERT INTO \"{}\" VALUE {{'pk':'d2','sk':'1','gsiPk':'g1','proj':'{}'}}",
+            TABLE,
+            pad(3000)
+        )],
+    );
+
+    assert_eq!(cc.capacity_units, 9.0);
+    assert_eq!(table_arm(&cc), 6.0);
+    assert_eq!(gsi(&cc), Some(3.0));
+}
+
+#[test]
+fn q1_a_transactional_shrinking_update_holds_the_larger_image() {
+    // Capture Q1: total 9, table 6, gsi 3.
+    let db = indexed_table();
+    seed(
+        &db,
+        serde_json::json!({
+            "pk": {"S": "q1"}, "sk": {"S": "1"},
+            "gsiPk": {"S": "g1"}, "proj": {"S": pad(3000)}
+        }),
+    );
+
+    let cc = one_transaction(
+        &db,
+        &[&format!(
+            "UPDATE \"{TABLE}\" SET proj='p' WHERE pk='q1' AND sk='1'"
+        )],
+    );
+    assert_eq!(cc.capacity_units, 9.0);
+    assert_eq!(table_arm(&cc), 6.0);
+    assert_eq!(gsi(&cc), Some(3.0));
+}
+
+#[test]
+fn q3_two_statements_on_one_table_sum_every_arm() {
+    // Capture Q3: total 8, table 4, gsi 2, lsi 2.
+    let db = indexed_table();
+    let cc = one_transaction(
+        &db,
+        &[
+            &format!(
+                "INSERT INTO \"{TABLE}\" VALUE {{'pk':'q3','sk':'1','gsiPk':'g1','lsiSk':'L1'}}"
+            ),
+            &format!(
+                "INSERT INTO \"{TABLE}\" VALUE {{'pk':'q4','sk':'1','gsiPk':'g1','lsiSk':'L1'}}"
+            ),
+        ],
+    );
+
+    assert_eq!(cc.capacity_units, 8.0);
+    assert_eq!(table_arm(&cc), 4.0);
+    assert_eq!(gsi(&cc), Some(2.0));
+    assert_eq!(lsi(&cc), Some(2.0));
+}
+
+#[test]
+fn q4_each_table_carries_only_its_own_arms() {
+    // Capture Q4: the two-index member reports total 4, the GSI-only member 3.
+    let db = indexed_table();
+    db.create_table(serde_json::from_value(table_def(OTHER_TABLE)).unwrap())
+        .unwrap();
+
+    let entries = transaction(
+        &db,
+        &[
+            &format!(
+                "INSERT INTO \"{TABLE}\" VALUE {{'pk':'q5','sk':'1','gsiPk':'g1','lsiSk':'L1'}}"
+            ),
+            &format!("INSERT INTO \"{OTHER_TABLE}\" VALUE {{'pk':'q5','sk':'1','gsiPk':'g1'}}"),
+        ],
+        "INDEXES",
+    );
+
+    assert_eq!(entries.len(), 2);
+    let names: Vec<&str> = entries.iter().map(|e| e.table_name.as_str()).collect();
+    assert_eq!(names, vec![TABLE, OTHER_TABLE]);
+    assert_eq!(entries[0].capacity_units, 4.0);
+    assert_eq!(entries[1].capacity_units, 3.0);
+    assert!(entries[1].local_secondary_indexes.is_none());
+}
+
+#[test]
+fn d3_a_read_set_reports_read_capacity_with_no_arms() {
+    // Capture D3: total 2, r=2, table 2. A read set is charged at 4KB
+    // granularity, doubled, with no index breakdown.
+    let db = indexed_table();
+    seed(
+        &db,
+        serde_json::json!({"pk": {"S": "d3"}, "sk": {"S": "1"}, "gsiPk": {"S": "g1"}}),
+    );
+
+    let mut entries = transaction(
+        &db,
+        &[&format!(
+            "SELECT * FROM \"{TABLE}\" WHERE pk='d3' AND sk='1'"
+        )],
+        "INDEXES",
+    );
+    let cc = entries.remove(0);
+    assert_eq!(cc.capacity_units, 2.0);
+    assert_eq!(cc.read_capacity_units, Some(2.0));
+    assert!(cc.global_secondary_indexes.is_none());
+}
+
+#[test]
+fn a_transactional_write_reports_the_write_axis_at_every_level() {
+    // The transactional shape mirrors its units into WriteCapacityUnits
+    // everywhere, including each index arm. ExecuteStatement does not.
+    let db = indexed_table();
+    let cc = one_transaction(
+        &db,
+        &[&format!(
+            "INSERT INTO \"{TABLE}\" VALUE {{'pk':'w1','sk':'1','gsiPk':'g1','lsiSk':'L1'}}"
+        )],
+    );
+    assert_eq!(cc.write_capacity_units, Some(4.0));
+    assert_eq!(cc.table.as_ref().unwrap().write_capacity_units, Some(2.0));
+    assert_eq!(
+        cc.global_secondary_indexes
+            .as_ref()
+            .unwrap()
+            .get("gsi-inc")
+            .unwrap()
+            .write_capacity_units,
+        Some(1.0)
+    );
+
+    let single = statement(
+        &db,
+        &format!("INSERT INTO \"{TABLE}\" VALUE {{'pk':'w2','sk':'1','gsiPk':'g1'}}"),
+    );
+    assert_eq!(single.write_capacity_units, None);
+    assert_eq!(single.table.as_ref().unwrap().write_capacity_units, None);
+    assert_eq!(
+        single
+            .global_secondary_indexes
+            .as_ref()
+            .unwrap()
+            .get("gsi-inc")
+            .unwrap()
+            .write_capacity_units,
+        None
+    );
+}
+
+// ---------------------------------------------------------------------------
+// BatchExecuteStatement. Capture rounds E, M and R.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn m2_a_single_succeeding_insert_charges_its_index() {
+    // Capture M2: total 2, table 1, gsi 1.
+    let db = indexed_table();
+    let cc = one_batch(
+        &db,
+        &[&format!(
+            "INSERT INTO \"{TABLE}\" VALUE {{'pk':'m2','sk':'1','gsiPk':'g1'}}"
+        )],
+    );
+    assert_eq!(cc.capacity_units, 2.0);
+    assert_eq!(table_arm(&cc), 1.0);
+    assert_eq!(gsi(&cc), Some(1.0));
+}
+
+#[test]
+fn m3_an_insert_touching_no_index_reports_no_arms() {
+    // Capture M3: total 1, table 1.
+    let db = indexed_table();
+    let cc = one_batch(
+        &db,
+        &[&format!(
+            "INSERT INTO \"{TABLE}\" VALUE {{'pk':'m3','sk':'1','other':'o'}}"
+        )],
+    );
+    assert_eq!(cc.capacity_units, 1.0);
+    assert_eq!(table_arm(&cc), 1.0);
+    assert!(cc.global_secondary_indexes.is_none());
+}
+
+#[test]
+fn m5_two_inserts_sum_per_table() {
+    // Capture M5: total 4, table 2, gsi 2.
+    let db = indexed_table();
+    let cc = one_batch(
+        &db,
+        &[
+            &format!("INSERT INTO \"{TABLE}\" VALUE {{'pk':'m5','sk':'1','gsiPk':'g1'}}"),
+            &format!("INSERT INTO \"{TABLE}\" VALUE {{'pk':'m6','sk':'1','gsiPk':'g1'}}"),
+        ],
+    );
+    assert_eq!(cc.capacity_units, 4.0);
+    assert_eq!(table_arm(&cc), 2.0);
+    assert_eq!(gsi(&cc), Some(2.0));
+}
+
+#[test]
+fn m1_a_batch_where_nothing_succeeds_reports_no_capacity() {
+    // Capture M1: a lone failing statement reports no ConsumedCapacity at all,
+    // even though the same failure costs a unit when something else succeeds.
+    let db = indexed_table();
+    seed(
+        &db,
+        serde_json::json!({"pk": {"S": "m1"}, "sk": {"S": "1"}, "gsiPk": {"S": "g1"}}),
+    );
+
+    let entries = batch(
+        &db,
+        &[&format!(
+            "INSERT INTO \"{TABLE}\" VALUE {{'pk':'m1','sk':'1','gsiPk':'g1'}}"
+        )],
+        "INDEXES",
+    );
+    assert!(entries.is_none());
+}
+
+#[test]
+fn m4_a_failed_statement_reaches_the_total_but_no_arm() {
+    // Capture M4: one failing and one succeeding insert reports total 3 against
+    // arms summing to 2. The two rows do not reconcile into a rule, so both are
+    // pinned as measured rather than derived.
+    let db = indexed_table();
+    seed(
+        &db,
+        serde_json::json!({"pk": {"S": "m4"}, "sk": {"S": "1"}, "gsiPk": {"S": "g1"}}),
+    );
+
+    let cc = one_batch(
+        &db,
+        &[
+            &format!("INSERT INTO \"{TABLE}\" VALUE {{'pk':'m4','sk':'1','gsiPk':'g1'}}"),
+            &format!("INSERT INTO \"{TABLE}\" VALUE {{'pk':'m7','sk':'1','gsiPk':'g1'}}"),
+        ],
+    );
+    assert_eq!(cc.capacity_units, 3.0);
+    assert_eq!(table_arm(&cc), 1.0);
+    assert_eq!(gsi(&cc), Some(1.0));
+}
+
+#[test]
+fn r1_a_batch_update_is_sized_on_the_larger_image() {
+    // Capture R1: total 6, table 3, gsi 3, with no transactional factor.
+    let db = indexed_table();
+    seed(
+        &db,
+        serde_json::json!({
+            "pk": {"S": "r1"}, "sk": {"S": "1"},
+            "gsiPk": {"S": "g1"}, "proj": {"S": pad(3000)}
+        }),
+    );
+
+    let cc = one_batch(
+        &db,
+        &[&format!(
+            "UPDATE \"{TABLE}\" SET proj='p' WHERE pk='r1' AND sk='1'"
+        )],
+    );
+    assert_eq!(cc.capacity_units, 6.0);
+    assert_eq!(table_arm(&cc), 3.0);
+    assert_eq!(gsi(&cc), Some(3.0));
+}
+
+#[test]
+fn r2_a_batch_delete_charges_both_arms() {
+    // Capture R2: total 3, table 1, gsi 1, lsi 1.
+    let db = indexed_table();
+    seed(
+        &db,
+        serde_json::json!({
+            "pk": {"S": "r2"}, "sk": {"S": "1"},
+            "gsiPk": {"S": "g1"}, "lsiSk": {"S": "L1"}
+        }),
+    );
+
+    let cc = one_batch(
+        &db,
+        &[&format!("DELETE FROM \"{TABLE}\" WHERE pk='r2' AND sk='1'")],
+    );
+    assert_eq!(cc.capacity_units, 3.0);
+    assert_eq!(table_arm(&cc), 1.0);
+    assert_eq!(gsi(&cc), Some(1.0));
+    assert_eq!(lsi(&cc), Some(1.0));
+}
+
+#[test]
+fn h_a_batch_across_two_tables_reports_one_entry_each() {
+    // Capture H: per-table aggregation, each entry carrying only its own arms.
+    let db = indexed_table();
+    db.create_table(serde_json::from_value(table_def(OTHER_TABLE)).unwrap())
+        .unwrap();
+
+    let entries = batch(
+        &db,
+        &[
+            &format!(
+                "INSERT INTO \"{}\" VALUE {{'pk':'h1','sk':'1','gsiPk':'g1','lsiSk':'L1','proj':'{}'}}",
+                TABLE,
+                pad(3000)
+            ),
+            &format!("INSERT INTO \"{OTHER_TABLE}\" VALUE {{'pk':'h2','sk':'1','gsiPk':'g1'}}"),
+        ],
+        "INDEXES",
+    )
+    .expect("INDEXES mode reports capacity");
+
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].capacity_units, 9.0);
+    assert_eq!(table_arm(&entries[0]), 3.0);
+    assert_eq!(gsi(&entries[0]), Some(3.0));
+    assert_eq!(lsi(&entries[0]), Some(3.0));
+
+    assert_eq!(entries[1].capacity_units, 2.0);
+    assert_eq!(table_arm(&entries[1]), 1.0);
+    assert!(entries[1].local_secondary_indexes.is_none());
+}
+
+#[test]
+fn u2_a_failed_statement_is_charged_on_the_item_already_stored() {
+    // Capture U2: three failing inserts alongside one success report total 7
+    // against arms summing to 2. Two failures name tiny items and cost 1 each;
+    // the third also names a tiny item, but the row already at that key is 3KB,
+    // and it costs 3. Sizing the failure on the statement alone reports 5.
+    let db = indexed_table();
+    seed(
+        &db,
+        serde_json::json!({"pk": {"S": "u1"}, "sk": {"S": "1"}, "proj": {"S": pad(3000)}}),
+    );
+    seed(
+        &db,
+        serde_json::json!({"pk": {"S": "u3"}, "sk": {"S": "1"}}),
+    );
+    seed(
+        &db,
+        serde_json::json!({"pk": {"S": "u4"}, "sk": {"S": "1"}}),
+    );
+
+    let cc = one_batch(
+        &db,
+        &[
+            &format!("INSERT INTO \"{TABLE}\" VALUE {{'pk':'u3','sk':'1'}}"),
+            &format!("INSERT INTO \"{TABLE}\" VALUE {{'pk':'u4','sk':'1'}}"),
+            &format!("INSERT INTO \"{TABLE}\" VALUE {{'pk':'u1','sk':'1'}}"),
+            &format!("INSERT INTO \"{TABLE}\" VALUE {{'pk':'u5','sk':'1','gsiPk':'g1'}}"),
+        ],
+    );
+    assert_eq!(cc.capacity_units, 7.0);
+    assert_eq!(table_arm(&cc), 1.0);
+    assert_eq!(gsi(&cc), Some(1.0));
+}
+
+#[test]
+fn a_no_op_write_still_names_its_table() {
+    // An `IF NOT EXISTS` duplicate writes nothing, and the entry it produces
+    // must still carry the table. Building it from a defaulted record leaves
+    // the name empty and surfaces a nameless entry in the response.
+    let db = indexed_table();
+    seed(
+        &db,
+        serde_json::json!({"pk": {"S": "noop"}, "sk": {"S": "1"}, "gsiPk": {"S": "g1"}}),
+    );
+
+    let cc = one_batch(
+        &db,
+        &[&format!(
+            "INSERT INTO \"{TABLE}\" VALUE {{'pk':'noop','sk':'1'}} IF NOT EXISTS"
+        )],
+    );
+    assert_eq!(cc.table_name, TABLE);
+    assert!(cc.global_secondary_indexes.is_none());
+}
+
+#[test]
+fn v2_two_keyed_selects_on_one_item_are_rejected() {
+    // Capture V2: a read batch naming one item twice is rejected, the same way
+    // a write batch is. A SELECT that pins every key attribute resolves to a
+    // target; one spanning a partition does not.
+    let db = indexed_table();
+    seed(
+        &db,
+        serde_json::json!({"pk": {"S": "v1"}, "sk": {"S": "1"}}),
+    );
+
+    let req = serde_json::json!({
+        "Statements": [
+            {"Statement": format!("SELECT * FROM \"{TABLE}\" WHERE pk='v1' AND sk='1'")},
+            {"Statement": format!("SELECT * FROM \"{TABLE}\" WHERE pk='v1' AND sk='1'")}
+        ],
+        "ReturnConsumedCapacity": "INDEXES"
+    });
+    let err = db
+        .batch_execute_statement(serde_json::from_value(req).unwrap())
+        .expect_err("two reads of one item are rejected");
+    assert!(
+        err.to_string()
+            .contains("Provided list of item keys contains duplicates"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn v1_two_keyed_selects_on_distinct_items_are_charged_as_reads() {
+    // Capture V1: two keyed reads at 0.5 each, summed per table, no index arms.
+    let db = indexed_table();
+    seed(
+        &db,
+        serde_json::json!({"pk": {"S": "v1"}, "sk": {"S": "1"}}),
+    );
+    seed(
+        &db,
+        serde_json::json!({"pk": {"S": "v2"}, "sk": {"S": "1"}}),
+    );
+
+    let cc = one_batch(
+        &db,
+        &[
+            &format!("SELECT * FROM \"{TABLE}\" WHERE pk='v1' AND sk='1'"),
+            &format!("SELECT * FROM \"{TABLE}\" WHERE pk='v2' AND sk='1'"),
+        ],
+    );
+    assert_eq!(cc.capacity_units, 1.0);
+    assert!(cc.global_secondary_indexes.is_none());
+}
+
+#[test]
+fn w1_key_values_carrying_the_delimiter_are_not_confused() {
+    // Capture W1: AWS accepts these as two distinct items. Joining table, pk
+    // and sk on a delimiter is not injective once a key value contains it, so
+    // a naive dedup key rejects a batch that should be written.
+    let db = indexed_table();
+    let cc = one_batch(
+        &db,
+        &[
+            &format!("INSERT INTO \"{TABLE}\" VALUE {{'pk':'a#S:b','sk':'c'}}"),
+            &format!("INSERT INTO \"{TABLE}\" VALUE {{'pk':'a','sk':'b#S:c'}}"),
+        ],
+    );
+    assert_eq!(cc.capacity_units, 2.0);
+    assert_eq!(table_arm(&cc), 2.0);
+}
+
+#[test]
+fn a_batch_reports_nothing_without_a_mode() {
+    let db = indexed_table();
+    let req = serde_json::json!({
+        "Statements": [{
+            "Statement": format!(
+                "INSERT INTO \"{TABLE}\" VALUE {{'pk':'n1','sk':'1','gsiPk':'g1'}}"
+            )
+        }]
+    });
+    let response = db
+        .batch_execute_statement(serde_json::from_value(req).unwrap())
+        .unwrap();
+    assert!(response.consumed_capacity.is_none());
+}
+
+#[test]
+fn total_mode_folds_the_arms_in_without_a_breakdown() {
+    let db = indexed_table();
+    let mut entries = batch(
+        &db,
+        &[&format!(
+            "INSERT INTO \"{TABLE}\" VALUE {{'pk':'t1','sk':'1','gsiPk':'g1','lsiSk':'L1'}}"
+        )],
+        "TOTAL",
+    )
+    .expect("TOTAL reports capacity");
+
+    let cc = entries.remove(0);
+    assert_eq!(cc.capacity_units, 3.0);
+    assert!(cc.table.is_none());
+    assert!(cc.global_secondary_indexes.is_none());
+    assert!(cc.local_secondary_indexes.is_none());
+}

--- a/tests/transactional_index_consumed_capacity.rs
+++ b/tests/transactional_index_consumed_capacity.rs
@@ -1,0 +1,844 @@
+//! Per-index `ConsumedCapacity` on transactional writes.
+//!
+//! Every figure asserted here was measured against real DynamoDB in eu-west-2 on
+//! 13 August 2026, against a table keyed `pk`/`sk` with a GSI `gsi-inc` on
+//! `gsiPk` projecting `INCLUDE [proj]` and an LSI `lsi-all` on `pk`/`lsiSk`
+//! projecting `ALL`. Case labels (A1, B7, K3) refer to that capture.
+//!
+//! The rule the capture settled, and the one these tests exist to hold: the
+//! transactional 2x factor applies to the base table arm alone. Index arms
+//! inside a transaction cost what the same write costs outside one. A GSI key
+//! move at 1517B per side charges the index 4 while the table arm on that same
+//! write doubles from 2 to 4, and the two fours have different arithmetic
+//! behind them.
+
+use dynoxide::Database;
+use dynoxide::types::{CapacityDetail, ConsumedCapacity};
+use std::collections::HashMap;
+
+const TABLE: &str = "tx_idx_wcu";
+const OTHER_TABLE: &str = "tx_idx_wcu_b";
+
+fn table_def(name: &str) -> serde_json::Value {
+    serde_json::json!({
+        "TableName": name,
+        "KeySchema": [
+            {"AttributeName": "pk", "KeyType": "HASH"},
+            {"AttributeName": "sk", "KeyType": "RANGE"}
+        ],
+        "AttributeDefinitions": [
+            {"AttributeName": "pk", "AttributeType": "S"},
+            {"AttributeName": "sk", "AttributeType": "S"},
+            {"AttributeName": "gsiPk", "AttributeType": "S"},
+            {"AttributeName": "lsiSk", "AttributeType": "S"}
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+        "GlobalSecondaryIndexes": [{
+            "IndexName": "gsi-inc",
+            "KeySchema": [{"AttributeName": "gsiPk", "KeyType": "HASH"}],
+            "Projection": {"ProjectionType": "INCLUDE", "NonKeyAttributes": ["proj"]}
+        }],
+        "LocalSecondaryIndexes": [{
+            "IndexName": "lsi-all",
+            "KeySchema": [
+                {"AttributeName": "pk", "KeyType": "HASH"},
+                {"AttributeName": "lsiSk", "KeyType": "RANGE"}
+            ],
+            "Projection": {"ProjectionType": "ALL"}
+        }]
+    })
+}
+
+fn indexed_table() -> Database {
+    let db = Database::memory().unwrap();
+    db.create_table(serde_json::from_value(table_def(TABLE)).unwrap())
+        .unwrap();
+    db
+}
+
+fn pad(n: usize) -> String {
+    "x".repeat(n)
+}
+
+/// PutItem without asking for capacity, for setting a case up.
+fn seed(db: &Database, table: &str, item: serde_json::Value) {
+    let req = serde_json::json!({"TableName": table, "Item": item});
+    db.put_item(serde_json::from_value(req).unwrap()).unwrap();
+}
+
+/// Run a transaction and return its per-table capacity entries.
+fn tx(db: &Database, actions: serde_json::Value, mode: &str) -> Vec<ConsumedCapacity> {
+    let req = serde_json::json!({
+        "TransactItems": actions,
+        "ReturnConsumedCapacity": mode
+    });
+    db.transact_write_items(serde_json::from_value(req).unwrap())
+        .unwrap()
+        .consumed_capacity
+        .expect("TOTAL and INDEXES report capacity")
+}
+
+/// Run a single-table transaction and return that table's entry.
+fn one(db: &Database, actions: serde_json::Value) -> ConsumedCapacity {
+    let mut entries = tx(db, actions, "INDEXES");
+    assert_eq!(entries.len(), 1, "expected one table in the response");
+    entries.remove(0)
+}
+
+fn arm(map: &Option<HashMap<String, CapacityDetail>>, name: &str) -> Option<f64> {
+    map.as_ref()
+        .and_then(|m| m.get(name))
+        .map(|d| d.capacity_units)
+}
+
+fn gsi(cc: &ConsumedCapacity) -> Option<f64> {
+    arm(&cc.global_secondary_indexes, "gsi-inc")
+}
+
+fn lsi(cc: &ConsumedCapacity) -> Option<f64> {
+    arm(&cc.local_secondary_indexes, "lsi-all")
+}
+
+fn table_arm(cc: &ConsumedCapacity) -> f64 {
+    cc.table
+        .as_ref()
+        .expect("INDEXES reports a Table detail")
+        .capacity_units
+}
+
+fn put_action(table: &str, item: serde_json::Value) -> serde_json::Value {
+    serde_json::json!({"Put": {"TableName": table, "Item": item}})
+}
+
+// ---------------------------------------------------------------------------
+// Structure, all sub-1KB. Capture round A.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a1_put_of_a_gsi_member_charges_the_index_undoubled() {
+    // Capture A1: total 3, table 2, gsi 1. The single-item equivalent is
+    // total 2, table 1, gsi 1, so the table arm doubles and the index arm
+    // does not. This is the assertion the whole change rests on.
+    let db = indexed_table();
+    let cc = one(
+        &db,
+        serde_json::json!([put_action(
+            TABLE,
+            serde_json::json!({"pk": {"S": "a1"}, "sk": {"S": "1"}, "gsiPk": {"S": "g1"}})
+        )]),
+    );
+
+    assert_eq!(cc.capacity_units, 3.0);
+    assert_eq!(table_arm(&cc), 2.0);
+    assert_eq!(gsi(&cc), Some(1.0));
+    assert_eq!(lsi(&cc), None);
+}
+
+#[test]
+fn a2_put_of_a_member_of_neither_index_reports_no_arms() {
+    // Capture A2: total 2, table 2, no arms at all.
+    let db = indexed_table();
+    let cc = one(
+        &db,
+        serde_json::json!([put_action(
+            TABLE,
+            serde_json::json!({"pk": {"S": "a2"}, "sk": {"S": "1"}, "other": {"S": "o"}})
+        )]),
+    );
+
+    assert_eq!(cc.capacity_units, 2.0);
+    assert_eq!(table_arm(&cc), 2.0);
+    assert!(cc.global_secondary_indexes.is_none());
+    assert!(cc.local_secondary_indexes.is_none());
+}
+
+#[test]
+fn a3_put_of_a_member_of_both_indexes_charges_both_arms() {
+    // Capture A3: total 4, table 2, gsi 1, lsi 1.
+    let db = indexed_table();
+    let cc = one(
+        &db,
+        serde_json::json!([put_action(
+            TABLE,
+            serde_json::json!({
+                "pk": {"S": "a3"}, "sk": {"S": "1"},
+                "gsiPk": {"S": "g1"}, "lsiSk": {"S": "L1"}, "proj": {"S": "p"}
+            })
+        )]),
+    );
+
+    assert_eq!(cc.capacity_units, 4.0);
+    assert_eq!(table_arm(&cc), 2.0);
+    assert_eq!(gsi(&cc), Some(1.0));
+    assert_eq!(lsi(&cc), Some(1.0));
+}
+
+#[test]
+fn a4_identical_overwrite_charges_the_table_and_no_index() {
+    // Capture A4: total 2, table 2, no arms. The write still costs its table
+    // arm; only the untouched index views go free.
+    let db = indexed_table();
+    let item = serde_json::json!({
+        "pk": {"S": "a4"}, "sk": {"S": "1"},
+        "gsiPk": {"S": "g1"}, "lsiSk": {"S": "L1"}
+    });
+    seed(&db, TABLE, item.clone());
+
+    let cc = one(&db, serde_json::json!([put_action(TABLE, item)]));
+    assert_eq!(cc.capacity_units, 2.0);
+    assert_eq!(table_arm(&cc), 2.0);
+    assert_eq!(gsi(&cc), None);
+    assert_eq!(lsi(&cc), None);
+}
+
+#[test]
+fn a5_update_outside_the_gsi_projection_charges_only_the_lsi() {
+    // Capture A5: total 3, table 2, lsi 1, no GSI arm. `other` is outside the
+    // GSI's INCLUDE list but inside the LSI's ALL projection.
+    let db = indexed_table();
+    seed(
+        &db,
+        TABLE,
+        serde_json::json!({
+            "pk": {"S": "a5"}, "sk": {"S": "1"},
+            "gsiPk": {"S": "g1"}, "lsiSk": {"S": "L1"}, "other": {"S": "o"}
+        }),
+    );
+
+    let cc = one(
+        &db,
+        serde_json::json!([{"Update": {
+            "TableName": TABLE,
+            "Key": {"pk": {"S": "a5"}, "sk": {"S": "1"}},
+            "UpdateExpression": "SET #o = :v",
+            "ExpressionAttributeNames": {"#o": "other"},
+            "ExpressionAttributeValues": {":v": {"S": "o2"}}
+        }}]),
+    );
+
+    assert_eq!(cc.capacity_units, 3.0);
+    assert_eq!(table_arm(&cc), 2.0);
+    assert_eq!(gsi(&cc), None);
+    assert_eq!(lsi(&cc), Some(1.0));
+}
+
+#[test]
+fn a7_moving_a_gsi_key_charges_the_index_twice_undoubled() {
+    // Capture A7: total 5, table 2, gsi 2, lsi 1. A move is a delete plus an
+    // insert; the transactional factor does not touch either half.
+    let db = indexed_table();
+    seed(
+        &db,
+        TABLE,
+        serde_json::json!({
+            "pk": {"S": "a7"}, "sk": {"S": "1"},
+            "gsiPk": {"S": "g1"}, "lsiSk": {"S": "L1"}
+        }),
+    );
+
+    let cc = one(
+        &db,
+        serde_json::json!([{"Update": {
+            "TableName": TABLE,
+            "Key": {"pk": {"S": "a7"}, "sk": {"S": "1"}},
+            "UpdateExpression": "SET gsiPk = :v",
+            "ExpressionAttributeValues": {":v": {"S": "g2"}}
+        }}]),
+    );
+
+    assert_eq!(cc.capacity_units, 5.0);
+    assert_eq!(table_arm(&cc), 2.0);
+    assert_eq!(gsi(&cc), Some(2.0));
+    assert_eq!(lsi(&cc), Some(1.0));
+}
+
+#[test]
+fn a10_delete_of_an_item_in_both_indexes_charges_both_arms() {
+    // Capture A10: total 4, table 2, gsi 1, lsi 1.
+    let db = indexed_table();
+    seed(
+        &db,
+        TABLE,
+        serde_json::json!({
+            "pk": {"S": "a10"}, "sk": {"S": "1"},
+            "gsiPk": {"S": "g1"}, "lsiSk": {"S": "L1"}
+        }),
+    );
+
+    let cc = one(
+        &db,
+        serde_json::json!([{"Delete": {
+            "TableName": TABLE,
+            "Key": {"pk": {"S": "a10"}, "sk": {"S": "1"}}
+        }}]),
+    );
+
+    assert_eq!(cc.capacity_units, 4.0);
+    assert_eq!(table_arm(&cc), 2.0);
+    assert_eq!(gsi(&cc), Some(1.0));
+    assert_eq!(lsi(&cc), Some(1.0));
+}
+
+#[test]
+fn a12_condition_check_charges_the_table_and_no_index() {
+    // Capture A12: total 2, table 2, no arms. A check touches no index view.
+    let db = indexed_table();
+    seed(
+        &db,
+        TABLE,
+        serde_json::json!({
+            "pk": {"S": "a12"}, "sk": {"S": "1"},
+            "gsiPk": {"S": "g1"}, "lsiSk": {"S": "L1"}
+        }),
+    );
+
+    let cc = one(
+        &db,
+        serde_json::json!([{"ConditionCheck": {
+            "TableName": TABLE,
+            "Key": {"pk": {"S": "a12"}, "sk": {"S": "1"}},
+            "ConditionExpression": "attribute_exists(pk)"
+        }}]),
+    );
+
+    assert_eq!(cc.capacity_units, 2.0);
+    assert_eq!(table_arm(&cc), 2.0);
+    assert!(cc.global_secondary_indexes.is_none());
+    assert!(cc.local_secondary_indexes.is_none());
+}
+
+#[test]
+fn a13_two_actions_on_one_table_sum_every_arm() {
+    // Capture A13: total 8, table 4, gsi 2, lsi 2.
+    let db = indexed_table();
+    let cc = one(
+        &db,
+        serde_json::json!([
+            put_action(
+                TABLE,
+                serde_json::json!({
+                    "pk": {"S": "a13"}, "sk": {"S": "1"},
+                    "gsiPk": {"S": "g1"}, "lsiSk": {"S": "L1"}
+                })
+            ),
+            put_action(
+                TABLE,
+                serde_json::json!({
+                    "pk": {"S": "a14"}, "sk": {"S": "1"},
+                    "gsiPk": {"S": "g1"}, "lsiSk": {"S": "L1"}
+                })
+            )
+        ]),
+    );
+
+    assert_eq!(cc.capacity_units, 8.0);
+    assert_eq!(table_arm(&cc), 4.0);
+    assert_eq!(gsi(&cc), Some(2.0));
+    assert_eq!(lsi(&cc), Some(2.0));
+}
+
+// ---------------------------------------------------------------------------
+// Sizing past 1KB. Capture round B, plus F and J.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn b5_delete_is_sized_on_the_stored_image_not_the_key() {
+    // Capture B5: total 9, table 6, gsi 3. Sizing the delete on its request
+    // payload, which carries only the key, reports total 2.
+    let db = indexed_table();
+    seed(
+        &db,
+        TABLE,
+        serde_json::json!({
+            "pk": {"S": "b5"}, "sk": {"S": "1"},
+            "gsiPk": {"S": "g1"}, "proj": {"S": pad(3000)}
+        }),
+    );
+
+    let cc = one(
+        &db,
+        serde_json::json!([{"Delete": {
+            "TableName": TABLE,
+            "Key": {"pk": {"S": "b5"}, "sk": {"S": "1"}}
+        }}]),
+    );
+
+    assert_eq!(table_arm(&cc), 6.0);
+    assert_eq!(gsi(&cc), Some(3.0));
+    assert_eq!(cc.capacity_units, 9.0);
+}
+
+#[test]
+fn b3_a_shrinking_put_is_sized_on_the_image_it_replaced() {
+    // Capture B3: total 6, table 6. Sizing on the request item alone reports 2.
+    let db = indexed_table();
+    seed(
+        &db,
+        TABLE,
+        serde_json::json!({"pk": {"S": "b3"}, "sk": {"S": "1"}, "other": {"S": pad(3000)}}),
+    );
+
+    let cc = one(
+        &db,
+        serde_json::json!([put_action(
+            TABLE,
+            serde_json::json!({"pk": {"S": "b3"}, "sk": {"S": "1"}})
+        )]),
+    );
+
+    assert_eq!(cc.capacity_units, 6.0);
+    assert_eq!(table_arm(&cc), 6.0);
+}
+
+#[test]
+fn b7_a_key_move_doubles_its_table_arm_and_leaves_its_index_arm_alone() {
+    // Capture B7: total 8, table 4, gsi 4. Both arms read 4 and neither is the
+    // other's arithmetic: the table is 2 x ceil(1.5KB) and the GSI is
+    // ceil(1517) + ceil(1517), undoubled. Doubling the index arm reports 12.
+    let db = indexed_table();
+    seed(
+        &db,
+        TABLE,
+        serde_json::json!({
+            "pk": {"S": "b7"}, "sk": {"S": "1"},
+            "gsiPk": {"S": "g1"}, "proj": {"S": pad(1500)}
+        }),
+    );
+
+    let cc = one(
+        &db,
+        serde_json::json!([{"Update": {
+            "TableName": TABLE,
+            "Key": {"pk": {"S": "b7"}, "sk": {"S": "1"}},
+            "UpdateExpression": "SET gsiPk = :v",
+            "ExpressionAttributeValues": {":v": {"S": "g9"}}
+        }}]),
+    );
+
+    assert_eq!(cc.capacity_units, 8.0);
+    assert_eq!(table_arm(&cc), 4.0);
+    assert_eq!(gsi(&cc), Some(4.0));
+}
+
+#[test]
+fn j3_an_update_shrinking_an_entry_holds_the_larger_image() {
+    // Capture J3: total 9, table 6, gsi 3. Both arms hold the pre-image.
+    let db = indexed_table();
+    seed(
+        &db,
+        TABLE,
+        serde_json::json!({
+            "pk": {"S": "j3"}, "sk": {"S": "1"},
+            "gsiPk": {"S": "g1"}, "proj": {"S": pad(3000)}
+        }),
+    );
+
+    let cc = one(
+        &db,
+        serde_json::json!([{"Update": {
+            "TableName": TABLE,
+            "Key": {"pk": {"S": "j3"}, "sk": {"S": "1"}},
+            "UpdateExpression": "SET proj = :v",
+            "ExpressionAttributeValues": {":v": {"S": "p"}}
+        }}]),
+    );
+
+    assert_eq!(cc.capacity_units, 9.0);
+    assert_eq!(table_arm(&cc), 6.0);
+    assert_eq!(gsi(&cc), Some(3.0));
+}
+
+#[test]
+fn f1_condition_check_is_sized_on_the_image_it_reads() {
+    // Capture F1: total 6, table 6. A check writes nothing and is still charged
+    // on the item it looked at. Sizing on the key reports 2.
+    let db = indexed_table();
+    seed(
+        &db,
+        TABLE,
+        serde_json::json!({"pk": {"S": "f1"}, "sk": {"S": "1"}, "other": {"S": pad(3000)}}),
+    );
+
+    let cc = one(
+        &db,
+        serde_json::json!([{"ConditionCheck": {
+            "TableName": TABLE,
+            "Key": {"pk": {"S": "f1"}, "sk": {"S": "1"}},
+            "ConditionExpression": "attribute_exists(pk)"
+        }}]),
+    );
+
+    assert_eq!(cc.capacity_units, 6.0);
+    assert_eq!(table_arm(&cc), 6.0);
+}
+
+#[test]
+fn f4_an_update_that_creates_the_item_charges_each_index_once() {
+    // Capture F4: total 4, table 2, gsi 1, lsi 1. The update injects the key
+    // attributes for the upsert, so charging against the assembled item rather
+    // than the stored one would read as a key move and report gsi 2.
+    let db = indexed_table();
+    let cc = one(
+        &db,
+        serde_json::json!([{"Update": {
+            "TableName": TABLE,
+            "Key": {"pk": {"S": "f4"}, "sk": {"S": "1"}},
+            "UpdateExpression": "SET gsiPk = :g, lsiSk = :l",
+            "ExpressionAttributeValues": {":g": {"S": "g1"}, ":l": {"S": "L1"}}
+        }}]),
+    );
+
+    assert_eq!(cc.capacity_units, 4.0);
+    assert_eq!(table_arm(&cc), 2.0);
+    assert_eq!(gsi(&cc), Some(1.0));
+    assert_eq!(lsi(&cc), Some(1.0));
+}
+
+// ---------------------------------------------------------------------------
+// Missing targets and no-ops. Capture round K.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn k1_delete_of_a_missing_target_costs_the_minimum() {
+    // Capture K1: total 2, table 2, no arms.
+    let db = indexed_table();
+    let cc = one(
+        &db,
+        serde_json::json!([{"Delete": {
+            "TableName": TABLE,
+            "Key": {"pk": {"S": "k1"}, "sk": {"S": "1"}}
+        }}]),
+    );
+
+    assert_eq!(cc.capacity_units, 2.0);
+    assert_eq!(table_arm(&cc), 2.0);
+    assert!(cc.global_secondary_indexes.is_none());
+}
+
+#[test]
+fn k3_identical_overwrite_of_a_large_item_charges_the_table_alone() {
+    // Capture K3: total 6, table 6, no arms. The table arm and the index arms
+    // are independent readings of the same write.
+    let db = indexed_table();
+    let item = serde_json::json!({
+        "pk": {"S": "k3"}, "sk": {"S": "1"},
+        "gsiPk": {"S": "g1"}, "proj": {"S": pad(3000)}
+    });
+    seed(&db, TABLE, item.clone());
+
+    let cc = one(&db, serde_json::json!([put_action(TABLE, item)]));
+    assert_eq!(cc.capacity_units, 6.0);
+    assert_eq!(table_arm(&cc), 6.0);
+    assert_eq!(gsi(&cc), None);
+}
+
+// ---------------------------------------------------------------------------
+// Multi-table, modes, and the cancellation path.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn g1_each_table_carries_only_its_own_arms() {
+    // Capture G1: the indexed member reports total 4 with both arms, the
+    // GSI-only member total 3 with one. Entries are sorted by table name so the
+    // response order does not shift between calls.
+    let db = indexed_table();
+    db.create_table(serde_json::from_value(table_def(OTHER_TABLE)).unwrap())
+        .unwrap();
+
+    let entries = tx(
+        &db,
+        serde_json::json!([
+            put_action(
+                TABLE,
+                serde_json::json!({
+                    "pk": {"S": "g1"}, "sk": {"S": "1"},
+                    "gsiPk": {"S": "g1"}, "lsiSk": {"S": "L1"}
+                })
+            ),
+            put_action(
+                OTHER_TABLE,
+                serde_json::json!({
+                    "pk": {"S": "g1"}, "sk": {"S": "1"}, "gsiPk": {"S": "g1"}
+                })
+            )
+        ]),
+        "INDEXES",
+    );
+
+    assert_eq!(entries.len(), 2);
+    let names: Vec<&str> = entries.iter().map(|e| e.table_name.as_str()).collect();
+    assert_eq!(names, vec![TABLE, OTHER_TABLE]);
+
+    let first = &entries[0];
+    assert_eq!(first.capacity_units, 4.0);
+    assert_eq!(gsi(first), Some(1.0));
+    assert_eq!(lsi(first), Some(1.0));
+
+    let second = &entries[1];
+    assert_eq!(second.capacity_units, 3.0);
+    assert_eq!(gsi(second), Some(1.0));
+    assert!(second.local_secondary_indexes.is_none());
+}
+
+#[test]
+fn total_mode_folds_the_index_arms_in_and_reports_no_breakdown() {
+    // Capture A3 under TOTAL: the same total, with no Table detail and no arms.
+    let db = indexed_table();
+    let mut entries = tx(
+        &db,
+        serde_json::json!([put_action(
+            TABLE,
+            serde_json::json!({
+                "pk": {"S": "t1"}, "sk": {"S": "1"},
+                "gsiPk": {"S": "g1"}, "lsiSk": {"S": "L1"}
+            })
+        )]),
+        "TOTAL",
+    );
+
+    let cc = entries.remove(0);
+    assert_eq!(cc.capacity_units, 4.0);
+    assert_eq!(cc.write_capacity_units, Some(4.0));
+    assert!(cc.table.is_none());
+    assert!(cc.global_secondary_indexes.is_none());
+    assert!(cc.local_secondary_indexes.is_none());
+}
+
+#[test]
+fn the_write_axis_is_reported_at_every_level() {
+    // The transactional shape mirrors its units into WriteCapacityUnits at the
+    // top level, on the Table detail, and on each index arm. The single-item
+    // shape reports CapacityUnits alone, which is why the two builders differ.
+    let db = indexed_table();
+    let cc = one(
+        &db,
+        serde_json::json!([put_action(
+            TABLE,
+            serde_json::json!({
+                "pk": {"S": "w1"}, "sk": {"S": "1"},
+                "gsiPk": {"S": "g1"}, "lsiSk": {"S": "L1"}
+            })
+        )]),
+    );
+
+    assert_eq!(cc.write_capacity_units, Some(4.0));
+    assert_eq!(
+        cc.table.as_ref().unwrap().write_capacity_units,
+        Some(2.0),
+        "the Table detail carries the write axis"
+    );
+    let gsi_detail = cc.global_secondary_indexes.as_ref().unwrap();
+    assert_eq!(
+        gsi_detail.get("gsi-inc").unwrap().write_capacity_units,
+        Some(1.0),
+        "each index arm carries the write axis too"
+    );
+}
+
+#[test]
+fn no_capacity_is_reported_without_a_mode() {
+    let db = indexed_table();
+    let req = serde_json::json!({
+        "TransactItems": [put_action(
+            TABLE,
+            serde_json::json!({"pk": {"S": "n1"}, "sk": {"S": "1"}, "gsiPk": {"S": "g1"}})
+        )]
+    });
+    let response = db
+        .transact_write_items(serde_json::from_value(req).unwrap())
+        .unwrap();
+    assert!(response.consumed_capacity.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Same-token replay. Captured 13 August 2026, round S.
+// ---------------------------------------------------------------------------
+
+/// Run the same tokened transaction twice and return both capacity totals.
+fn first_and_replay(db: &Database, actions: serde_json::Value, token: &str) -> (f64, f64) {
+    let req = serde_json::json!({
+        "TransactItems": actions,
+        "ReturnConsumedCapacity": "TOTAL",
+        "ClientRequestToken": token
+    });
+    let total = |r: dynoxide::actions::transact_write_items::TransactWriteItemsResponse| {
+        r.consumed_capacity
+            .expect("TOTAL reports capacity")
+            .iter()
+            .map(|c| c.capacity_units)
+            .sum::<f64>()
+    };
+    let first = total(
+        db.transact_write_items(serde_json::from_value(req.clone()).unwrap())
+            .unwrap(),
+    );
+    let replay = total(
+        db.transact_write_items(serde_json::from_value(req).unwrap())
+            .unwrap(),
+    );
+    (first, replay)
+}
+
+#[test]
+fn s1_a_replayed_shrinking_put_is_sized_on_the_image_it_replaced() {
+    // Capture S1: a put shrinking a ~9KB item reports 18 on the first call and
+    // 6 on the replay. Sizing the replay on the after image alone reports 2, so
+    // this row is what rules that reading out.
+    let db = indexed_table();
+    seed(
+        &db,
+        TABLE,
+        serde_json::json!({"pk": {"S": "s1"}, "sk": {"S": "1"}, "proj": {"S": pad(9000)}}),
+    );
+
+    let (first, replay) = first_and_replay(
+        &db,
+        serde_json::json!([put_action(
+            TABLE,
+            serde_json::json!({"pk": {"S": "s1"}, "sk": {"S": "1"}})
+        )]),
+        "replay-shrink",
+    );
+    assert_eq!(first, 18.0);
+    assert_eq!(replay, 6.0);
+}
+
+#[test]
+fn s2_a_replayed_growing_put_is_sized_on_the_image_it_wrote() {
+    // Capture S2: the mirror of S1, ruling out sizing on the before image
+    // alone, which would report 2.
+    let db = indexed_table();
+    seed(
+        &db,
+        TABLE,
+        serde_json::json!({"pk": {"S": "s2"}, "sk": {"S": "1"}, "other": {"S": "o"}}),
+    );
+
+    let (first, replay) = first_and_replay(
+        &db,
+        serde_json::json!([put_action(
+            TABLE,
+            serde_json::json!({"pk": {"S": "s2"}, "sk": {"S": "1"}, "proj": {"S": pad(9000)}})
+        )]),
+        "replay-grow",
+    );
+    assert_eq!(first, 18.0);
+    assert_eq!(replay, 6.0);
+}
+
+#[test]
+fn r1_a_replayed_delete_is_sized_on_the_stored_image_not_the_key() {
+    // Capture R1: a delete of a ~9KB item reports 18 on the first call and 6 on
+    // the replay. The request carries only the key, so sizing the replay from
+    // the request reports 2.
+    let db = indexed_table();
+    seed(
+        &db,
+        TABLE,
+        serde_json::json!({"pk": {"S": "r1"}, "sk": {"S": "1"}, "proj": {"S": pad(9000)}}),
+    );
+
+    let (first, replay) = first_and_replay(
+        &db,
+        serde_json::json!([{"Delete": {
+            "TableName": TABLE,
+            "Key": {"pk": {"S": "r1"}, "sk": {"S": "1"}}
+        }}]),
+        "replay-delete",
+    );
+    assert_eq!(first, 18.0);
+    assert_eq!(replay, 6.0);
+}
+
+#[test]
+fn r2_a_replayed_condition_check_is_sized_on_the_image_it_read() {
+    // Capture R2: same figures as the delete, against an action that writes
+    // nothing at all.
+    let db = indexed_table();
+    seed(
+        &db,
+        TABLE,
+        serde_json::json!({"pk": {"S": "r2"}, "sk": {"S": "1"}, "proj": {"S": pad(9000)}}),
+    );
+
+    let (first, replay) = first_and_replay(
+        &db,
+        serde_json::json!([{"ConditionCheck": {
+            "TableName": TABLE,
+            "Key": {"pk": {"S": "r2"}, "sk": {"S": "1"}},
+            "ConditionExpression": "attribute_exists(pk)"
+        }}]),
+        "replay-check",
+    );
+    assert_eq!(first, 18.0);
+    assert_eq!(replay, 6.0);
+}
+
+#[test]
+fn s3_a_replay_sums_its_actions_before_the_transactional_factor() {
+    // Capture S3: a ~9KB delete alongside a small put reports 20 on the first
+    // call and 8 on the replay, which is 6 + 2 rather than one rounding of the
+    // summed bytes.
+    let db = indexed_table();
+    seed(
+        &db,
+        TABLE,
+        serde_json::json!({"pk": {"S": "s3"}, "sk": {"S": "1"}, "proj": {"S": pad(9000)}}),
+    );
+
+    let (first, replay) = first_and_replay(
+        &db,
+        serde_json::json!([
+            {"Delete": {"TableName": TABLE, "Key": {"pk": {"S": "s3"}, "sk": {"S": "1"}}}},
+            put_action(
+                TABLE,
+                serde_json::json!({"pk": {"S": "s4"}, "sk": {"S": "1"}, "other": {"S": "o"}})
+            )
+        ]),
+        "replay-pair",
+    );
+    assert_eq!(first, 20.0);
+    assert_eq!(replay, 8.0);
+}
+
+#[test]
+fn a_cancelled_transaction_reports_no_capacity_at_all() {
+    // The per-action records accumulate inside the transaction and are dropped
+    // with the error, so a cancellation carries no partial bill.
+    let db = indexed_table();
+    let req = serde_json::json!({
+        "TransactItems": [
+            put_action(
+                TABLE,
+                serde_json::json!({
+                    "pk": {"S": "c1"}, "sk": {"S": "1"}, "gsiPk": {"S": "g1"}
+                })
+            ),
+            {"ConditionCheck": {
+                "TableName": TABLE,
+                "Key": {"pk": {"S": "missing"}, "sk": {"S": "1"}},
+                "ConditionExpression": "attribute_exists(pk)"
+            }}
+        ],
+        "ReturnConsumedCapacity": "INDEXES"
+    });
+
+    let err = db
+        .transact_write_items(serde_json::from_value(req).unwrap())
+        .expect_err("the condition check fails, cancelling the transaction");
+    assert!(
+        err.to_string().contains("Transaction cancelled"),
+        "unexpected error: {err}"
+    );
+
+    // The failed transaction rolled back, so the put left nothing behind.
+    let get = serde_json::json!({
+        "TableName": TABLE,
+        "Key": {"pk": {"S": "c1"}, "sk": {"S": "1"}}
+    });
+    let found = db
+        .get_item(serde_json::from_value(get).unwrap())
+        .unwrap()
+        .item;
+    assert!(found.is_none(), "a cancelled transaction writes nothing");
+}


### PR DESCRIPTION
Closes #178.

## What this changes

`TransactWriteItems`, `ExecuteStatement`, `ExecuteTransaction` and
`BatchExecuteStatement` reported a `Table` arm and nothing else under `INDEXES`.
They now report the per-index breakdown the single-item paths already did, and the
index units fold into the total, so figures move under `TOTAL` as well on an
indexed table.

The rule that decides this, and the one worth reviewing carefully, is that the
transactional 2x factor applies to the base table arm alone. An index arm inside a
transaction costs what the same write costs outside one. A GSI key move charges the
index the same either way while the table arm doubles.

Checking that against real DynamoDB turned up four more divergences in the same
paths, all fixed here:

- The transactional table arm was sized on the request rather than on the item.
  `Delete` and `ConditionCheck` carry a key and no item, so both were sized on the
  key: deleting a 3KB item reported 2 units against DynamoDB's 6. A `ConditionCheck`
  writes nothing and is still charged on the image it read.
- A same-token replay recomputed from the request, which has the same problem. A
  replayed delete of a 9KB item reported 2 against DynamoDB's 6. It is now charged
  against the images the first call was sized on, at 4KB read granularity.
- `BatchExecuteStatement` had no way to report capacity at all. It now accepts
  `ReturnConsumedCapacity` and aggregates per table across the batch. A failed
  statement is still charged the write it attempted, sized on the row already
  stored rather than on the item the statement carried.
- Four request shapes DynamoDB rejects were accepted. A batch or transaction may
  not mix reads with writes, and may not name the same item twice, reads included.
  Both surfaces now reject both, top level, before any statement runs.

Everything above is captured against eu-west-2, 74 rows across the four surfaces.

## Two things reviewers should know

**This is behaviour-breaking twice over.** A request that previously succeeded in a
mixed or duplicate shape now fails, and the reported numbers change. Both are
covered in `CHANGELOG.md`.

**It costs about 7% on a 25-statement `BatchExecuteStatement`**, measured against
`958e340`. That is the price of the four validations, and it is stated in the
changelog beside them rather than left for someone to find.

## Checklist

- [x] Tests added or updated
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` pass locally
- [x] `CHANGELOG.md` updated if this is a user-visible change
- [x] Linked issue, discussion, or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms
  (MIT License and Apache License, Version 2.0)

## DynamoDB compatibility note

This moves dynoxide towards DynamoDB on every point above, and each figure is
pinned to a captured value rather than to a derivation. One gap is deliberately
left: a PartiQL `SELECT` against an index still scans the base table and drops its
`WHERE` clause, so its capacity lands on the wrong arm. That is a data-correctness
bug rather than a capacity one, it is tracked as #179, and fixing the capacity
figure before the qualifier is honoured would pin the wrong number.
