### PR TITLE
fix: answer an empty BatchGetItem with the validation envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-09-03
+
+### Behaviour changes
+
+- **`BatchGetItem` with an empty `RequestItems` map now answers the standard
+  validation envelope** rather than a bespoke sentence: `1 validation error
+  detected: Value at 'RequestItems' failed to satisfy constraint: Member must
+  have length greater than or equal to 1`. AWS moved the operation onto that
+  message in 32 of the 33 regions observed on 2026-09-02. `BatchWriteItem` has
+  not followed and keeps `The requestItems parameter is required for
+  BatchWriteItem`, so the two siblings answer differently on purpose.
+
 ## [1.0.0] - 2026-08-25
 
 Every artefact moves to 1.0.0 together: the crate, the npm CLI wrapper and its
@@ -634,7 +646,8 @@ The wire API and the CLI, server and MCP surfaces are unaffected by all of these
 - HTTP server (axum-based, DynamoDB JSON wire protocol)
 - 300+ tests
 
-[Unreleased]: https://github.com/nubo-db/dynoxide/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/nubo-db/dynoxide/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/nubo-db/dynoxide/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/nubo-db/dynoxide/compare/v0.13.0...v1.0.0
 [0.13.0]: https://github.com/nubo-db/dynoxide/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/nubo-db/dynoxide/compare/v0.11.4...v0.12.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,7 +937,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "dynoxide-rs"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "async-lock",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dynoxide-rs"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 description = "An embeddable DynamoDB emulator backed by SQLite. Starts in under a millisecond, and is verified against real AWS by a public conformance suite."
 license = "MIT OR Apache-2.0"

--- a/docs/compatibility-summary.md
+++ b/docs/compatibility-summary.md
@@ -14,6 +14,10 @@ Dynoxide is an embeddable DynamoDB emulator backed by SQLite. It is designed for
 
 Conformance fixes ship as minor releases, so behaviour moves within a major line. This is the cumulative record: if something answers differently after an upgrade, look here first. `docs/versioning.md` explains the rule and how to pin if you would rather behaviour held still.
 
+### 1.1.0
+
+- **`BatchGetItem` with an empty `RequestItems` map answers the standard validation envelope** (`Value at 'RequestItems' failed to satisfy constraint: Member must have length greater than or equal to 1`) in place of a bespoke parameter-required sentence, following AWS. `BatchWriteItem` has not moved and still answers the bespoke sentence, so the two siblings differ.
+
 ### 1.0.0
 
 A large correction pass. Full detail in `CHANGELOG.md`; the shapes that matter:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -52,10 +52,10 @@ cargo install dynoxide-rs --no-default-features --features encrypted-full
 ```toml
 [dependencies]
 # Minimal - just the embedded database, no server or CLI dependencies
-dynoxide-rs = { version = "1.0", default-features = false, features = ["native-sqlite"] }
+dynoxide-rs = { version = "1.1", default-features = false, features = ["native-sqlite"] }
 
 # Or with encryption:
-# dynoxide-rs = { version = "1.0", default-features = false, features = ["encryption"] }
+# dynoxide-rs = { version = "1.1", default-features = false, features = ["encryption"] }
 ```
 
 ## Upgrading to 1.0.0
@@ -115,7 +115,7 @@ became `#[non_exhaustive]`:
 ## GitHub Actions
 
 ```yaml
-- uses: nubo-db/dynoxide/action@v1.0.0
+- uses: nubo-db/dynoxide/action@v1.1.0
   with:
     snapshot-url: https://example.com/test-data.db.zst  # optional
     port: 8000
@@ -140,9 +140,9 @@ docker run --rm -p 8000:8000 \
   serve --host 0.0.0.0 --port 8000 --db-path /data/dynoxide.sqlite
 ```
 
-Image tags follow the version: `dynoxide:1.0.0` is exact, `dynoxide:1.0` floats
+Image tags follow the version: `dynoxide:1.1.0` is exact, `dynoxide:1.1` floats
 across patches, and `dynoxide:1` floats across the whole 1.x line. `:1` receives
-conformance fixes, which change behaviour within a major; `:1.0` does not. See
+conformance fixes, which change behaviour within a major; `:1.1` does not. See
 `docs/versioning.md`.
 
 The image runs as root by default, matching `amazon/dynamodb-local`, so bind mounts on Linux Just Work without `--user`. The canonical image lives at `ghcr.io/nubo-db/dynoxide`. Mirrors are pushed to `docker.io/nubodb/dynoxide` and `public.ecr.aws/nubo-db/dynoxide` on a best-effort basis. SLSA provenance and SBOM attestations are published to GHCR only; if you want to verify provenance, pull from the GHCR canonical.

