### PR TITLE
docs: present npm and npx as alternatives in the Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,16 @@ LocalStack uses DynamoDB Local internally as its DynamoDB engine, so its startup
 
 ## Quick Start
 
-Install from npm and start a local server:
+Run a local server without installing anything:
+
+```sh
+npx dynoxide --port 8000
+```
+
+Or install it into a project to pin the version, after which `npx dynoxide` uses that copy:
 
 ```sh
 npm install --save-dev dynoxide
-npx dynoxide --port 8000
 ```
 
 Or run it in Docker, a drop-in for `amazon/dynamodb-local`:


### PR DESCRIPTION
## What this changes

The npm install and `npx` commands sat on consecutive lines in one block, which reads as a required sequence rather than a choice. They are now presented as alternatives, matching `docs/installation.md` and the npm package README.

## Checklist

- ~~Tests added or updated~~ - documentation only, no code changed
- ~~`cargo fmt --check` and `cargo clippy -- -D warnings` pass locally~~ - no Rust changed
- ~~`CHANGELOG.md` updated if this is a user-visible change~~ - README wording, no behaviour change
- [x] Linked issue, discussion, or a short note explaining the motivation
- [x] I agree my contribution is licensed under the project's terms (MIT License and Apache License, Version 2.0)
