### PR TITLE
fix: read the criterion output a cached baseline directory breaks apart

### DIFF
--- a/.github/workflows/benchmark-refresh.yml
+++ b/.github/workflows/benchmark-refresh.yml
@@ -201,7 +201,13 @@ jobs:
           status=$?
           set -e
 
-          if [ "$status" -ne 0 ] && [ "$status" -ne 3 ]; then
+          # Exit 4 lost benchmarks but still wrote a comparison naming them,
+          # which is exactly what the reviewer of this PR needs to see.
+          if [ "$status" -eq 4 ]; then
+            echo "::warning::criterion run produced no result for some benchmarks"
+          fi
+
+          if [ "$status" -ne 0 ] && [ "$status" -ne 3 ] && [ "$status" -ne 4 ]; then
             echo "::warning::criterion comparison failed (exit $status)"
             echo "_Criterion comparison unavailable; see the run log._" >> /tmp/pr_body.md
           else

--- a/.github/workflows/benchmark-refresh.yml
+++ b/.github/workflows/benchmark-refresh.yml
@@ -153,14 +153,26 @@ jobs:
         shell: bash
         run: |
           cd benchmarks
+          # A cache hit brings target/criterion back with the per-benchmark
+          # base directory present but no sample.json in it. Criterion takes
+          # that as a baseline to compare against, fails to read it, and prints
+          # the error into the middle of the result line it was writing. Start
+          # from nothing so the output stays parseable.
+          rm -rf target/criterion
           cargo bench --bench embedded_micro -- --output-format bencher | tee criterion_output.txt
           python3 -c "
-          import json, re
-          results = {}
-          for line in open('criterion_output.txt'):
-              m = re.match(r'^test\s+(.+?)\s+\.\.\.\s+bench:\s+([\d,]+)\s+ns/iter', line)
-              if m:
-                  results[m.group(1)] = int(m.group(2).replace(',', ''))
+          import json, sys
+          sys.path.insert(0, 'scripts')
+          from compare_criterion import parse_bencher
+          with open('criterion_output.txt') as handle:
+              results = parse_bencher(handle.read())
+          # An empty baseline stored on benchmark-data is skipped by every
+          # later comparison, quietly shrinking the window the median rests on.
+          # Failing here stops the store and the README PR as well, so a refresh
+          # that cannot read its own criterion numbers publishes none of them.
+          # The raw results are still uploaded by the artifact step.
+          if not results:
+              sys.exit('no criterion results parsed from criterion_output.txt')
           with open('results/criterion_baseline.json', 'w') as f:
               json.dump(results, f, indent=2)
           "

--- a/.github/workflows/benchmark-regression.yml
+++ b/.github/workflows/benchmark-regression.yml
@@ -56,6 +56,16 @@ jobs:
           # advisory: the step stays green and the warning is the whole signal,
           # because wall-clock timings on shared runners move on their own.
           #
+          # Exit 4 means the run lost benchmarks. It fails the step, but the
+          # comparison it wrote covers the ones that survived and names the
+          # ones that did not, so keep that file rather than replacing it with
+          # the error block below.
+          if [ "$status" -eq 4 ]; then
+            echo "regressed=false" >> "$GITHUB_OUTPUT"
+            echo "::error::criterion run produced no result for some benchmarks"
+            exit "$status"
+          fi
+
           # Any other non-zero means no comparison happened at all. That fails
           # the step, since a check that could not run must not look like one
           # that passed. It still does not block merge -- this job is not a

--- a/.github/workflows/benchmark-regression.yml
+++ b/.github/workflows/benchmark-regression.yml
@@ -21,6 +21,17 @@ jobs:
             .
             benchmarks
 
+      - name: Discard any cached criterion state
+        # A cache hit brings back benchmarks/target with target/criterion in a
+        # half state: the per-benchmark base directory is there but the
+        # sample.json inside it is not. Criterion takes the directory alone as
+        # a baseline to compare against, fails to read it, and prints the error
+        # to stdout in the middle of the result line it was writing, leaving
+        # the comparison below nothing to parse. The baseline this job wants
+        # comes from the benchmark-data branch, so criterion's own on-disk one
+        # is only ever leftovers from an unrelated PR.
+        run: rm -rf benchmarks/target/criterion
+
       - name: Run criterion micro-benchmarks
         # shell: bash adds -o pipefail. Without it the exit status of the pipe
         # is tee's, so a bench that dies partway leaves a truncated file and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,19 @@ jobs:
       - name: Format
         run: cargo fmt --check
 