--- a/docs/library.md
+++ b/docs/library.md
@@ -89,7 +89,7 @@ No Docker. No port conflicts. No table name prefixes. Tests run in parallel with
 `native-sqlite`, `encryption` and `wasm-sqlite` are **mutually exclusive** - they select different SQLite backends. `wasm-sqlite` additionally excludes the CLI, server and MCP features, which are native-only. Cargo adds the default features to whatever you list, so naming one of these on its own is not enough: `features = ["wasm-sqlite"]` still enables `native-sqlite` and the CLI from the defaults, and the build stops on a `compile_error!` saying so. Always pair a non-default backend with `default-features = false`. To use encryption:
 
 ```toml
-dynoxide-rs = { version = "1.0", default-features = false, features = ["encryption"] }
+dynoxide-rs = { version = "1.1", default-features = false, features = ["encryption"] }
 ```
 
 **Workspace note:** Cargo unifies features across a workspace. If any crate depends on `dynoxide-rs` with default features (getting `native-sqlite`) and another uses `encryption`, both activate and the build fails. Use `default-features = false` on all `dynoxide-rs` dependencies in the workspace.

--- a/docs/testcontainers.md
+++ b/docs/testcontainers.md
@@ -11,7 +11,7 @@ If you arrived here from a timeout error, skip to
 
 | | |
 |---|---|
-| Image | `ghcr.io/nubo-db/dynoxide:1.0` |
+| Image | `ghcr.io/nubo-db/dynoxide:1.1` |
 | Port | `8000` |
 | Wait on | `GET /` returning `200` |
 | Command | the image default, `serve --host 0.0.0.0 --port 8000` |
@@ -23,7 +23,7 @@ serve, not just that the socket is open. `docs/versioning.md` names it as part
 of the CLI and wire contract, so it will not move inside 1.x, and
 `tests/container_contract.rs` holds it.
 
-Pin to `:1.0` rather than `:1` for a test fixture. Both float, but `:1` picks up
+Pin to `:1.1` rather than `:1` for a test fixture. Both float, but `:1` picks up
 conformance fixes, which change behaviour within the major on purpose. See
 [installation](installation.md) for the full tag semantics.
 
@@ -33,7 +33,7 @@ conformance fixes, which change behaviour within the major on purpose. See
 
 ```java
 GenericContainer<?> dynoxide = new GenericContainer<>(
-        DockerImageName.parse("ghcr.io/nubo-db/dynoxide:1.0"))
+        DockerImageName.parse("ghcr.io/nubo-db/dynoxide:1.1"))
     .withExposedPorts(8000)
     .waitingFor(Wait.forHttp("/").forPort(8000).forStatusCode(200));
 
@@ -47,7 +47,7 @@ and fails, for the reason in [Troubleshooting](#troubleshooting).
 ### Node
 
 ```ts
-const dynoxide = await new GenericContainer("ghcr.io/nubo-db/dynoxide:1.0")
+const dynoxide = await new GenericContainer("ghcr.io/nubo-db/dynoxide:1.1")
   .withExposedPorts(8000)
   .withWaitStrategy(Wait.forHttp("/", 8000).forStatusCode(200))
   .start();
@@ -58,7 +58,7 @@ const endpoint = `http://${dynoxide.getHost()}:${dynoxide.getMappedPort(8000)}`;
 ### Go
 
 ```go
-ctr, err := testcontainers.Run(ctx, "ghcr.io/nubo-db/dynoxide:1.0",
+ctr, err := testcontainers.Run(ctx, "ghcr.io/nubo-db/dynoxide:1.1",
     testcontainers.WithExposedPorts("8000/tcp"),
     testcontainers.WithWaitStrategy(
         wait.ForHTTP("/").
@@ -76,7 +76,7 @@ as a ready engine.
 
 ```csharp
 var dynoxide = new ContainerBuilder()
-    .WithImage("ghcr.io/nubo-db/dynoxide:1.0")
+    .WithImage("ghcr.io/nubo-db/dynoxide:1.1")
     .WithPortBinding(8000, true)
     .WithWaitStrategy(Wait.ForUnixContainer()
         .UntilHttpRequestIsSucceeded(r => r

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "dynoxide",
   "display_name": "Dynoxide",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A DynamoDB emulator with an MCP server exposing 35 DynamoDB tools to coding agents.",
   "long_description": "A DynamoDB emulator that starts in milliseconds, giving coding agents a real local DynamoDB to work against.\n\n**35 tools** covering tables, items, query and scan, batch and transactional writes, PartiQL, secondary indexes, TTL and vector search. Snapshot and restore let an agent set up a fixture, experiment against it, and roll back.\n\nRuns as a single native binary backed by SQLite, with no JVM or Docker required. Verified against real AWS by a public conformance suite.",
   "author": {

--- a/npm/wasm-engine/README.md
+++ b/npm/wasm-engine/README.md
@@ -10,7 +10,7 @@ The wasm build is a scored target in the same conformance suite that backs dynox
 npm install @dynoxide/wasm-engine
 ```
 
-The package is versioned in lockstep with every other dynoxide artefact; see `docs/versioning.md` for what that number promises and what the conformance suite does and does not exercise. `npm install @dynoxide/wasm-engine` gets the current release; use `~1.0.0` to hold behaviour still across minors.
+The package is versioned in lockstep with every other dynoxide artefact; see `docs/versioning.md` for what that number promises and what the conformance suite does and does not exercise. `npm install @dynoxide/wasm-engine` gets the current release; use `~1.1.0` to hold behaviour still across minors.
 
 ## Quick start
 

--- a/npm/wasm-engine/package.json
+++ b/npm/wasm-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynoxide/wasm-engine",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "description": "The Dynoxide DynamoDB emulator compiled to WebAssembly, with a Web Worker client for running DynamoDB operations in the browser.",
   "author": "Martin Hicks",

--- a/src/actions/batch_get_item.rs
+++ b/src/actions/batch_get_item.rs
@@ -43,11 +43,15 @@ pub async fn execute<S: StorageBackend>(
     request: BatchGetItemRequest,
 ) -> Result<BatchGetItemResponse> {
     // Validate RequestItems is not empty.
-    // AWS routes the empty-map case through a separate parameter-required path
-    // rather than the standard "N validation errors detected" envelope.
+    // AWS used to answer the empty-map case with a bespoke parameter-required
+    // sentence. It has since moved BatchGetItem onto the standard validation
+    // envelope, and as of the 2026-09-02 sweep 32 of the 33 regions observed
+    // answer this message; only me-central-1 still returns the old sentence.
+    // BatchWriteItem has not followed, so the sibling operation deliberately
+    // keeps its bespoke sentence rather than matching this one.
     if request.request_items.is_empty() {
         return Err(DynoxideError::ValidationException(
-            "The requestItems parameter is required for BatchGetItem".to_string(),
+            "1 validation error detected: Value at 'RequestItems' failed to satisfy constraint: Member must have length greater than or equal to 1".to_string(),
         ));
     }
 

--- a/src/actions/batch_write_item.rs
+++ b/src/actions/batch_write_item.rs
@@ -74,6 +74,11 @@ pub async fn execute<S: StorageBackend>(
     // Validate RequestItems is not empty.
     // AWS routes the empty-map case through a separate parameter-required path
     // rather than the standard "N validation errors detected" envelope.
+    //
+    // Do not align this with BatchGetItem, which now answers the standard
+    // envelope. The two have diverged: as of the 2026-09-02 sweep 31 of the 33
+    // regions observed still return this sentence for BatchWriteItem, against
+    // 1 of 33 for BatchGetItem. Matching them would break the common case here.
     if request.request_items.is_empty() {
         return Err(DynoxideError::ValidationException(
             "The requestItems parameter is required for BatchWriteItem".to_string(),

--- a/tests/batch_operations.rs
+++ b/tests/batch_operations.rs
@@ -185,6 +185,25 @@ fn test_batch_get_exceeds_100_keys() {
     assert!(msg.contains("RequestItems.Tbl.member.Keys"), "Got: {msg}");
 }
 
+#[test]
+fn test_batch_get_empty_request_items_uses_validation_envelope() {
+    let db = setup_db();
+
+    let req: BatchGetItemRequest = serde_json::from_value(serde_json::json!({
+        "RequestItems": {}
+    }))
+    .unwrap();
+
+    let err = db.batch_get_item(req).unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains(
+            "1 validation error detected: Value at 'RequestItems' failed to satisfy constraint: Member must have length greater than or equal to 1"
+        ),
+        "Got: {msg}"
+    );
+}
+
 // =============================================================================
 // BatchWriteItem tests
 // =============================================================================
@@ -708,4 +727,24 @@ fn batch_get_allows_uniform_projection_across_tables() {
     }))
     .unwrap();
     assert!(db.batch_get_item(req).is_ok());
+}
+
+#[test]
+fn test_batch_write_empty_request_items_keeps_bespoke_message() {
+    // BatchWriteItem has not followed BatchGetItem onto the validation
+    // envelope, so this sentence is the answer nearly every region gives.
+    // Pinned to stop the two being aligned for consistency's sake.
+    let db = setup_db();
+
+    let req: BatchWriteItemRequest = serde_json::from_value(serde_json::json!({
+        "RequestItems": {}
+    }))
+    .unwrap();
+
+    let err = db.batch_write_item(req).unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("The requestItems parameter is required for BatchWriteItem"),
+        "Got: {msg}"
+    );
 }


### PR DESCRIPTION
## What this changes

AWS has moved `BatchGetItem` onto the standard validation envelope for an empty
`RequestItems` map. In 32 of the 33 regions observed on 2026-09-02 it answers
`1 validation error detected: Value at 'RequestItems' failed to satisfy
constraint: Member must have length greater than or equal to 1`; only
me-central-1 still gives the old bespoke sentence. Dynoxide gave the bespoke
sentence everywhere, so it now matches.

`BatchWriteItem` has not moved. 31 of the same 33 regions still answer `The
requestItems parameter is required for BatchWriteItem`, so it stays as it was.
A test pins each message to stop the pair being aligned later.

Cut as 1.1.0: `docs/versioning.md` puts a capture-backed conformance fix at a
minor. Doc pins move off the 1.0 line with it.

## Checklist

- [x] Tests added or updated
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` pass locally
- [x] `CHANGELOG.md` updated if this is a user-visible change
- [x] Linked issue, discussion, or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms
  (MIT License and Apache License, Version 2.0)

## DynamoDB compatibility note

Yes, it changes an observable error string. Detail above. The divergence between
the two batch operations is current AWS behaviour, not an inconsistency here.