+  benchmark-scripts:
+    name: Benchmark script tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      # The benchmark workflows read criterion's output through these scripts,
+      # and a parser that quietly returns nothing turns a failed comparison
+      # into a red check with no explanation.
+      - name: Test
+        run: python3 -m unittest discover -s benchmarks/scripts -p 'test_*.py' -v
+
   cargo-deny:
     name: cargo-deny
     runs-on: ubuntu-latest

--- a/benchmarks/scripts/compare_criterion.py
+++ b/benchmarks/scripts/compare_criterion.py
@@ -16,6 +16,7 @@ branch on the exit code, so it is a contract:
     1  could not compare
     2  usage error (argparse's own)
     3  threshold exceeded, advisory
+    4  compared, but benchmarks in the baseline produced no result
 
 Usage:
     python3 benchmarks/scripts/compare_criterion.py \
@@ -58,6 +59,10 @@ EXIT_ERROR = 1
 # Not 2: argparse exits 2 on a usage error, and a caller branching on the
 # regression signal must not read a mistyped flag as a regression.
 EXIT_REGRESSED = 3
+# A run that lost benchmarks compared the ones it still had, so the report is
+# worth keeping. It is separate from 1 for that reason: the caller has a table
+# to show, where an exit 1 leaves it nothing.
+EXIT_INCOMPLETE = 4
 
 
 def parse_bencher(text):
@@ -164,7 +169,11 @@ def sanitize(text):
 
 
 def build_report(current, baseline, history, threshold):
-    """Render the markdown comparison. Returns (markdown, regressions)."""
+    """Render the markdown comparison.
+
+    Returns (markdown, regressions, missing), where `missing` names the
+    baselined benchmarks this run produced no result for.
+    """
     regressions = []
     missing = []
     rows = []
@@ -237,29 +246,34 @@ def build_report(current, baseline, history, threshold):
             "> No stored runs to compare against. Baselines are recorded by "
             "the benchmark refresh workflow."
         )
-    elif regressions:
-        lines.append(
-            "> :warning: {} benchmark(s) came in more than {:.0%} above the "
-            "{}-run median. Check whether the current value falls outside the "
-            "range column before treating it as real; iai-callgrind gives a "
-            "deterministic instruction-count answer.".format(
-                len(regressions), threshold - 1, window
-            )
-        )
-    elif missing:
-        lines.append(
-            "> :warning: {} benchmark(s) in the baseline produced no result in "
-            "this run: {}. A partial bench run reports the rest as clean, so "
-            "treat this as a failed comparison rather than a pass.".format(
-                len(missing), ", ".join(sanitize(n) for n in missing)
-            )
-        )
     else:
-        lines.append(
-            "> All benchmarks within {:.0%} of the {}-run median.".format(
-                threshold - 1, window
+        if regressions:
+            lines.append(
+                "> :warning: {} benchmark(s) came in more than {:.0%} above the "
+                "{}-run median. Check whether the current value falls outside "
+                "the range column before treating it as real; iai-callgrind "
+                "gives a deterministic instruction-count answer.".format(
+                    len(regressions), threshold - 1, window
+                )
             )
-        )
+        # Not an elif. A run can both lose benchmarks and regress on the ones
+        # it kept, and the missing list is the more important of the two to
+        # read, so it must not be hidden behind the regression warning.
+        if missing:
+            lines.append(
+                "> :warning: {} benchmark(s) in the baseline produced no result "
+                "in this run: {}. A partial bench run reports the rest as "
+                "clean, so treat this as a failed comparison rather than a "
+                "pass.".format(
+                    len(missing), ", ".join(sanitize(n) for n in missing)
+                )
+            )
+        if not regressions and not missing:
+            lines.append(
+                "> All benchmarks within {:.0%} of the {}-run median.".format(
+                    threshold - 1, window
+                )
+            )
 
     if window:
         lines.append("")
@@ -270,7 +284,7 @@ def build_report(current, baseline, history, threshold):
         lines.append("")
         lines.append("</details>")
 
-    return "\n".join(lines) + "\n", regressions
+    return "\n".join(lines) + "\n", regressions, missing
 
 
 def main():
@@ -317,7 +331,7 @@ def main():
     if not history:
         print("no stored runs found on '{}'".format(args.ref), file=sys.stderr)
 
-    markdown, regressions = build_report(
+    markdown, regressions, missing = build_report(
         current, build_baseline(history), history, args.threshold
     )
 
@@ -330,6 +344,14 @@ def main():
     if regressions:
         print("exceeded threshold: {}".format(", ".join(regressions)),
               file=sys.stderr)
+
+    # Reported before the regression exit, and takes precedence over it. A run
+    # missing benchmarks cannot say the rest are clean, so it must not leave
+    # the advisory exit 3 -- or worse, exit 0 -- as the whole signal.
+    if missing:
+        print("no result for: {}".format(", ".join(missing)), file=sys.stderr)
+        return EXIT_INCOMPLETE
+    if regressions:
         return EXIT_REGRESSED
     return EXIT_OK
 

--- a/benchmarks/scripts/compare_criterion.py
+++ b/benchmarks/scripts/compare_criterion.py
@@ -35,8 +35,23 @@ import subprocess
 import sys
 
 
-# criterion --output-format bencher: "test NAME ... bench: N,NNN ns/iter (+/- N)"
-BENCHER_RE = re.compile(r"^test\s+(.+?)\s+\.\.\.\s+bench:\s+([\d,]+)\s+ns/iter")
+# criterion --output-format bencher writes a result as "test NAME ... " and
+# "bench: N,NNN ns/iter (+/- N)", in two separate writes with the measurement
+# in between. On a clean run they land on one line:
+#
+#     test get_item ... bench: 15,543 ns/iter (+/- 755)
+#
+# Criterion prints its own errors to stdout rather than stderr, so anything it
+# has to report during the run splits that line in two:
+#
+#     test get_item ... Criterion.rs ERROR: error: Failed to access file "..."
+#     bench: 15,543 ns/iter (+/- 755)
+#
+# Matching the header and the measurement separately reads both shapes. A
+# header with no measurement after it is a benchmark that produced no result,
+# and is left out so the caller reports it as missing.
+HEADER_RE = re.compile(r"^test\s+(.+?)\s+\.\.\.\s*(.*)$")
+BENCH_RE = re.compile(r"^\s*bench:\s+([\d,]+)\s+ns/iter")
 
 EXIT_OK = 0
 EXIT_ERROR = 1
@@ -48,11 +63,32 @@ EXIT_REGRESSED = 3
 def parse_bencher(text):
     """Parse criterion bencher-format output into {benchmark_name: ns}."""
     results = {}
+    pending = None
     for line in text.splitlines():
-        match = BENCHER_RE.match(line)
-        if match:
-            results[match.group(1)] = int(match.group(2).replace(",", ""))
+        header = HEADER_RE.match(line)
+        if header:
+            name, remainder = header.group(1), header.group(2)
+            measurement = BENCH_RE.match(remainder)
+            if measurement:
+                results[name] = _nanoseconds(measurement)
+                pending = None
+            else:
+                # Whatever criterion printed here pushed the measurement onto
+                # the next line. Hold the name until it arrives; if it never
+                # does, the next header discards it.
+                pending = name
+            continue
+
+        measurement = BENCH_RE.match(line)
+        if measurement and pending is not None:
+            results[pending] = _nanoseconds(measurement)
+            pending = None
     return results
+
+
+def _nanoseconds(measurement):
+    """Read the ns/iter figure out of a matched measurement."""
+    return int(measurement.group(1).replace(",", ""))
 
 
 def git(*args):

--- a/benchmarks/scripts/run_local_benchmarks.sh
+++ b/benchmarks/scripts/run_local_benchmarks.sh
@@ -177,12 +177,11 @@ echo ""
 echo "--- Criterion micro-benchmarks (embedded_micro) ---"
 cargo bench --bench embedded_micro -- --output-format bencher | tee "$RESULTS_DIR/criterion_output.txt"
 python3 -c "
-import json, re
-results = {}
-for line in open('$RESULTS_DIR/criterion_output.txt'):
-    m = re.match(r'^test\s+(.+?)\s+\.\.\.\s+bench:\s+([\d,]+)\s+ns/iter', line)
-    if m:
-        results[m.group(1)] = int(m.group(2).replace(',', ''))
+import json, sys
+sys.path.insert(0, '$SCRIPT_DIR')
+from compare_criterion import parse_bencher
+with open('$RESULTS_DIR/criterion_output.txt') as handle:
+    results = parse_bencher(handle.read())
 with open('$RESULTS_DIR/criterion_baseline.json', 'w') as f:
     json.dump(results, f, indent=2)
 print(f'Parsed {len(results)} criterion benchmarks')

--- a/benchmarks/scripts/test_compare_criterion.py
+++ b/benchmarks/scripts/test_compare_criterion.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Tests for the criterion bencher-output parser.
+
+Run with: python3 -m unittest discover -s benchmarks/scripts -p 'test_*.py'
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from compare_criterion import parse_bencher
+
+
+# What criterion writes to stdout when nothing goes wrong. The workflows pipe
+# through `tee`, which captures stdout only, so criterion's own progress notes
+# ("Gnuplot not found", "Warning: Unable to complete 100 samples...") never
+# reach the file being parsed -- it writes those with eprintln!. The blank line
+# is the separator it emits between benchmark groups.
+CLEAN = """test put_item/put_item/small ... bench:       26475 ns/iter (+/- 1730)
+test get_item ... bench:       14739 ns/iter (+/- 273)
+
+test query_base_table ... bench:     1,112,845 ns/iter (+/- 12302)
+"""
+
+# What it writes when a stale target/criterion leaves a base directory behind
+# without the sample.json inside it. That error goes to stdout, unlike the
+# progress notes above, so it lands between the header and the measurement.
+INTERLEAVED = """test put_item/put_item/small ... Criterion.rs ERROR: error: \
+Failed to access file \
+"/tmp/benchmarks/target/criterion/put_item/put_item/small/base/sample.json": \
+No such file or directory (os error 2)
+bench:       27261 ns/iter (+/- 2501)
+test get_item ... Criterion.rs ERROR: error: Failed to access file \
+"/tmp/benchmarks/target/criterion/get_item/base/sample.json": No such file or \
+directory (os error 2)
+bench:       15543 ns/iter (+/- 755)
+"""
+
+
+class ParseBencherTest(unittest.TestCase):
+    def test_reads_clean_output(self):
+        self.assertEqual(
+            parse_bencher(CLEAN),
+            {
+                "put_item/put_item/small": 26475,
+                "get_item": 14739,
+                "query_base_table": 1112845,
+            },
+        )
+
+    def test_reads_output_split_by_a_criterion_error(self):
+        self.assertEqual(
+            parse_bencher(INTERLEAVED),
+            {"put_item/put_item/small": 27261, "get_item": 15543},
+        )
+
+    def test_ignores_noise_that_is_not_a_result(self):
+        self.assertEqual(parse_bencher("\nCriterion.rs ERROR: error: boom\n"), {})
+
+    def test_leaves_out_a_benchmark_that_produced_no_measurement(self):
+        # The caller reports a baselined benchmark with no current result as a
+        # failed comparison, so a name with nothing behind it must not appear.
+        self.assertEqual(parse_bencher("test get_item ... \n"), {})
+
+    def test_does_not_credit_a_measurement_to_the_wrong_benchmark(self):
+        # get_item died before reporting. Its name must not pick up the figure
+        # belonging to the benchmark that ran next.
+        text = "test get_item ... \ntest delete_item ... bench: 53258 ns/iter (+/- 5623)\n"
+        self.assertEqual(parse_bencher(text), {"delete_item": 53258})
+
+    def test_reads_a_measurement_that_follows_two_lines_of_noise(self):
+        text = (
+            "test get_item ... Criterion.rs ERROR: first\n"
+            "Criterion.rs ERROR: second\n"
+            "bench:       15543 ns/iter (+/- 755)\n"
+        )
+        self.assertEqual(parse_bencher(text), {"get_item": 15543})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/scripts/test_compare_criterion.py
+++ b/benchmarks/scripts/test_compare_criterion.py
@@ -4,13 +4,17 @@
 Run with: python3 -m unittest discover -s benchmarks/scripts -p 'test_*.py'
 """
 
+import json
 import os
 import sys
+import tempfile
 import unittest
+from unittest import mock
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from compare_criterion import parse_bencher
+import compare_criterion
+from compare_criterion import build_baseline, build_report, parse_bencher
 
 
 # What criterion writes to stdout when nothing goes wrong. The workflows pipe
@@ -81,3 +85,105 @@ class ParseBencherTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class BuildReportTest(unittest.TestCase):
+    """The report's own text calls a partial run a failed comparison, so the
+    caller has to be able to see that state rather than infer it."""
+
+    HISTORY = [
+        ("runs/2026-01-01-aaaaaaa", {"get_item": 100, "put_item": 200}),
+        ("runs/2026-01-02-bbbbbbb", {"get_item": 100, "put_item": 200}),
+    ]
+
+    def report(self, current, threshold=1.50):
+        baseline = build_baseline(self.HISTORY)
+        return build_report(current, baseline, self.HISTORY, threshold)
+
+    def test_names_a_baselined_benchmark_that_produced_no_result(self):
+        _, regressions, missing = self.report({"get_item": 100})
+        self.assertEqual(missing, ["put_item"])
+        self.assertEqual(regressions, [])
+
+    def test_reports_nothing_missing_when_every_benchmark_ran(self):
+        _, regressions, missing = self.report({"get_item": 100, "put_item": 200})
+        self.assertEqual(missing, [])
+        self.assertEqual(regressions, [])
+
+    def test_a_benchmark_new_to_the_window_is_not_missing(self):
+        current = {"get_item": 100, "put_item": 200, "scan": 300}
+        _, _, missing = self.report(current)
+        self.assertEqual(missing, [])
+
+    def test_warns_about_a_regression_and_a_missing_benchmark_together(self):
+        # The two warnings used to share an if/elif chain, so a run that both
+        # regressed and lost a benchmark only ever mentioned the regression.
+        markdown, regressions, missing = self.report({"get_item": 1000})
+        self.assertEqual(regressions, ["get_item"])
+        self.assertEqual(missing, ["put_item"])
+        self.assertIn("above the", markdown)
+        self.assertIn("produced no result", markdown)
+
+    def test_says_so_when_everything_is_within_threshold(self):
+        markdown, _, _ = self.report({"get_item": 100, "put_item": 200})
+        self.assertIn("All benchmarks within", markdown)
+
+
+class ExitCodeTest(unittest.TestCase):
+    """Both workflows branch on these, so they are a contract."""
+
+    STORED = json.dumps({"get_item": 100, "put_item": 200})
+
+    def run_main(self, current, tmpdir):
+        """Run main() against a synthetic history.
+
+        Two stored runs, not one: a benchmark with a single sample behind it
+        reports its change without flagging it, so a one-run history could
+        never reach the regression exit.
+        """
+        current_path = os.path.join(tmpdir, "current.json")
+        with open(current_path, "w") as handle:
+            json.dump(current, handle)
+
+        def fake_git(*args):
+            if args[0] == "ls-tree":
+                return "runs/2026-01-01-aaaaaaa\nruns/2026-01-02-bbbbbbb\n"
+            return self.STORED
+
+        argv = [
+            "compare_criterion.py",
+            "--current-json", current_path,
+            "--output", os.path.join(tmpdir, "out.md"),
+        ]
+        with mock.patch.object(compare_criterion, "git", fake_git), \
+                mock.patch.object(sys, "argv", argv):
+            return compare_criterion.main()
+
+    def test_clean_run_exits_ok(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            status = self.run_main({"get_item": 100, "put_item": 200}, tmpdir)
+        self.assertEqual(status, compare_criterion.EXIT_OK)
+
+    def test_a_run_over_the_threshold_exits_regressed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            status = self.run_main({"get_item": 1000, "put_item": 200}, tmpdir)
+        self.assertEqual(status, compare_criterion.EXIT_REGRESSED)
+
+    def test_a_run_missing_a_benchmark_exits_incomplete(self):
+        # Exit 0 here is how a partial run used to reach a green check while
+        # the comparison it posted said not to trust it.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            status = self.run_main({"get_item": 100}, tmpdir)
+        self.assertEqual(status, compare_criterion.EXIT_INCOMPLETE)
+
+    def test_missing_takes_precedence_over_a_regression(self):
+        # Exit 3 is advisory and leaves the step green, which a run that lost
+        # benchmarks has not earned.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            status = self.run_main({"get_item": 1000}, tmpdir)
+        self.assertEqual(status, compare_criterion.EXIT_INCOMPLETE)
+
+    def test_a_run_that_parsed_nothing_exits_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            status = self.run_main({}, tmpdir)
+        self.assertEqual(status, compare_criterion.EXIT_ERROR)


### PR DESCRIPTION
## What this changes

`criterion-benchmarks` fails whenever the job gets a cache hit. A restored `target/criterion` has the per-benchmark `base` directory but not the `sample.json` in it, and criterion prints the resulting read failure to stdout, in the middle of the line the bencher formatter is writing. The workflows now clear `target/criterion` before the run, and the parser reads a split line as well as a whole one.

A second problem surfaced alongside it: a run that lost some benchmarks compared the rest and exited 0, so the check went green while the comment it posted said the result should not be trusted. That now exits 4 and fails the step, keeping the table that names what went missing.

Closes #192.

Note for whoever merges `feat/vector-indexes`: 5533bae on that branch adds the same `rm -rf` inline on the `cargo bench` line. Keep one, not both.

## Checklist

- [x] Tests added or updated
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` pass locally
- ~~`CHANGELOG.md` updated if this is a user-visible change~~ CI only, nothing user-visible
- [x] Linked issue, discussion, or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms
  (MIT License and Apache License, Version 2.0)

## DynamoDB compatibility note

Not applicable.
