### PR TITLE
feat: rebuild keys from a OneTable model and take rule values on import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the value the item arrived with; anything else is left alone and reported
   once per entity and key, without quoting the value, since removing those
   values is the point of the run. A rule that names a key attribute directly
-  wins over its template and is reported. A rule that replaces an attribute a
+  wins over its template on the items it matches, decided per item rather than
+  per entity so that a rule matching one entity cannot leave another entity's
+  key unrebuilt, and is reported. A rule that replaces an attribute a
   key is built from with a constant (`redact`, `null`, `mask`) is reported
   before any data is read, because every item of that entity would then render
   the same key and overwrite the last; collisions are counted if the import
@@ -40,12 +42,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   stays correct, every key stays well formed and every value is genuinely
   fake, so nothing in the output says anything is wrong: the only symptom is
   that a query for a customer's orders returns nothing. The model and the
-  rules together are enough to warn up front, but the failure waits until
-  items of both entities have actually been imported, so pulling one entity's
-  slice still works and the check does not earn a bypass flag. Nothing is
-  persisted on the error path. Matching on the key and its template rather
-  than the attribute name keeps it off entities that merely reuse a name, and
-  an attribute no rule rewrites is not at risk
+  rules together are enough to warn up front, but the failure waits until two
+  entities are actually seen carrying the same value, so pulling one entity's
+  slice still works, and so does importing two entities that share nothing.
+  Neither has a join to lose, and a check that fires on legitimate use earns a
+  bypass flag. Nothing is persisted on the error path. Matching on the key and
+  its template rather than the attribute name keeps it off entities that
+  merely reuse a name, and an attribute no rule rewrites is not at risk
   ([#202](https://github.com/nubo-db/dynoxide/issues/202)).
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   keys built from attributes keep their original values. `ImportCommand` gains
   a `data_model` field for library callers
   ([#201](https://github.com/nubo-db/dynoxide/issues/201)).
+- An import that would silently break the join between two entities now fails.
+  When two entities build the same key from the same template, an anonymised
+  attribute that template reads has to be in `[consistency] fields` or each
+  entity anonymises it independently and their keys stop agreeing. Every count
+  stays correct, every key stays well formed and every value is genuinely
+  fake, so nothing in the output says anything is wrong: the only symptom is
+  that a query for a customer's orders returns nothing. The model and the
+  rules together are enough to warn up front, but the failure waits until
+  items of both entities have actually been imported, so pulling one entity's
+  slice still works and the check does not earn a bypass flag. Nothing is
+  persisted on the error path. Matching on the key and its template rather
+  than the attribute name keeps it off entities that merely reuse a name, and
+  an attribute no rule rewrites is not at risk
+  ([#202](https://github.com/nubo-db/dynoxide/issues/202)).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `dynoxide import --data-model <onetable.json>` rebuilds keys from their
+  entity templates after anonymisation. Rules rewrite whole attribute values,
+  so in a single-table design a rule on `email` left the real address inside
+  `pk = "CUSTOMER#<email>"` and every GSI key built from it, while a rule on
+  `pk` itself replaced the whole value and lost the `CUSTOMER#` prefix. With a
+  data model loaded the importer resolves each item's entity, notes which of
+  `pk`, `sk` and the GSI keys are built from a template such as
+  `user#${email}`, applies the rules to the attributes, then renders those keys
+  again from the anonymised values. The prefix survives and key and attribute
+  agree by construction. A key is only rewritten when its template reproduces
+  the value the item arrived with; anything else is left alone and reported
+  once per entity and key, without quoting the value, since removing those
+  values is the point of the run. A rule that names a key attribute directly
+  wins over its template and is reported. A rule that replaces an attribute a
+  key is built from with a constant (`redact`, `null`, `mask`) is reported
+  before any data is read, because every item of that entity would then render
+  the same key and overwrite the last; collisions are counted if the import
+  goes ahead. Templates follow OneTable's own forms, including dotted paths
+  and `${name:length:pad}` sort padding, while an unclosed `${` fails the
+  import rather than leaving a key silently unrebuilt.
+  An import that has rules but no data model now says in its warnings that
+  keys built from attributes keep their original values. `ImportCommand` gains
+  a `data_model` field for library callers
+  ([#201](https://github.com/nubo-db/dynoxide/issues/201)).
+
+### Fixed
+
+- A OneTable schema whose primary key is not literally `pk` / `sk` now parses
+  its primary key templates. The parser read the model attributes named `pk`
+  and `sk` rather than the ones `indexes.primary` names, so a schema keyed on
+  `PK` / `SK` came back with an empty `pk_template`, which reached the MCP
+  data model as well as import.
+- Anonymisation rules take `values` and `names` tables, in the shape of
+  ExpressionAttributeValues and ExpressionAttributeNames, so a match
+  expression can be scoped by key prefix and can reach an attribute whose
+  name is a reserved word: `match = "begins_with(pk, :prefix)"` with
+  `values = { ":prefix" = "USER#" }`, and `#n` with
+  `names = { "#n" = "name" }`. Strings become `S`, integers and floats `N`,
+  booleans `BOOL`. The rules file is validated before any data is read: a
+  reference with nothing behind it, a name or value nothing references, a
+  non-finite float, and an operand of the wrong type for its function all
+  fail there with the messages DynamoDB gives for the equivalent request
+  ([#200](https://github.com/nubo-db/dynoxide/issues/200)).
+
+### Fixed
+
+- `docs/import.md` showed `begins_with(pk, 'USER#')` as a match expression,
+  which the rule parser rejected with a syntax error on the quote. The parser
+  only ever accepted `:name` references, and the code comment said so while
+  the docs promised otherwise. The example now uses the `values` table above
+  ([#200](https://github.com/nubo-db/dynoxide/issues/200)).
+
 ## [1.1.0] - 2026-09-03
 
 ### Behaviour changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the value the item arrived with; anything else is left alone and reported
   once per entity and key, without quoting the value, since removing those
   values is the point of the run. A rule that names a key attribute directly
-  wins over its template on the items it matches, decided per item rather than
-  per entity so that a rule matching one entity cannot leave another entity's
-  key unrebuilt, and is reported. A rule that replaces an attribute a
+  wins over its template on the items it actually rewrote, taken from what the
+  rules did rather than from what their conditions predicted, and is reported. A rule that replaces an attribute a
   key is built from with a constant (`redact`, `null`, `mask`) is reported
   before any data is read, because every item of that entity would then render
   the same key and overwrite the last; collisions are counted if the import
@@ -43,10 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fake, so nothing in the output says anything is wrong: the only symptom is
   that a query for a customer's orders returns nothing. The model and the
   rules together are enough to warn up front, but the failure waits until two
-  entities are actually seen carrying the same value, so pulling one entity's
-  slice still works, and so does importing two entities that share nothing.
-  Neither has a join to lose, and a check that fires on legitimate use earns a
-  bypass flag. Nothing is persisted on the error path. Matching on the key and
+  entities are seen to anonymise the same value differently. Pulling one
+  entity's slice still works, so does importing two entities that share
+  nothing, and so does a deterministic action such as `hash`, which keeps both
+  entities agreeing without any `[consistency]` entry. None of those has a
+  join to lose, and a check that fires on legitimate use earns a bypass flag. Nothing is persisted on the error path. Matching on the key and
   its template rather than the attribute name keeps it off entities that
   merely reuse a name, and an attribute no rule rewrites is not at risk
   ([#202](https://github.com/nubo-db/dynoxide/issues/202)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,11 +48,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   entities agreeing without any `[consistency]` entry. None of those has a
   join to lose, and a check that fires on legitimate use earns a bypass flag. Nothing is persisted on the error path. Matching on the key and
   its template rather than the attribute name keeps it off entities that
-  merely reuse a name, and an attribute no rule rewrites is not at risk
+  merely reuse a name, and an attribute no rule rewrites is not at risk.
+  Templates are grouped by the key they build as well as the attribute they
+  read, so two unrelated pairs that happen to read an attribute of the same
+  name stay separate, and a nested source such as `${contact.email}` is
+  followed rather than collapsed to `contact`
   ([#202](https://github.com/nubo-db/dynoxide/issues/202)).
 
 ### Fixed
 
+- A OneTable index whose hash key is a plain attribute no longer loses its
+  sort key template. The parser required a template on the hash attribute and
+  dropped the whole index without one, so a GSI hashing on something like a
+  tenant id and sorting on `user#${email}` disappeared from the model. That
+  reached the MCP data model, and on import it meant the sort key was never
+  rebuilt and kept the value it arrived with. An index the entity templates
+  neither key of is still skipped.
 - A OneTable schema whose primary key is not literally `pk` / `sk` now parses
   its primary key templates. The parser read the model attributes named `pk`
   and `sk` rather than the ones `indexes.primary` names, so a schema keyed on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `${name:length:pad}` sort padding, while an unclosed `${` fails the
   import rather than leaving a key silently unrebuilt.
   An import that has rules but no data model now says in its warnings that
-  keys built from attributes keep their original values. `ImportCommand` gains
-  a `data_model` field for library callers
+  keys built from attributes keep their original values
   ([#201](https://github.com/nubo-db/dynoxide/issues/201)).
+- **Breaking (Rust API):** `ImportCommand` gains a `data_model` field. It is a
+  plain struct with public fields, so every existing struct literal that built
+  one now fails to compile and needs `data_model: None` adding.
 - An import that would silently break the join between two entities now fails.
   When two entities build the same key from the same template, an anonymised
   attribute that template reads has to be in `[consistency] fields` or each
@@ -53,8 +55,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so two composite keys sharing only a component are left alone, and every
   outcome for a key is kept rather than the first, so a break is found
   whatever order the export is in. The field named in the advice is always a
-  top-level one, matching what `[consistency] fields` is keyed on
+  top-level one, matching what `[consistency] fields` is keyed on. Past a
+  million distinct keys per template the check keeps comparing the keys it
+  holds and reports how many it could not take on, rather than going quiet
   ([#202](https://github.com/nubo-db/dynoxide/issues/202)).
+- Anonymisation guidance changed: prefer `hash` for an attribute a key is
+  built from. `fake` draws from a small pool (`safe_email` has roughly nine
+  thousand possible values), so a few hundred items already produce repeats
+  and each one merges two identities onto one key; `mask` collides whenever
+  two values share their masked tail; `redact` collapses every item onto one
+  key; and `null` cannot render a key at all, so the most thorough-sounding
+  action is the one that leaves the most personal data in the keys. The
+  up-front warning names the actual consequence per action rather than calling
+  them all collapses, and the collision warning no longer asserts a cause it
+  has not established.
+- A rule `path` that starts with `#` is rejected. It looks like an expression
+  attribute name, the names table does not reach a path, and it previously
+  matched nothing at all, so the rule was silently inert.
+- An empty salt environment variable is rejected. It was accepted and produced
+  plain unsalted SHA-256, which is the shape an unset CI secret takes.
+- A OneTable index the table does not have, and a local secondary index, are
+  both reported rather than skipped in silence. Either left its key holding
+  the value it arrived with, and OneTable defaults an index name to its schema
+  key (`gs1`), which rarely matches the deployed index.
+- The broken-join check groups on the key attribute rather than the template
+  text, so the ordinary single-table join is covered: `CUSTOMER#${email}` and
+  `CUSTOMER#${customerEmail}` build the same partition from differently named
+  attributes. It also no longer counts a key that was left unrebuilt, which
+  turned a documented warning into a failure whose advice could not work.
+- An import that rebuilds keys now maintains secondary indexes on write.
+  Rebuilding can land two source items on one primary key, which is the
+  assumption the faster bulk path trades away: it skips the index
+  delete-before-insert, so an overwritten row left its old index entry behind
+  and a `Query` on that index answered from a row that no longer existed. An
+  import without `--data-model` takes keys from the export unchanged, cannot
+  collide, and keeps the faster path.
 
 ### Fixed
 
@@ -81,8 +116,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   non-finite float, and an operand of the wrong type for its function all
   fail there with the messages DynamoDB gives for the equivalent request
   ([#200](https://github.com/nubo-db/dynoxide/issues/200)).
-
-### Fixed
 
 - `docs/import.md` showed `begins_with(pk, 'USER#')` as a match expression,
   which the rule parser rejected with a syntax error on the quote. The parser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,11 +48,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   entities agreeing without any `[consistency]` entry. None of those has a
   join to lose, and a check that fires on legitimate use earns a bypass flag. Nothing is persisted on the error path. Matching on the key and
   its template rather than the attribute name keeps it off entities that
-  merely reuse a name, and an attribute no rule rewrites is not at risk.
-  Templates are grouped by the key they build as well as the attribute they
-  read, so two unrelated pairs that happen to read an attribute of the same
-  name stay separate, and a nested source such as `${contact.email}` is
-  followed rather than collapsed to `contact`
+  merely reuse a name, and an attribute no rule rewrites is not at risk. The
+  comparison is on the whole key rather than one attribute its template reads,
+  so two composite keys sharing only a component are left alone, and every
+  outcome for a key is kept rather than the first, so a break is found
+  whatever order the export is in. The field named in the advice is always a
+  top-level one, matching what `[consistency] fields` is keyed on
   ([#202](https://github.com/nubo-db/dynoxide/issues/202)).
 
 ### Fixed

--- a/docs/import.md
+++ b/docs/import.md
@@ -166,6 +166,10 @@ matched on the shape of its keys, constant templates included, since a
 constant `sk` is often the only thing separating two entities that share a
 partition template.
 
+An index counts when the entity templates either of its keys, so a GSI that
+hashes on a plain attribute such as a tenant id and sorts on
+`user#${email}` still gets its sort key rebuilt.
+
 A key is only rewritten when its template reproduces the value the item
 arrived with. A key the template cannot reproduce, or that names an attribute
 the item does not carry, is left as it is and reported once per entity and

--- a/docs/import.md
+++ b/docs/import.md
@@ -52,6 +52,12 @@ path = "email"
 action = { type = "fake", generator = "safe_email" }
 
 [[rules]]
+match = "begins_with(pk, :prefix)"
+values = { ":prefix" = "USER#" }
+path = "fullName"
+action = { type = "fake", generator = "name" }
+
+[[rules]]
 match = "attribute_exists(phone)"
 path = "phone"
 action = { type = "mask", keep_last = 4, mask_char = "*" }
@@ -88,7 +94,102 @@ ANON_SALT=my-secret-salt dynoxide import \
 | `redact` | Replace with `[REDACTED]` |
 | `null` | Replace with NULL |
 
-**Consistency:** Fields listed in `[consistency].fields` produce the same anonymised value across all tables in a single import run. Same input + same salt = same output.
+**Match expressions** use DynamoDB ConditionExpression syntax, so anything a
+ConditionExpression can say works: `attribute_exists`, `attribute_not_exists`,
+`attribute_type`, `begins_with`, `contains`, `size`, comparisons, `BETWEEN`,
+`IN`, and `AND` / `OR` / `NOT`. As on DynamoDB, an operand that is not a path
+is a `:name` reference rather than an inline literal, and the rule's `values`
+table supplies it in the shape of ExpressionAttributeValues. Strings become
+`S`, integers and floats `N`, booleans `BOOL`.
+
+An attribute whose name is a DynamoDB reserved word (`name`, `status`, `type`
+and the rest) goes through a `names` table as `#alias`, exactly as
+ExpressionAttributeNames would:
+
+```toml
+[[rules]]
+match = "begins_with(pk, :prefix) AND attribute_exists(#n)"
+values = { ":prefix" = "USER#" }
+names = { "#n" = "name" }
+path = "name"
+action = { type = "fake", generator = "name" }
+```
+
+The rules file is validated before any data is read. A reference with nothing
+behind it, a name or value nothing references, and an operand of the wrong
+type for its function all fail there, with the same messages DynamoDB gives
+for the equivalent request.
+
+**Consistency:** Fields listed in `[consistency].fields` produce the same anonymised value across all tables in a single import run. Same input + same salt = same output. Consistency is per field: `email` and `contactEmail` holding the same address get different fake values unless both are derived from one attribute, which is what `--data-model` does for keys.
+
+### Single-table designs
+
+Rules rewrite whole attribute values. In a single-table design the sensitive
+value is usually also inside a key, `pk = "CUSTOMER#a.okonkwo@example.co.uk"`,
+and a rule on `email` never touches it. Without a data model the import
+reports this once in its warnings, because the output would otherwise look
+anonymised while every partition key still holds the real address.
+
+Pass the same [OneTable](https://doc.onetable.io/) schema the MCP server uses
+as `--data-model` and the importer rebuilds keys from the anonymised
+attributes:
+
+```sh
+dynoxide import \
+  --source ./export/ \
+  --schema schema.json \
+  --rules rules.toml \
+  --data-model onetable.json \
+  --output anonymised.db
+```
+
+For each item the importer resolves the entity (by the type attribute,
+`_type` by default, or failing that by which entity's key templates reproduce
+the item's keys), notes which of `pk`, `sk` and the GSI keys the entity builds
+from a template such as `user#${email}`, applies the rules to the attributes,
+then renders those keys again. The prefix survives, and the key and the
+attribute agree by construction, so a rule on `email` is all a `User` entity
+needs. Which model attributes hold the primary key comes from the schema's
+`indexes.primary`, the DynamoDB attribute names come from the `--schema` file,
+and GSI keys are matched by index name, so the OneTable index `name` must
+match the DynamoDB index.
+
+Templates follow OneTable's own forms: `${name}`, a dotted path that reaches
+into a map (`${address.city}`), and `${name:length:pad}` sort padding, which
+prefixes the value with `pad` (default `0`) until it is `length` characters.
+An unclosed `${` fails the import rather than leaving a key silently
+unrebuilt.
+
+A key is only rewritten when its template reproduces the value the item
+arrived with. A key the template cannot reproduce, or that names an attribute
+the item does not carry, is left as it is and reported once per entity and
+key. That last case is the one to watch for: an `Order` item whose `pk` holds
+the customer's email but which has no attribute holding that email cannot be
+rebuilt, because there is nothing to derive it from. Give the entity an
+attribute for the value and put it in the template.
+
+**Name that attribute the same on every entity that shares the value, and
+list the name in `[consistency] fields`.** Both halves are load-bearing,
+because consistency is keyed on the attribute name. An `Order` carrying
+`customerEmail` where the `Customer` carries `email` is two namespaces, so
+the same real address anonymises to two different values, both keys rebuild
+correctly, and the order lands in a different partition from its customer.
+The same name in both places with no `[consistency]` entry fails the same
+way, since each item is then anonymised independently. Name it `email` on
+both and list `email`, and the order stays in its customer's partition.
+
+**Use `fake` or `hash` for an attribute a key is built from.** `redact`,
+`null` and `mask` produce the same output for every input, so every item of
+that entity would render an identical key and overwrite the previous one,
+leaving a database with fewer rows than the export. The importer says so
+before it reads any data, and counts the collisions if you go ahead anyway.
+
+**A rule that names a key attribute directly wins.** The key is not rebuilt
+from its template, the rule's value is what gets stored, and the import says
+which key that happened to.
+
+When `--mcp` is set, `--data-model` also serves as the MCP data model unless
+`--mcp-data-model` is given.
 
 ## Options
 

--- a/docs/import.md
+++ b/docs/import.md
@@ -158,7 +158,13 @@ Templates follow OneTable's own forms: `${name}`, a dotted path that reaches
 into a map (`${address.city}`), and `${name:length:pad}` sort padding, which
 prefixes the value with `pad` (default `0`) until it is `length` characters.
 An unclosed `${` fails the import rather than leaving a key silently
-unrebuilt.
+unrebuilt, and so does a key built from another templated key, which could
+only be rendered correctly in dependency order.
+
+An item carrying the type attribute is matched by it. One that does not is
+matched on the shape of its keys, constant templates included, since a
+constant `sk` is often the only thing separating two entities that share a
+partition template.
 
 A key is only rewritten when its template reproduces the value the item
 arrived with. A key the template cannot reproduce, or that names an attribute
@@ -181,18 +187,20 @@ both and list `email`, and the order stays in its customer's partition.
 The importer enforces the second half. When two entities build the same key
 from the same template, an anonymised attribute that template reads has to be
 consistency-tracked, or their keys cannot agree. That is a warning when the
-model says it could happen, and an error once two entities are actually seen
-carrying the same value for it:
+model says it could happen, and an error once two entities are seen to
+anonymise the same value differently:
 
 ```
-entity 'Customer' and entity 'Order' share a value of 'email', which is not in
-[consistency] fields, so it anonymised differently for each and their keys no
-longer agree. Add 'email' to [consistency] fields
+entity 'Customer' and entity 'Order' anonymised a shared value of 'email'
+differently, so their keys no longer agree and they will not join.
+Add 'email' to [consistency] fields
 ```
 
-It fails on the data rather than on the model, so importing one entity's slice
-still works, and so does importing two entities that share no value, since
-neither has a join to lose. Nothing is written on the error path, so a failed
+It fails on what the anonymisation actually produced, rather than on the model
+or on a shared input. Importing one entity's slice still works, so does
+importing two entities that share no value, and so does a deterministic action
+such as `hash`, which gives both entities the same result and keeps them
+joined without any `[consistency]` entry at all. Nothing is written on the error path, so a failed
 import leaves no database rather than a broken one. Matching on the key and
 its template, rather than on the attribute name, keeps this off entities that
 merely reuse a name: `account#${id}` and `project#${id}` are different
@@ -205,12 +213,12 @@ that entity would render an identical key and overwrite the previous one,
 leaving a database with fewer rows than the export. The importer says so
 before it reads any data, and counts the collisions if you go ahead anyway.
 
-**A rule that names a key attribute directly wins, on the items it matches.**
+**A rule that names a key attribute directly wins on the items it rewrote.**
 That key is not rebuilt from its template and the rule's value is stored
-instead. It is decided per item, not per entity, because a rule's condition
-may not match every entity that builds the key: a rule on `sk` that only
-matches an `Account` must not stop a `User` rebuilding its own `sk`, or the
-real value survives in the key while the attribute beside it is anonymised.
+instead. It is decided from what the rules actually did to each item, not
+from which rules looked like they would match, because each rule's condition
+sees the item as the rules before it left it. Deciding otherwise would leave
+a key unrebuilt on items the rule never touched, real value intact.
 
 When `--mcp` is set, `--data-model` also serves as the MCP data model unless
 `--mcp-data-model` is given.

--- a/docs/import.md
+++ b/docs/import.md
@@ -191,20 +191,28 @@ both and list `email`, and the order stays in its customer's partition.
 The importer enforces the second half. When two entities build the same key
 from the same template, an anonymised attribute that template reads has to be
 consistency-tracked, or their keys cannot agree. That is a warning when the
-model says it could happen, and an error once two entities are seen to
-anonymise the same value differently:
+model says it could happen, and an error once two entities are seen to take
+the same original key to different values:
 
 ```
-entity 'Customer' and entity 'Order' anonymised a shared value of 'email'
-differently, so their keys no longer agree and they will not join.
-Add 'email' to [consistency] fields
+entity 'Customer' and entity 'Order' took the same original pk to different
+values, so their keys no longer agree and they will not join.
+Template 'CUSTOMER#${email}' reads 'email': add 'email' to [consistency] fields
 ```
 
-It fails on what the anonymisation actually produced, rather than on the model
-or on a shared input. Importing one entity's slice still works, so does
-importing two entities that share no value, and so does a deterministic action
-such as `hash`, which gives both entities the same result and keeps them
-joined without any `[consistency]` entry at all. Nothing is written on the error path, so a failed
+It compares the whole key rather than one attribute the template reads, so two
+composite keys that merely share a component are left alone:
+`TENANT#a#${email}` and `TENANT#b#${email}` never agreed and have no join to
+lose. It fails on what the anonymisation actually produced, rather than on the
+model or on a shared input, so importing one entity's slice still works, and
+so does a deterministic action such as `hash`, which takes both entities to
+the same result and keeps them joined without any `[consistency]` entry at
+all. Every outcome for a key is kept rather than the first, so a break is
+found whatever order the export happens to be in.
+
+The field it names is always a top-level one, because that is what
+`[consistency] fields` is keyed on. A template reading `${contact.email}`
+is reported as `contact`. Nothing is written on the error path, so a failed
 import leaves no database rather than a broken one. Matching on the key and
 its template, rather than on the attribute name, keeps this off entities that
 merely reuse a name: `account#${id}` and `project#${id}` are different

--- a/docs/import.md
+++ b/docs/import.md
@@ -181,23 +181,23 @@ both and list `email`, and the order stays in its customer's partition.
 The importer enforces the second half. When two entities build the same key
 from the same template, an anonymised attribute that template reads has to be
 consistency-tracked, or their keys cannot agree. That is a warning when the
-model says it could happen and an error once items of both entities have
-actually been imported:
+model says it could happen, and an error once two entities are actually seen
+carrying the same value for it:
 
 ```
-entity 'Customer' and entity 'Order' were both imported and both build keys
-from 'email', which is not in [consistency] fields, so the same value
-anonymised differently for each and they no longer join.
-Add 'email' to [consistency] fields
+entity 'Customer' and entity 'Order' share a value of 'email', which is not in
+[consistency] fields, so it anonymised differently for each and their keys no
+longer agree. Add 'email' to [consistency] fields
 ```
 
-It fails on the data rather than on the model so that importing one entity's
-slice still works, since there is no join to lose there. Nothing is written on
-the error path, so a failed import leaves no database rather than a broken
-one. Matching on the key and its template, rather than on the attribute name,
-keeps this off entities that merely reuse a name: `account#${id}` and
-`project#${id}` are different entities' own ids and never had a join. An
-attribute no rule rewrites is left alone too, since its keys still agree.
+It fails on the data rather than on the model, so importing one entity's slice
+still works, and so does importing two entities that share no value, since
+neither has a join to lose. Nothing is written on the error path, so a failed
+import leaves no database rather than a broken one. Matching on the key and
+its template, rather than on the attribute name, keeps this off entities that
+merely reuse a name: `account#${id}` and `project#${id}` are different
+entities' own ids and never had a join. An attribute no rule rewrites is left
+alone too, since its keys still agree.
 
 **Use `fake` or `hash` for an attribute a key is built from.** `redact`,
 `null` and `mask` produce the same output for every input, so every item of
@@ -205,9 +205,12 @@ that entity would render an identical key and overwrite the previous one,
 leaving a database with fewer rows than the export. The importer says so
 before it reads any data, and counts the collisions if you go ahead anyway.
 
-**A rule that names a key attribute directly wins.** The key is not rebuilt
-from its template, the rule's value is what gets stored, and the import says
-which key that happened to.
+**A rule that names a key attribute directly wins, on the items it matches.**
+That key is not rebuilt from its template and the rule's value is stored
+instead. It is decided per item, not per entity, because a rule's condition
+may not match every entity that builds the key: a rule on `sk` that only
+matches an `Account` must not stop a `User` rebuilding its own `sk`, or the
+real value survives in the key while the attribute beside it is anonymised.
 
 When `--mcp` is set, `--data-model` also serves as the MCP data model unless
 `--mcp-data-model` is given.

--- a/docs/import.md
+++ b/docs/import.md
@@ -154,9 +154,14 @@ needs. Which model attributes hold the primary key comes from the schema's
 and GSI keys are matched by index name, so the OneTable index `name` must
 match the DynamoDB index.
 
+Only a key that is actually rebuilt takes part in that check. One left holding
+its original value has already been reported as a template that does not
+reproduce, which is the accurate diagnostic for it.
+
 Templates follow OneTable's own forms: `${name}`, a dotted path that reaches
 into a map (`${address.city}`), and `${name:length:pad}` sort padding, which
-prefixes the value with `pad` (default `0`) until it is `length` characters.
+prefixes the value with `pad` (default `0`, as OneTable treats an empty one)
+until it is `length` characters.
 An unclosed `${` fails the import rather than leaving a key silently
 unrebuilt, and so does a key built from another templated key, which could
 only be rendered correctly in dependency order.
@@ -168,7 +173,16 @@ partition template.
 
 An index counts when the entity templates either of its keys, so a GSI that
 hashes on a plain attribute such as a tenant id and sorts on
-`user#${email}` still gets its sort key rebuilt.
+`user#${email}` still gets its sort key rebuilt. The OneTable index's `name`
+has to match the DynamoDB index, since OneTable otherwise defaults it to the
+schema key (`gs1`) and the importer cannot tell which index is meant. It
+reports any index in the model that the table does not have, rather than
+skipping it quietly.
+
+**Local secondary indexes are not rebuilt.** OneTable declares one with a sort
+key and no hash key, so it never reaches the model as an index the importer
+can act on, and an LSI sort key keeps the value it arrives with. The import
+says so when the table has any.
 
 A key is only rewritten when its template reproduces the value the item
 arrived with. A key the template cannot reproduce, or that names an attribute
@@ -200,8 +214,13 @@ values, so their keys no longer agree and they will not join.
 Template 'CUSTOMER#${email}' reads 'email': add 'email' to [consistency] fields
 ```
 
-It compares the whole key rather than one attribute the template reads, so two
-composite keys that merely share a component are left alone:
+It groups on the key attribute rather than the template text, so the ordinary
+single-table join is covered: a `Customer` keyed `CUSTOMER#${email}` and an
+`Order` keyed `CUSTOMER#${customerEmail}` build the same partition from
+differently named attributes, and requiring identical template text would miss
+it. What it compares is the whole key value rather than one attribute the
+template reads, so two composite keys that merely share a component are left
+alone:
 `TENANT#a#${email}` and `TENANT#b#${email}` never agreed and have no join to
 lose. It fails on what the anonymisation actually produced, rather than on the
 model or on a shared input, so importing one entity's slice still works, and
@@ -212,18 +231,57 @@ found whatever order the export happens to be in.
 
 The field it names is always a top-level one, because that is what
 `[consistency] fields` is keyed on. A template reading `${contact.email}`
-is reported as `contact`. Nothing is written on the error path, so a failed
-import leaves no database rather than a broken one. Matching on the key and
+is reported as `contact`.
+
+The check holds a million distinct keys per template. Past that it keeps
+checking the keys it already has and says how many it could not take on, so
+a very large import is told its check was partial rather than left to look
+clean. In file mode nothing is written on the
+error path, so a failed import leaves no database rather than a broken one.
+The library entry point `run_into` writes into a database you supply, so
+there a failure on a later table leaves the earlier ones in place. Matching on the key and
 its template, rather than on the attribute name, keeps this off entities that
 merely reuse a name: `account#${id}` and `project#${id}` are different
 entities' own ids and never had a join. An attribute no rule rewrites is left
 alone too, since its keys still agree.
 
-**Use `fake` or `hash` for an attribute a key is built from.** `redact`,
-`null` and `mask` produce the same output for every input, so every item of
-that entity would render an identical key and overwrite the previous one,
-leaving a database with fewer rows than the export. The importer says so
-before it reads any data, and counts the collisions if you go ahead anyway.
+**Prefer `hash` for an attribute a key is built from.** The other actions all
+go wrong in their own way, and the importer names which before it reads any
+data:
+
+| Action | What it does to a key built from it |
+|---|---|
+| `hash` | Same input gives the same output, so keys agree and rows stay distinct. The safe choice. |
+| `fake` | Draws from a small pool. `safe_email` has about nine thousand possible values, so a few hundred people already produce repeats, and each repeat merges two identities onto one key. |
+| `mask` | Two values that share their last few characters mask to the same text, so they collide too. |
+| `redact` | Every item renders the same key and overwrites the last. |
+| `null` | The key cannot render at all, so every item keeps the value it arrived with. The most thorough-sounding action leaves the most personal data in the keys. |
+
+Collisions are counted whichever way they arise, and the overwritten item's
+index entries go with it, so the output stays internally consistent even when
+rows are lost.
+
+**The salt is the security property, not a formality.** `hash` is required to
+take one because an unsalted SHA-256 of a low-entropy value is trivially
+reversible: an attacker with the hashed output hashes a wordlist of plausible
+email addresses and matches them off, recovering the originals without ever
+touching your data. The salt is what makes that wordlist useless, so it needs
+to be an actual secret. `ANON_SALT=test` gives you the reversibility back. An
+empty variable is rejected outright, since that is the shape an unset CI
+secret takes and it would produce plain unsalted hashes with no error.
+
+Keep the salt somewhere the anonymised output does not go. Anyone holding both
+can re-derive every original value.
+
+`hash` is pseudonymisation rather than anonymisation. Equal inputs give equal
+outputs by design, which is what keeps joins working, but it also means the
+shape of the original data survives into the keys and anyone holding the salt
+can re-derive every one of them. Treat a hashed export as sensitive, not
+anonymous.
+
+`--data-model` therefore imports on the index-maintaining write path rather
+than the faster one that assumes every key is unique. Without it, keys come
+from the export unchanged and cannot collide, so nothing is given up.
 
 **A rule that names a key attribute directly wins on the items it rewrote.**
 That key is not rebuilt from its template and the rule's value is stored

--- a/docs/import.md
+++ b/docs/import.md
@@ -178,6 +178,27 @@ The same name in both places with no `[consistency]` entry fails the same
 way, since each item is then anonymised independently. Name it `email` on
 both and list `email`, and the order stays in its customer's partition.
 
+The importer enforces the second half. When two entities build the same key
+from the same template, an anonymised attribute that template reads has to be
+consistency-tracked, or their keys cannot agree. That is a warning when the
+model says it could happen and an error once items of both entities have
+actually been imported:
+
+```
+entity 'Customer' and entity 'Order' were both imported and both build keys
+from 'email', which is not in [consistency] fields, so the same value
+anonymised differently for each and they no longer join.
+Add 'email' to [consistency] fields
+```
+
+It fails on the data rather than on the model so that importing one entity's
+slice still works, since there is no join to lose there. Nothing is written on
+the error path, so a failed import leaves no database rather than a broken
+one. Matching on the key and its template, rather than on the attribute name,
+keeps this off entities that merely reuse a name: `account#${id}` and
+`project#${id}` are different entities' own ids and never had a join. An
+attribute no rule rewrites is left alone too, since its keys still agree.
+
 **Use `fake` or `hash` for an attribute a key is built from.** `redact`,
 `null` and `mask` produce the same output for every input, so every item of
 that entity would render an identical key and overwrite the previous one,

--- a/docs/mcp-data-model.md
+++ b/docs/mcp-data-model.md
@@ -56,4 +56,6 @@ dynoxide serve --mcp --mcp-data-model schema.json
 
 ## Important
 
-The data model is context-only. Dynoxide does not validate writes against the schema. The MCP instructions note this explicitly so agents don't assume enforcement.
+The data model is context-only for MCP. Dynoxide does not validate writes against the schema. The MCP instructions note this explicitly so agents don't assume enforcement.
+
+The same file has one active use: `dynoxide import --data-model` rebuilds keys from their entity templates after anonymisation, so a rule on `email` also rewrites `user#${email}`. See [import.md](import.md#single-table-designs).

--- a/src/expressions/condition.rs
+++ b/src/expressions/condition.rs
@@ -1019,6 +1019,53 @@ fn check_path_non_scalar(
     }
 }
 
+/// Extract the `:name` value references in a condition expression, sorted and
+/// deduplicated, so a caller can check them against the values it holds.
+pub fn extract_value_refs(expr: &ConditionExpr) -> Vec<String> {
+    let mut refs = Vec::new();
+    collect_value_refs(expr, &mut refs);
+    refs.sort();
+    refs.dedup();
+    refs
+}
+
+fn collect_value_refs(expr: &ConditionExpr, out: &mut Vec<String>) {
+    match expr {
+        ConditionExpr::Comparison { left, right, .. } => {
+            collect_operand_value_ref(left, out);
+            collect_operand_value_ref(right, out);
+        }
+        ConditionExpr::Between { operand, lo, hi } => {
+            collect_operand_value_ref(operand, out);
+            collect_operand_value_ref(lo, out);
+            collect_operand_value_ref(hi, out);
+        }
+        ConditionExpr::In { operand, values } => {
+            collect_operand_value_ref(operand, out);
+            for v in values {
+                collect_operand_value_ref(v, out);
+            }
+        }
+        ConditionExpr::AttributeExists(_) | ConditionExpr::AttributeNotExists(_) => {}
+        ConditionExpr::AttributeType(_, operand) => collect_operand_value_ref(operand, out),
+        ConditionExpr::BeginsWith(a, b) | ConditionExpr::Contains(a, b) => {
+            collect_operand_value_ref(a, out);
+            collect_operand_value_ref(b, out);
+        }
+        ConditionExpr::And(a, b) | ConditionExpr::Or(a, b) => {
+            collect_value_refs(a, out);
+            collect_value_refs(b, out);
+        }
+        ConditionExpr::Not(inner) => collect_value_refs(inner, out),
+    }
+}
+
+fn collect_operand_value_ref(operand: &Operand, out: &mut Vec<String>) {
+    if let Operand::ValueRef(name) = operand {
+        out.push(name.clone());
+    }
+}
+
 /// Extract the top-level attribute names referenced in a condition expression.
 ///
 /// Resolves `#name` references using `expression_attribute_names`.
@@ -1117,6 +1164,16 @@ fn resolve_top_level_path(
         }
         _ => None,
     }
+}
+
+/// Extract the `#alias` name references in a condition expression, sorted
+/// and deduplicated.
+pub fn extract_name_refs(expr: &ConditionExpr) -> Vec<String> {
+    let mut refs = Vec::new();
+    collect_undefined_name_refs(expr, &None, &mut refs);
+    refs.sort();
+    refs.dedup();
+    refs
 }
 
 /// Validate that all `#name` references in a condition expression are defined
@@ -1313,6 +1370,20 @@ mod tests {
         let expr = parse("attribute_not_exists(email)").unwrap();
         let item: HashMap<String, AttributeValue> = HashMap::new();
         assert!(evaluate_without_tracking(&expr, &item, &None, &None).unwrap());
+    }
+
+    #[test]
+    fn test_extract_value_refs_walks_every_operand_slot() {
+        let expr = parse(
+            "begins_with(pk, :p) AND (age BETWEEN :lo AND :hi OR NOT tier IN (:a, :p)) \
+             AND attribute_type(x, :t) AND contains(tags, :tag) AND size(n) > :n",
+        )
+        .unwrap();
+        assert_eq!(
+            extract_value_refs(&expr),
+            vec![":a", ":hi", ":lo", ":n", ":p", ":t", ":tag"]
+        );
+        assert!(extract_value_refs(&parse("attribute_exists(pk)").unwrap()).is_empty());
     }
 
     #[test]

--- a/src/import/anonymise.rs
+++ b/src/import/anonymise.rs
@@ -20,15 +20,20 @@ use sha2::{Digest, Sha256};
 
 /// Apply all matching rules to an item, mutating it in place.
 ///
-/// Returns a list of warnings (e.g., key attribute collision risks).
+/// Returns the warnings raised (e.g. key attribute collision risks) and the
+/// top-level attributes actually rewritten. The caller needs the second to
+/// know which keys a rule has taken over: predicting it from the rules is
+/// wrong, because each rule's condition sees the item as the rules before it
+/// left it, not as it arrived.
 pub fn apply_rules(
     item: &mut Item,
     rules: &[ValidatedRule],
     consistency_map: &mut ConsistencyMap,
     consistency_fields: &std::collections::HashSet<String>,
     key_attrs: &[String],
-) -> Vec<String> {
+) -> (Vec<String>, std::collections::HashSet<String>) {
     let mut warnings = Vec::new();
+    let mut rewritten = std::collections::HashSet::new();
 
     for rule in rules {
         if !matches_item(rule, item) {
@@ -79,12 +84,17 @@ pub fn apply_rules(
         }
 
         // Apply the new value
-        if let Err(e) = set_path(item, &rule.path, new_value) {
-            warnings.push(format!("failed to set path '{}': {e}", field_name));
+        match set_path(item, &rule.path, new_value) {
+            Ok(()) => {
+                rewritten.insert(field_name);
+            }
+            Err(e) => {
+                warnings.push(format!("failed to set path '{}': {e}", field_name));
+            }
         }
     }
 
-    warnings
+    (warnings, rewritten)
 }
 
 /// Extract the top-level field name from a path.

--- a/src/import/config.rs
+++ b/src/import/config.rs
@@ -23,9 +23,22 @@ pub struct ImportConfig {
 #[derive(Debug, Deserialize)]
 pub struct RuleConfig {
     /// DynamoDB ConditionExpression syntax to match items.
-    /// e.g. `attribute_exists(email)` or `begins_with(pk, 'USER#')`
+    /// e.g. `attribute_exists(email)` or `begins_with(pk, :prefix)`, with
+    /// `:prefix` supplied through `values`.
     #[serde(rename = "match")]
     pub match_expr: String,
+
+    /// Names for the `#alias` references in `match`, in the shape of
+    /// ExpressionAttributeNames: `names = { "#n" = "name" }`. Needed for
+    /// attributes whose names are reserved words.
+    #[serde(default)]
+    pub names: HashMap<String, String>,
+
+    /// Values for the `:name` references in `match`, in the shape of
+    /// ExpressionAttributeValues: `values = { ":prefix" = "USER#" }`.
+    /// Strings become `S`, integers and floats `N`, booleans `BOOL`.
+    #[serde(default)]
+    pub values: HashMap<String, toml::Value>,
 
     /// Attribute path to transform (supports dot notation: `address.city`).
     pub path: String,
@@ -81,6 +94,10 @@ pub struct ConsistencyConfig {
 pub struct ValidatedRule {
     /// Parsed condition expression.
     pub condition: ConditionExpr,
+    /// Names behind the `#alias` references in `condition`, if it has any.
+    pub names: Option<HashMap<String, String>>,
+    /// Values behind the `:name` references in `condition`, if it has any.
+    pub values: Option<HashMap<String, AttributeValue>>,
     /// Parsed path elements for navigating into items.
     pub path: Vec<crate::expressions::PathElement>,
     /// The action to apply.
@@ -149,6 +166,20 @@ pub fn load_and_validate(
             )
         })?;
 
+        let names = convert_names(&rule.names, i + 1)?;
+        let values = convert_values(&rule.values, i + 1)?;
+        validate_name_refs(&condition, &names, i + 1)?;
+        validate_value_refs(&condition, &values, i + 1)?;
+        condition::validate_static(&condition, &values)
+            .and_then(|()| condition::validate_operand_semantics(&condition, &names, &values))
+            .map_err(|e| {
+                format!(
+                    "Rule {}: invalid match expression '{}': {e}",
+                    i + 1,
+                    rule.match_expr
+                )
+            })?;
+
         let path = parse_path(&rule.path)
             .map_err(|e| format!("Rule {}: invalid path '{}': {e}", i + 1, rule.path))?;
 
@@ -156,6 +187,8 @@ pub fn load_and_validate(
 
         validated.push(ValidatedRule {
             condition,
+            names,
+            values,
             path,
             action,
         });
@@ -164,9 +197,123 @@ pub fn load_and_validate(
     Ok((validated, config.consistency))
 }
 
+/// Check a rule's `names` table: every alias starts with `#`.
+fn convert_names(
+    names: &HashMap<String, String>,
+    rule_num: usize,
+) -> Result<Option<HashMap<String, String>>, String> {
+    if names.is_empty() {
+        return Ok(None);
+    }
+    for alias in names.keys() {
+        if !alias.starts_with('#') {
+            return Err(format!(
+                "Rule {rule_num}: name alias '{alias}' must start with '#' (for example \"#n\")"
+            ));
+        }
+    }
+    Ok(Some(names.clone()))
+}
+
+/// Check that `names` and the `#alias` references in the match expression
+/// line up: every reference is defined, and every name is used.
+fn validate_name_refs(
+    condition: &ConditionExpr,
+    names: &Option<HashMap<String, String>>,
+    rule_num: usize,
+) -> Result<(), String> {
+    condition::validate_name_refs(condition, names)
+        .map_err(|e| format!("Rule {rule_num}: {e}. Add it to the rule's names table"))?;
+
+    if let Some(names) = names {
+        let used = crate::expressions::condition::extract_name_refs(condition);
+        let mut unused: Vec<&String> = names.keys().filter(|k| !used.contains(k)).collect();
+        unused.sort();
+        if let Some(alias) = unused.first() {
+            return Err(format!(
+                "Rule {rule_num}: name {alias} is not referenced by the match expression"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Convert a rule's `values` table into attribute values.
+///
+/// Mirrors ExpressionAttributeValues: every name starts with `:`, and only
+/// scalars are accepted, since that is all a match expression can compare.
+fn convert_values(
+    values: &HashMap<String, toml::Value>,
+    rule_num: usize,
+) -> Result<Option<HashMap<String, AttributeValue>>, String> {
+    if values.is_empty() {
+        return Ok(None);
+    }
+
+    let mut converted = HashMap::with_capacity(values.len());
+    for (name, value) in values {
+        if !name.starts_with(':') {
+            return Err(format!(
+                "Rule {rule_num}: value name '{name}' must start with ':' (for example \":prefix\")"
+            ));
+        }
+        let attr = match value {
+            toml::Value::String(s) => AttributeValue::S(s.clone()),
+            toml::Value::Integer(i) => AttributeValue::N(i.to_string()),
+            toml::Value::Float(f) if f.is_finite() => AttributeValue::N(f.to_string()),
+            toml::Value::Float(_) => {
+                return Err(format!(
+                    "Rule {rule_num}: value '{name}' must be a finite number"
+                ));
+            }
+            toml::Value::Boolean(b) => AttributeValue::BOOL(*b),
+            _ => {
+                return Err(format!(
+                    "Rule {rule_num}: value '{name}' must be a string, number or boolean"
+                ));
+            }
+        };
+        converted.insert(name.clone(), attr);
+    }
+    Ok(Some(converted))
+}
+
+/// Check that `values` and the `:name` references in the match expression
+/// line up: every reference is defined, and every value is used. The same
+/// two checks DynamoDB applies to ExpressionAttributeValues.
+fn validate_value_refs(
+    condition: &ConditionExpr,
+    values: &Option<HashMap<String, AttributeValue>>,
+    rule_num: usize,
+) -> Result<(), String> {
+    let refs = condition::extract_value_refs(condition);
+
+    for name in &refs {
+        let defined = values.as_ref().is_some_and(|v| v.contains_key(name));
+        if !defined {
+            return Err(format!(
+                "Rule {rule_num}: match expression references {name} but values does not define it. \
+                 Add values = {{ \"{name}\" = \"...\" }} to the rule"
+            ));
+        }
+    }
+
+    if let Some(values) = values {
+        let mut unused: Vec<&String> = values.keys().filter(|k| !refs.contains(k)).collect();
+        unused.sort();
+        if let Some(name) = unused.first() {
+            return Err(format!(
+                "Rule {rule_num}: value {name} is not referenced by the match expression"
+            ));
+        }
+    }
+
+    Ok(())
+}
+
 /// Parse a dot-notation path into PathElements.
 /// Supports: `email`, `address.city`, `items[0].name`
-fn parse_path(path: &str) -> Result<Vec<crate::expressions::PathElement>, String> {
+pub(super) fn parse_path(path: &str) -> Result<Vec<crate::expressions::PathElement>, String> {
     use crate::expressions::PathElement;
 
     if path.is_empty() {
@@ -278,24 +425,17 @@ fn validate_action(action: &ActionConfig, rule_num: usize) -> Result<ValidatedAc
 
 /// Evaluate a match expression against an item.
 ///
-/// ## Supported expressions
+/// Match expressions use DynamoDB ConditionExpression syntax, so anything a
+/// ConditionExpression can say works here: `attribute_exists`,
+/// `attribute_not_exists`, `attribute_type`, `begins_with`, `contains`,
+/// `size`, comparisons, `BETWEEN`, `IN`, and `AND` / `OR` / `NOT`.
 ///
-/// Match expressions use DynamoDB ConditionExpression syntax. The following
-/// functions work without expression attribute values:
-///
-/// - `attribute_exists(path)`: matches if the attribute is present
-/// - `attribute_not_exists(path)`: matches if the attribute is absent
-/// - `attribute_type(path, type)`: matches if the attribute is the given type
-/// - Boolean operators: `AND`, `OR`, `NOT`
-///
-/// ## Known limitation
-///
-/// Functions that require string literal arguments (e.g., `begins_with(pk, 'USER#')`)
-/// are **not supported** because the condition parser expects `:val` expression
-/// attribute value references, not inline string literals. String literal support
-/// is tracked as a follow-up task.
+/// As on DynamoDB, an operand that is not a path is a `:name` reference,
+/// never an inline literal: `begins_with(pk, :prefix)` with the prefix in the
+/// rule's `values` table. A reserved word or an awkward attribute name goes
+/// through the `names` table as `#alias`, as ExpressionAttributeNames would.
 pub fn matches_item(rule: &ValidatedRule, item: &HashMap<String, AttributeValue>) -> bool {
-    crate::expressions::evaluate_without_tracking(&rule.condition, item, &None, &None)
+    crate::expressions::evaluate_without_tracking(&rule.condition, item, &rule.names, &rule.values)
         .unwrap_or(false)
 }
 
@@ -405,6 +545,8 @@ mod tests {
 
         let rule = ValidatedRule {
             condition: crate::expressions::condition::parse("attribute_exists(email)").unwrap(),
+            names: None,
+            values: None,
             path: vec![crate::expressions::PathElement::Attribute(
                 "email".to_string(),
             )],
@@ -413,6 +555,210 @@ mod tests {
         let rule_debug = format!("{:?}", rule);
         assert!(rule_debug.contains("[REDACTED]"));
         assert!(!rule_debug.contains("super"));
+    }
+
+    fn parsed_rule(toml_str: &str) -> Result<ValidatedRule, String> {
+        let config: ImportConfig = toml::from_str(toml_str).map_err(|e| e.to_string())?;
+        let rule = &config.rules[0];
+        let condition = condition::parse(&rule.match_expr).map_err(|e| e.to_string())?;
+        let names = convert_names(&rule.names, 1)?;
+        let values = convert_values(&rule.values, 1)?;
+        validate_name_refs(&condition, &names, 1)?;
+        validate_value_refs(&condition, &values, 1)?;
+        condition::validate_static(&condition, &values)?;
+        condition::validate_operand_semantics(&condition, &names, &values)?;
+        Ok(ValidatedRule {
+            condition,
+            names,
+            values,
+            path: parse_path(&rule.path)?,
+            action: validate_action(&rule.action, 1)?,
+        })
+    }
+
+    #[test]
+    fn test_values_table_feeds_begins_with() {
+        let rule = parsed_rule(
+            r#"
+[[rules]]
+match = "begins_with(pk, :prefix)"
+values = { ":prefix" = "USER#" }
+path = "email"
+action = { type = "redact" }
+"#,
+        )
+        .unwrap();
+
+        let mut item = HashMap::new();
+        item.insert("pk".to_string(), AttributeValue::S("USER#1".to_string()));
+        assert!(matches_item(&rule, &item));
+
+        item.insert("pk".to_string(), AttributeValue::S("ORDER#1".to_string()));
+        assert!(!matches_item(&rule, &item));
+    }
+
+    #[test]
+    fn test_values_convert_by_toml_type() {
+        let rule = parsed_rule(
+            r#"
+[[rules]]
+match = "age > :min AND active = :yes"
+values = { ":min" = 18, ":yes" = true }
+path = "name"
+action = { type = "redact" }
+"#,
+        )
+        .unwrap();
+        let values = rule.values.unwrap();
+        assert_eq!(values[":min"], AttributeValue::N("18".to_string()));
+        assert_eq!(values[":yes"], AttributeValue::BOOL(true));
+    }
+
+    #[test]
+    fn test_values_missing_reference_rejected() {
+        let err = parsed_rule(
+            r#"
+[[rules]]
+match = "begins_with(pk, :prefix)"
+path = "email"
+action = { type = "redact" }
+"#,
+        )
+        .unwrap_err();
+        assert!(err.contains(":prefix"), "{err}");
+        assert!(err.contains("does not define"), "{err}");
+    }
+
+    #[test]
+    fn test_values_unused_rejected() {
+        let err = parsed_rule(
+            r#"
+[[rules]]
+match = "attribute_exists(pk)"
+values = { ":prefix" = "USER#" }
+path = "email"
+action = { type = "redact" }
+"#,
+        )
+        .unwrap_err();
+        assert!(err.contains(":prefix"), "{err}");
+        assert!(err.contains("not referenced"), "{err}");
+    }
+
+    #[test]
+    fn test_values_name_must_start_with_colon() {
+        let err = parsed_rule(
+            r#"
+[[rules]]
+match = "begins_with(pk, :prefix)"
+values = { "prefix" = "USER#" }
+path = "email"
+action = { type = "redact" }
+"#,
+        )
+        .unwrap_err();
+        assert!(err.contains("must start with ':'"), "{err}");
+    }
+
+    #[test]
+    fn test_values_reject_non_finite_floats() {
+        let err = parsed_rule(
+            r#"
+[[rules]]
+match = "amount < :max"
+values = { ":max" = inf }
+path = "email"
+action = { type = "redact" }
+"#,
+        )
+        .unwrap_err();
+        assert!(err.contains("finite"), "{err}");
+    }
+
+    #[test]
+    fn test_values_of_the_wrong_type_are_rejected_up_front() {
+        let err = parsed_rule(
+            r#"
+[[rules]]
+match = "begins_with(pk, :prefix)"
+values = { ":prefix" = 123 }
+path = "email"
+action = { type = "redact" }
+"#,
+        )
+        .unwrap_err();
+        assert!(err.contains("begins_with"), "{err}");
+    }
+
+    #[test]
+    fn test_names_table_reaches_a_reserved_word_attribute() {
+        let rule = parsed_rule(
+            r##"
+[[rules]]
+match = "attribute_exists(#n)"
+names = { "#n" = "name" }
+path = "email"
+action = { type = "redact" }
+"##,
+        )
+        .unwrap();
+        let mut item = HashMap::new();
+        item.insert("name".to_string(), AttributeValue::S("Ada".to_string()));
+        assert!(matches_item(&rule, &item));
+        assert!(!matches_item(&rule, &HashMap::new()));
+    }
+
+    #[test]
+    fn test_names_undefined_or_unused_rejected() {
+        let err = parsed_rule(
+            r#"
+[[rules]]
+match = "attribute_exists(#n)"
+path = "email"
+action = { type = "redact" }
+"#,
+        )
+        .unwrap_err();
+        assert!(err.contains("#n"), "{err}");
+
+        let err = parsed_rule(
+            r##"
+[[rules]]
+match = "attribute_exists(pk)"
+names = { "#n" = "name" }
+path = "email"
+action = { type = "redact" }
+"##,
+        )
+        .unwrap_err();
+        assert!(err.contains("not referenced"), "{err}");
+
+        let err = parsed_rule(
+            r#"
+[[rules]]
+match = "attribute_exists(pk)"
+names = { "n" = "name" }
+path = "email"
+action = { type = "redact" }
+"#,
+        )
+        .unwrap_err();
+        assert!(err.contains("must start with '#'"), "{err}");
+    }
+
+    #[test]
+    fn test_values_reject_non_scalars() {
+        let err = parsed_rule(
+            r#"
+[[rules]]
+match = "begins_with(pk, :prefix)"
+values = { ":prefix" = ["USER#"] }
+path = "email"
+action = { type = "redact" }
+"#,
+        )
+        .unwrap_err();
+        assert!(err.contains("string, number or boolean"), "{err}");
     }
 
     #[test]

--- a/src/import/config.rs
+++ b/src/import/config.rs
@@ -325,6 +325,15 @@ pub(super) fn parse_path(path: &str) -> Result<Vec<crate::expressions::PathEleme
         if part.is_empty() {
             return Err("empty path segment".to_string());
         }
+        // A rule path names a real attribute. `#alias` is a match-expression
+        // idea, and the names table does not reach here, so accepting one
+        // would leave a rule that quietly matches nothing.
+        if part.starts_with('#') {
+            return Err(format!(
+                "'{part}' is an expression attribute name; a path names the attribute itself, \
+                 so write the attribute's own name here"
+            ));
+        }
 
         // Handle array indexing: `items[0]`
         if let Some(bracket_pos) = part.find('[') {
@@ -400,11 +409,21 @@ fn validate_action(action: &ActionConfig, rule_num: usize) -> Result<ValidatedAc
         ActionConfig::Hash { salt_env } => {
             let salt = match salt_env {
                 Some(env_var) => {
-                    std::env::var(env_var).map_err(|_| {
+                    let value = std::env::var(env_var).map_err(|_| {
                         format!(
                             "Rule {rule_num}: environment variable '{env_var}' not set (required for hash salt)"
                         )
-                    })?.into_bytes()
+                    })?;
+                    // An empty variable is the shape a missing CI secret takes,
+                    // and it would hash exactly as no salt at all.
+                    if value.is_empty() {
+                        return Err(format!(
+                            "Rule {rule_num}: environment variable '{env_var}' is empty. \
+                             SHA-256 without a salt is trivially reversible via rainbow tables, \
+                             so set it to a secret value"
+                        ));
+                    }
+                    value.into_bytes()
                 }
                 None => {
                     return Err(format!(
@@ -658,6 +677,27 @@ action = { type = "redact" }
         )
         .unwrap_err();
         assert!(err.contains("must start with ':'"), "{err}");
+    }
+
+    #[test]
+    fn test_path_rejects_an_expression_attribute_name() {
+        let err = parse_path("#n").unwrap_err();
+        assert!(err.contains("names the attribute itself"), "{err}");
+        assert!(parse_path("name").is_ok());
+    }
+
+    #[test]
+    fn test_empty_salt_is_rejected() {
+        // SAFETY: single-threaded test, no concurrent env reads
+        unsafe { std::env::set_var("DYNOXIDE_TEST_EMPTY_SALT", "") };
+        let action = ActionConfig::Hash {
+            salt_env: Some("DYNOXIDE_TEST_EMPTY_SALT".to_string()),
+        };
+        let err = validate_action(&action, 1).unwrap_err();
+        assert!(err.contains("is empty"), "{err}");
+
+        unsafe { std::env::set_var("DYNOXIDE_TEST_EMPTY_SALT", "s3cret") };
+        assert!(validate_action(&action, 1).is_ok());
     }
 
     #[test]

--- a/src/import/keys.rs
+++ b/src/import/keys.rs
@@ -23,7 +23,7 @@ use crate::schema::{DataModel, EntityDefinition};
 use crate::types::{AttributeValue, Item};
 use crate::validation::{partition_key_name, sort_key_name};
 
-use super::config::{ValidatedAction, ValidatedRule, parse_path};
+use super::config::{ValidatedAction, ValidatedRule, matches_item, parse_path};
 
 /// Rebuilt primary keys are remembered (as hashes) to spot two items
 /// collapsing onto one row. Past this many the check stops, and says so.
@@ -171,8 +171,14 @@ struct AtRisk {
     attribute: String,
     /// Entity indices that build a key from it, in model order.
     entities: Vec<usize>,
-    /// Entity indices actually seen in the data so far.
-    observed: HashSet<usize>,
+    /// Hash of each value seen, against the entity that carried it. A second
+    /// entity carrying a value already seen is the join, observed in the data
+    /// rather than inferred from the model.
+    seen_values: std::collections::HashMap<u64, usize>,
+    /// Entities that were found to share a value with another entity.
+    sharing: HashSet<usize>,
+    /// Set once `seen_values` hit its cap and stopped tracking.
+    capped: bool,
 }
 
 /// Which of an item's keys can be rebuilt after the rules run.
@@ -202,6 +208,13 @@ pub struct KeyDeriver {
     warned_unrenderable: HashSet<(usize, usize)>,
     /// Items that matched no entity, reported once per table.
     unmatched: usize,
+    /// Key attributes some rule rewrites directly. Whether the rule wins is
+    /// decided per item, since its condition may not match every entity that
+    /// builds that key.
+    rule_targeted: HashSet<String>,
+    /// (entity index, key index) pairs where a rule took the key instead of
+    /// its template, reported once.
+    warned_rule_wins: HashSet<(usize, usize)>,
     /// Attribute -> the entities that build a key from it, for attributes
     /// more than one entity keys on that are not consistency-tracked. Their
     /// keys cannot agree, so the entities stop joining.
@@ -279,17 +292,16 @@ impl KeyDeriver {
                     .collect(),
             );
 
-            keys.retain(|key| {
-                let targeted = rule_targets.contains(key.attribute.as_str());
-                if targeted {
+            for key in &keys {
+                if rule_targets.contains(key.attribute.as_str()) {
                     warnings.push(format!(
-                        "a rule targets key attribute '{}' directly, so it is not rebuilt \
-                         from entity '{}' template '{}'; the rule's value is kept as written",
+                        "a rule targets key attribute '{}' directly, so on any item that rule \
+                         matches it is not rebuilt from entity '{}' template '{}' and the \
+                         rule's value is kept as written",
                         key.attribute, entity.name, key.template
                     ));
                 }
-                !targeted
-            });
+            }
 
             for key in &keys {
                 for rule in rules {
@@ -386,7 +398,9 @@ impl KeyDeriver {
                 AtRisk {
                     attribute,
                     entities: entities_using,
-                    observed: HashSet::new(),
+                    seen_values: std::collections::HashMap::new(),
+                    sharing: HashSet::new(),
+                    capped: false,
                 }
             })
             .collect();
@@ -402,8 +416,10 @@ impl KeyDeriver {
                 type_attributes,
                 hash_attribute: hash.map(String::from),
                 range_attribute: range.map(String::from),
+                rule_targeted: rule_targets.iter().map(|s| s.to_string()).collect(),
                 warned_mismatch: HashSet::new(),
                 warned_unrenderable: HashSet::new(),
+                warned_rule_wins: HashSet::new(),
                 unmatched: 0,
                 at_risk,
                 rebuilt_keys: HashSet::new(),
@@ -420,21 +436,36 @@ impl KeyDeriver {
     /// item arrived with. Any key the template does not reproduce is left
     /// alone and reported (once per entity and key). An item that matches no
     /// entity is counted for [`take_unmatched`](Self::take_unmatched).
-    pub fn plan(&mut self, item: &Item, warnings: &mut Vec<String>) -> Option<Rederivation> {
+    pub fn plan(
+        &mut self,
+        item: &Item,
+        rules: &[ValidatedRule],
+        warnings: &mut Vec<String>,
+    ) -> Option<Rederivation> {
         let Some(entity_idx) = self.resolve_entity(item) else {
             self.unmatched += 1;
             return None;
         };
-        for risk in &mut self.at_risk {
-            if risk.entities.contains(&entity_idx) {
-                risk.observed.insert(entity_idx);
-            }
-        }
+        self.note_at_risk_values(entity_idx, item);
 
         let entity = &self.entities[entity_idx];
 
+        let mut rule_wins = Vec::new();
         let mut keys = Vec::new();
         for (idx, key) in entity.keys.iter().enumerate() {
+            // A rule that rewrites this key attribute wins over the template,
+            // but only on the items its condition actually matches. Deciding
+            // that per entity would leave the key unrebuilt on every item the
+            // rule never touches, real value intact.
+            if self.rule_targeted.contains(&key.attribute)
+                && rules.iter().any(|rule| {
+                    rule_target(rule) == Some(key.attribute.as_str()) && matches_item(rule, item)
+                })
+            {
+                rule_wins.push(idx);
+                continue;
+            }
+
             let Some(current) = item.get(&key.attribute) else {
                 // A sparse index key: nothing to rebuild.
                 continue;
@@ -455,10 +486,57 @@ impl KeyDeriver {
             }
         }
 
+        for idx in rule_wins {
+            if self.warned_rule_wins.insert((entity_idx, idx)) {
+                let key = &self.entities[entity_idx].keys[idx];
+                warnings.push(format!(
+                    "entity '{}': a rule rewrote {} directly, so it was not rebuilt from \
+                     template '{}'",
+                    self.entities[entity_idx].name, key.attribute, key.template
+                ));
+            }
+        }
+
         Some(Rederivation {
             entity: entity_idx,
             keys,
         })
+    }
+
+    /// Record this item's values for any at-risk attribute, so a value two
+    /// entities both carry is spotted. Presence of both entities is not
+    /// enough: two entities keyed on the same template with no value in
+    /// common never had a join to lose.
+    fn note_at_risk_values(&mut self, entity_idx: usize, item: &Item) {
+        for risk in &mut self.at_risk {
+            if !risk.entities.contains(&entity_idx) || risk.capped {
+                continue;
+            }
+            let Some(value) = item.get(&risk.attribute) else {
+                continue;
+            };
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            match value {
+                AttributeValue::S(s) => s.hash(&mut hasher),
+                AttributeValue::N(n) => n.hash(&mut hasher),
+                _ => continue,
+            }
+            let key = hasher.finish();
+            match risk.seen_values.get(&key) {
+                Some(previous) if *previous != entity_idx => {
+                    risk.sharing.insert(*previous);
+                    risk.sharing.insert(entity_idx);
+                }
+                Some(_) => {}
+                None => {
+                    if risk.seen_values.len() >= MAX_TRACKED_KEYS {
+                        risk.capped = true;
+                        continue;
+                    }
+                    risk.seen_values.insert(key, entity_idx);
+                }
+            }
+        }
     }
 
     /// After the rules run: render every planned key from the item's current
@@ -521,20 +599,22 @@ impl KeyDeriver {
     /// Attributes whose entities have now both turned up in the data, so the
     /// join between them is actually broken rather than merely at risk.
     ///
-    /// Checked once the items have been read rather than up front: the model
-    /// says the two entities *can* collide, but an import holding only one of
-    /// them has no join to lose, and failing there would earn a bypass flag.
+    /// Checked once the items have been read rather than up front, and only
+    /// for a value two entities actually share. The model says the two
+    /// entities *can* collide; an import holding only one of them, or holding
+    /// both with no value in common, has no join to lose, and failing there
+    /// would earn a bypass flag.
     pub fn join_breaks(&self) -> Vec<String> {
         self.at_risk
             .iter()
-            .filter(|risk| risk.observed.len() > 1)
+            .filter(|risk| risk.sharing.len() > 1)
             .map(|risk| {
-                let mut seen: Vec<usize> = risk.observed.iter().copied().collect();
+                let mut seen: Vec<usize> = risk.sharing.iter().copied().collect();
                 seen.sort();
                 format!(
-                    "{} were both imported and both build keys from '{}', which is not in \
-                     [consistency] fields, so the same value anonymised differently for each \
-                     and they no longer join. Add '{}' to [consistency] fields",
+                    "{} share a value of '{}', which is not in [consistency] fields, so it \
+                     anonymised differently for each and their keys no longer agree. \
+                     Add '{}' to [consistency] fields",
                     entity_list(&self.entities, &seen),
                     risk.attribute,
                     risk.attribute
@@ -867,7 +947,7 @@ mod tests {
             ("customerId", "cust1"),
             ("orderNo", "42"),
         ]);
-        let plan = d.plan(&order, &mut item_warnings).unwrap();
+        let plan = d.plan(&order, &[], &mut item_warnings).unwrap();
         assert!(item_warnings.is_empty(), "{item_warnings:?}");
         assert_eq!(plan.keys.len(), 2);
 
@@ -922,7 +1002,7 @@ mod tests {
         let mut warnings = Vec::new();
         let mut user = user();
 
-        let plan = d.plan(&user, &mut warnings).unwrap();
+        let plan = d.plan(&user, &[], &mut warnings).unwrap();
         assert!(warnings.is_empty(), "{warnings:?}");
         assert_eq!(plan.keys.len(), 3);
 
@@ -959,7 +1039,7 @@ mod tests {
                 ("accountId", "acc1"),
                 ("email", "alice@example.com"),
             ]);
-            let plan = d.plan(&user, &mut warnings).unwrap();
+            let plan = d.plan(&user, &[], &mut warnings).unwrap();
             assert_eq!(plan.keys.len(), 1, "only pk reproduces");
 
             user.insert(
@@ -987,7 +1067,7 @@ mod tests {
         let mut user = user();
         user.remove("gs1pk");
         user.remove("gs1sk");
-        let plan = d.plan(&user, &mut warnings).unwrap();
+        let plan = d.plan(&user, &[], &mut warnings).unwrap();
         assert_eq!(plan.keys.len(), 2);
         assert!(warnings.is_empty(), "{warnings:?}");
     }
@@ -1005,12 +1085,12 @@ mod tests {
             ("accountId", "acc1"),
             ("email", "alice@example.com"),
         ]);
-        d.plan(&legacy, &mut warnings).unwrap();
+        d.plan(&legacy, &[], &mut warnings).unwrap();
         assert_eq!(warnings.len(), 1);
 
         // Second item: sk on-template, but the rule nulls email so it cannot render.
         let mut user = user();
-        let plan = d.plan(&user, &mut warnings).unwrap();
+        let plan = d.plan(&user, &[], &mut warnings).unwrap();
         user.insert("email".to_string(), AttributeValue::NULL(true));
         d.apply(&plan, &mut user, &mut warnings);
 
@@ -1035,15 +1115,15 @@ mod tests {
             ("accountId", "acc1"),
             ("email", "alice@example.com"),
         ]);
-        let plan = d.plan(&user, &mut warnings).unwrap();
+        let plan = d.plan(&user, &[], &mut warnings).unwrap();
         assert_eq!(d.entities[plan.entity].name, "User");
 
         let account = item(&[("pk", "account#acc1"), ("sk", "account#"), ("id", "acc1")]);
-        let plan = d.plan(&account, &mut warnings).unwrap();
+        let plan = d.plan(&account, &[], &mut warnings).unwrap();
         assert_eq!(d.entities[plan.entity].name, "Account");
 
         let stranger = item(&[("pk", "thing#1"), ("sk", "meta")]);
-        assert!(d.plan(&stranger, &mut warnings).is_none());
+        assert!(d.plan(&stranger, &[], &mut warnings).is_none());
         assert_eq!(d.take_unmatched(), 1);
         assert_eq!(d.take_unmatched(), 0);
         assert!(warnings.is_empty(), "{warnings:?}");
@@ -1061,24 +1141,69 @@ mod tests {
     }
 
     #[test]
-    fn a_rule_on_a_key_attribute_wins_over_the_template() {
+    fn a_rule_on_a_key_attribute_wins_on_the_items_it_matches() {
         let rules = [rule("sk", ValidatedAction::Redact)];
         let (mut d, warnings) =
             KeyDeriver::new(&model(), &request(), &rules, &no_consistency()).unwrap();
-        assert_eq!(tracked(&d, 1), vec!["pk", "gs1pk"]);
+        // The key stays tracked: whether the rule wins is an per-item question.
+        assert_eq!(tracked(&d, 1), vec!["pk", "sk", "gs1pk"]);
         assert_eq!(warnings.len(), 1, "{warnings:?}");
         assert!(warnings[0].contains("targets key attribute 'sk' directly"));
 
         let mut item_warnings = Vec::new();
         let mut user = user();
-        let plan = d.plan(&user, &mut item_warnings).unwrap();
+        let plan = d.plan(&user, &rules, &mut item_warnings).unwrap();
         user.insert(
             "sk".to_string(),
             AttributeValue::S("[REDACTED]".to_string()),
         );
         d.apply(&plan, &mut user, &mut item_warnings);
         assert_eq!(user["sk"], AttributeValue::S("[REDACTED]".to_string()));
-        assert!(item_warnings.is_empty(), "{item_warnings:?}");
+        assert!(
+            item_warnings
+                .iter()
+                .any(|w| w.contains("a rule rewrote sk")),
+            "{item_warnings:?}"
+        );
+    }
+
+    #[test]
+    fn a_rule_on_a_key_that_does_not_match_this_item_leaves_the_rebuild_alone() {
+        // The rule targets sk but only matches Account items. A User's sk
+        // must still be rebuilt, or the real email survives in the key.
+        let rules = [
+            ValidatedRule {
+                condition: condition::parse("attribute_exists(accountName)").unwrap(),
+                names: None,
+                values: None,
+                path: parse_path("sk").unwrap(),
+                action: ValidatedAction::Redact,
+            },
+            rule(
+                "email",
+                ValidatedAction::Fake {
+                    generator: "safe_email".into(),
+                },
+            ),
+        ];
+        let (mut d, _) = KeyDeriver::new(&model(), &request(), &rules, &no_consistency()).unwrap();
+
+        let mut warnings = Vec::new();
+        let mut user = user();
+        assert!(!user.contains_key("accountName"), "the rule must not match");
+        let plan = d.plan(&user, &rules, &mut warnings).unwrap();
+
+        user.insert(
+            "email".to_string(),
+            AttributeValue::S("fake@example.org".to_string()),
+        );
+        d.apply(&plan, &mut user, &mut warnings);
+
+        assert_eq!(
+            user["sk"],
+            AttributeValue::S("user#fake@example.org".to_string()),
+            "sk must be rebuilt: the sk rule never matched this item"
+        );
     }
 
     #[test]
@@ -1191,7 +1316,7 @@ mod tests {
                 ("sk", "PROFILE"),
                 ("email", &format!("c{n}@x.co")),
             ]);
-            d.plan(&customer, &mut warnings).unwrap();
+            d.plan(&customer, &email_rule(), &mut warnings).unwrap();
         }
 
         assert!(
@@ -1218,7 +1343,7 @@ mod tests {
             ("sk", "PROFILE"),
             ("email", "a@x.co"),
         ]);
-        d.plan(&customer, &mut warnings).unwrap();
+        d.plan(&customer, &email_rule(), &mut warnings).unwrap();
         assert!(d.join_breaks().is_empty(), "one entity so far");
 
         let order = item(&[
@@ -1228,12 +1353,48 @@ mod tests {
             ("email", "a@x.co"),
             ("orderId", "1"),
         ]);
-        d.plan(&order, &mut warnings).unwrap();
+        d.plan(&order, &email_rule(), &mut warnings).unwrap();
 
         let breaks = d.join_breaks();
         assert_eq!(breaks.len(), 1, "{breaks:?}");
         assert!(breaks[0].contains("entity 'Customer' and entity 'Order'"));
         assert!(breaks[0].contains("Add 'email' to [consistency] fields"));
+    }
+
+    #[test]
+    fn both_entities_with_no_value_in_common_is_not_a_broken_join() {
+        let (mut d, _) = KeyDeriver::new(
+            &shared_key_model(),
+            &request(),
+            &email_rule(),
+            &no_consistency(),
+        )
+        .unwrap();
+        let mut warnings = Vec::new();
+
+        let customer = item(&[
+            ("_type", "Customer"),
+            ("pk", "CUSTOMER#a@x.co"),
+            ("sk", "PROFILE"),
+            ("email", "a@x.co"),
+        ]);
+        d.plan(&customer, &email_rule(), &mut warnings).unwrap();
+
+        // A different address, so these two never joined.
+        let order = item(&[
+            ("_type", "Order"),
+            ("pk", "CUSTOMER#b@y.co"),
+            ("sk", "ORDER#1"),
+            ("email", "b@y.co"),
+            ("orderId", "1"),
+        ]);
+        d.plan(&order, &email_rule(), &mut warnings).unwrap();
+
+        assert!(
+            d.join_breaks().is_empty(),
+            "both entities present but no shared value: {:?}",
+            d.join_breaks()
+        );
     }
 
     #[test]
@@ -1248,7 +1409,7 @@ mod tests {
                 ("accountId", "acc1"),
                 ("email", &format!("u{n}@example.com")),
             ]);
-            let plan = d.plan(&user, &mut warnings).unwrap();
+            let plan = d.plan(&user, &[], &mut warnings).unwrap();
             user.insert(
                 "email".to_string(),
                 AttributeValue::S("[REDACTED]".to_string()),

--- a/src/import/keys.rs
+++ b/src/import/keys.rs
@@ -29,6 +29,11 @@ use super::config::{ValidatedAction, ValidatedRule, parse_path};
 /// collapsing onto one row. Past this many the check stops, and says so.
 pub(super) const MAX_TRACKED_KEYS: usize = 1_000_000;
 
+/// Longest `${name:length:pad}` padding a key is allowed to ask for. A key is
+/// capped at 2048 bytes, so anything past this is a typo rather than intent,
+/// and rendering it would look like a hang.
+const MAX_PAD_LENGTH: usize = 4096;
+
 /// One piece of a `${name}` template.
 #[derive(Debug, Clone, PartialEq)]
 enum Segment {
@@ -54,9 +59,6 @@ struct Padding {
 impl Padding {
     fn apply(&self, value: &str) -> String {
         let mut out = value.to_string();
-        if self.fill.is_empty() {
-            return out;
-        }
         while out.chars().count() < self.length {
             out.insert_str(0, &self.fill);
         }
@@ -91,10 +93,19 @@ fn parse_template(template: &str) -> Result<Vec<Segment>, String> {
                          the form is '${{name:length:pad}}'"
                     )
                 })?;
-                Some(Padding {
-                    length,
-                    fill: parts.next().unwrap_or("0").to_string(),
-                })
+                if length > MAX_PAD_LENGTH {
+                    return Err(format!(
+                        "template '{template}': a pad length of {length} is beyond the {MAX_PAD_LENGTH} \
+                         a key can usefully hold"
+                    ));
+                }
+                // OneTable treats an empty pad character as "0" (`pad || '0'`),
+                // and an empty one would also never reach the length.
+                let fill = match parts.next() {
+                    Some("") | None => "0".to_string(),
+                    Some(fill) => fill.to_string(),
+                };
+                Some(Padding { length, fill })
             }
             None => None,
         };
@@ -183,8 +194,6 @@ struct EntityKeys {
 struct AtRisk {
     /// The key attribute the shared template builds.
     key_attribute: String,
-    /// The template itself, for the message.
-    template: String,
     /// Root field names to put in `[consistency] fields`. Roots, because
     /// that is what the consistency map is keyed on: advising `contact.email`
     /// when only `contact` is honoured would send someone in a circle.
@@ -197,11 +206,25 @@ struct AtRisk {
     /// merely share a component: `TENANT#a#x` and `TENANT#b#x` never agreed,
     /// so they have nothing to lose. A deterministic action such as hash
     /// takes both to the same place and stays quiet.
-    seen_keys: std::collections::HashMap<u64, Vec<(usize, u64)>>,
+    seen_keys: std::collections::HashMap<u64, Vec<Outcome>>,
     /// Entities found to have taken a shared key to different values.
     diverged: HashSet<usize>,
-    /// Set once `seen_keys` hit its cap and stopped tracking.
-    capped: bool,
+    /// Keys that went unchecked after the cap.
+    unchecked: usize,
+}
+
+/// What one entity made of one original key value.
+///
+/// A summary rather than every value: many items of one entity sharing a
+/// customer key would otherwise keep a row each, and be rescanned per item.
+/// The first result, plus whether that entity ever produced a second, is
+/// enough to spot a disagreement with another entity.
+#[derive(Debug, Clone, Copy)]
+struct Outcome {
+    entity: usize,
+    first: u64,
+    /// This entity produced more than one distinct result for the key.
+    multiple: bool,
 }
 
 /// Which of an item's keys can be rebuilt after the rules run.
@@ -273,6 +296,22 @@ impl KeyDeriver {
 
         let rule_targets: HashSet<&str> = rules.iter().filter_map(rule_target).collect();
         let mut warnings = Vec::new();
+        let mut unmatched_indexes: HashSet<String> = HashSet::new();
+
+        // A local secondary index never reaches the model: OneTable declares
+        // one with a sort key and no hash, and the parser keeps only indexes
+        // that name a hash attribute. Say so rather than leave its sort key
+        // quietly holding the value it arrived with.
+        if let Some(lsis) = request.local_secondary_indexes.as_deref()
+            && !lsis.is_empty()
+        {
+            warnings.push(format!(
+                "table '{}' has {} local secondary index(es); their sort keys are not rebuilt \
+                 from templates and keep the values they arrive with",
+                request.table_name,
+                lsis.len()
+            ));
+        }
 
         let mut entities = Vec::with_capacity(model.entities.len());
         type KeyShape = (String, String, Vec<Vec<PathElement>>);
@@ -289,6 +328,18 @@ impl KeyDeriver {
 
             for mapping in &entity.gsi_mappings {
                 let Some(gsi) = gsis.iter().find(|g| g.index_name == mapping.index_name) else {
+                    // OneTable defaults an index's name to its schema key
+                    // ("gs1"), which rarely matches the deployed index
+                    // ("GSI1"). Silently skipping would leave that index's
+                    // key holding whatever it arrived with.
+                    if unmatched_indexes.insert(mapping.index_name.clone()) {
+                        warnings.push(format!(
+                            "the data model has an index '{}' that table '{}' does not: its keys \
+                             are not rebuilt and keep the values they arrive with. Set the \
+                             OneTable index's \"name\" to the DynamoDB index name",
+                            mapping.index_name, request.table_name
+                        ));
+                    }
                     continue;
                 };
                 push_key(
@@ -364,20 +415,38 @@ impl KeyDeriver {
                     let Some(target) = rule_target(rule) else {
                         continue;
                     };
-                    let collapses = match rule.action {
-                        ValidatedAction::Redact | ValidatedAction::Null => "every",
-                        ValidatedAction::Mask { .. } => "most",
+
+                    if !key.sources().any(|source| source == target) {
+                        continue;
+                    }
+                    let consequence = match rule.action {
+                        // NULL is not a string, so the template cannot render
+                        // at all and the key keeps the value it arrived with.
+                        // That is the opposite of collapsing, and worse.
+                        ValidatedAction::Null => format!(
+                            "no item of that entity can rebuild {}, so every one of them keeps \
+                             the key value it arrived with. Use fake or hash instead",
+                            key.attribute
+                        ),
+                        ValidatedAction::Redact => format!(
+                            "every item of that entity renders the same {} and overwrites the \
+                             last, leaving fewer rows than the export. Use fake or hash instead",
+                            key.attribute
+                        ),
+                        // Masking keeps the last few characters, so two
+                        // different values often mask to the same thing.
+                        ValidatedAction::Mask { .. } => format!(
+                            "items of that entity whose '{target}' masks to the same text render \
+                             the same {} and overwrite each other. Use fake or hash instead",
+                            key.attribute
+                        ),
                         ValidatedAction::Fake { .. } | ValidatedAction::Hash { .. } => continue,
                     };
-                    if key.sources().any(|source| source == target) {
-                        warnings.push(format!(
-                            "a rule replaces '{target}' with a constant, and entity '{}' builds \
-                             {} from template '{}': {collapses} item of that entity would render \
-                             the same key and collapse onto one row. Use fake or hash for an \
-                             attribute a key is built from",
-                            entity.name, key.attribute, key.template
-                        ));
-                    }
+                    warnings.push(format!(
+                        "a rule rewrites '{target}', which entity '{}' builds {} from via \
+                         template '{}': {consequence}",
+                        entity.name, key.attribute, key.template
+                    ));
                 }
             }
 
@@ -389,39 +458,35 @@ impl KeyDeriver {
             });
         }
 
-        // Two entities that build the *same* key attribute from the *same*
-        // template are asserting their keys agree, which is how a
-        // single-table design keeps a customer and its orders in one
-        // partition. If a rule rewrites an attribute that template reads and
-        // it is not consistency-tracked, each entity anonymises it
-        // independently and the two stop agreeing.
+        // Two entities that build the same key attribute are asserting their
+        // keys can agree, which is how a single-table design keeps a customer
+        // and its orders in one partition. If a rule rewrites an attribute
+        // one of those templates reads, each entity anonymises it
+        // independently and the two can stop agreeing.
         //
-        // Matching on the (attribute, template) pair rather than on the
-        // attribute name alone is what keeps this off entities that merely
-        // reuse a name: `account#${id}` and `project#${id}` are different
-        // entities' own ids, and never had a join to lose.
-        // Grouped by the key and its template as well as the source, so two
-        // unrelated pairs that happen to read an attribute of the same name
-        // stay separate: A and B sharing `account#${id}` have nothing to do
-        // with C and D sharing `project#${id}`.
-        // Grouped by the key and its template, so two unrelated pairs that
-        // happen to read an attribute of the same name stay separate: A and B
-        // sharing `account#${id}` have nothing to do with C and D sharing
-        // `project#${id}`.
-        /// (key attribute, template) -> (entities building it, roots needing consistency)
-        type SharedGroups = Vec<((String, String), (Vec<usize>, Vec<String>))>;
+        // Grouping on the key attribute alone, not on the template text, is
+        // deliberate: the canonical join is `CUSTOMER#${id}` against
+        // `CUSTOMER#${customerId}`, two different templates that produce the
+        // same partition. Requiring identical text would miss it. Unrelated
+        // entities that merely share a key name cost nothing here, because
+        // what is actually compared later is the key *value* an item arrived
+        // with, and `account#acc1` never equalled `project#p1`.
+        //
+        // Consistency-tracked roots are tracked too, and only excused from
+        // the warning. The consistency map stops taking new values at its own
+        // cap and starts handing out fresh ones, so a field listed in
+        // [consistency] is not a permanent guarantee, and the value check is
+        // what notices when it lapses.
+        type SharedGroups = Vec<(String, (Vec<usize>, Vec<String>))>;
         let mut shared: SharedGroups = Vec::new();
         for (idx, shape) in entity_key_shapes.iter().enumerate() {
-            for (attribute, template, sources) in shape {
+            for (attribute, _template, sources) in shape {
                 let shared_with_another =
                     entity_key_shapes
                         .iter()
                         .enumerate()
                         .any(|(other, other_shape)| {
-                            other != idx
-                                && other_shape
-                                    .iter()
-                                    .any(|(a, t, _)| a == attribute && t == template)
+                            other != idx && other_shape.iter().any(|(a, _, _)| a == attribute)
                         });
                 if !shared_with_another {
                     continue;
@@ -434,15 +499,12 @@ impl KeyDeriver {
                         Some(PathElement::Attribute(root)) => Some(root.clone()),
                         _ => None,
                     })
-                    .filter(|root| {
-                        !consistency_fields.contains(root) && rule_targets.contains(root.as_str())
-                    })
+                    .filter(|root| rule_targets.contains(root.as_str()))
                     .collect();
                 if roots.is_empty() {
                     continue;
                 }
-                let group = (attribute.clone(), template.clone());
-                match shared.iter_mut().find(|(k, _)| *k == group) {
+                match shared.iter_mut().find(|(k, _)| k == attribute) {
                     Some((_, (users, known_roots))) => {
                         if !users.contains(&idx) {
                             users.push(idx);
@@ -453,7 +515,7 @@ impl KeyDeriver {
                             }
                         }
                     }
-                    None => shared.push((group, (vec![idx], roots))),
+                    None => shared.push((attribute.clone(), (vec![idx], roots))),
                 }
             }
         }
@@ -466,28 +528,31 @@ impl KeyDeriver {
 
         let at_risk: Vec<AtRisk> = shared
             .into_iter()
-            .map(
-                |((key_attribute, template), (entities_using, consistency_roots))| {
+            .map(|(key_attribute, (entities_using, roots))| {
+                let unlisted: Vec<String> = roots
+                    .iter()
+                    .filter(|root| !consistency_fields.contains(*root))
+                    .cloned()
+                    .collect();
+                if !unlisted.is_empty() {
                     warnings.push(format!(
-                        "{} both build {} from template '{}', which reads {} outside \
-                     [consistency] fields: if they both appear in this import their keys \
-                     will not agree and the entities will not join",
+                        "{} both build {} from an attribute outside [consistency] fields ({}): \
+                         if they both appear in this import their keys may not agree and the \
+                         entities will not join",
                         entity_list(&entities, &entities_using),
                         key_attribute,
-                        template,
-                        quoted_list(&consistency_roots)
+                        quoted_list(&unlisted)
                     ));
-                    AtRisk {
-                        key_attribute,
-                        template,
-                        consistency_roots,
-                        entities: entities_using,
-                        seen_keys: std::collections::HashMap::new(),
-                        diverged: HashSet::new(),
-                        capped: false,
-                    }
-                },
-            )
+                }
+                AtRisk {
+                    key_attribute,
+                    consistency_roots: if unlisted.is_empty() { roots } else { unlisted },
+                    entities: entities_using,
+                    seen_keys: std::collections::HashMap::new(),
+                    diverged: HashSet::new(),
+                    unchecked: 0,
+                }
+            })
             .collect();
 
         let mut type_attributes: Vec<String> =
@@ -525,7 +590,6 @@ impl KeyDeriver {
             self.unmatched += 1;
             return None;
         };
-        let at_risk_originals = self.at_risk_originals(entity_idx, item);
 
         let entity = &self.entities[entity_idx];
 
@@ -551,6 +615,18 @@ impl KeyDeriver {
             }
         }
 
+        // Only a key that will actually be rebuilt takes part in the join
+        // check. One left holding its original value has already been
+        // reported as a template that does not reproduce, and that is the
+        // accurate diagnostic: comparing it against an entity that did
+        // rebuild would call it a broken join and advise [consistency],
+        // which cannot fix an attribute the item does not carry.
+        let rebuilt: Vec<&str> = keys
+            .iter()
+            .map(|idx| entity.keys[*idx].attribute.as_str())
+            .collect();
+        let at_risk_originals = self.at_risk_originals(entity_idx, item, &rebuilt);
+
         Some(Rederivation {
             entity: entity_idx,
             keys,
@@ -558,12 +634,21 @@ impl KeyDeriver {
         })
     }
 
-    /// The value this item arrived with for each at-risk attribute, hashed.
-    fn at_risk_originals(&self, entity_idx: usize, item: &Item) -> Vec<(usize, u64)> {
+    /// The key value this item arrived with, for each at-risk group whose key
+    /// this item will actually rebuild.
+    fn at_risk_originals(
+        &self,
+        entity_idx: usize,
+        item: &Item,
+        rebuilt: &[&str],
+    ) -> Vec<(usize, u64)> {
         self.at_risk
             .iter()
             .enumerate()
-            .filter(|(_, risk)| risk.entities.contains(&entity_idx) && !risk.capped)
+            .filter(|(_, risk)| {
+                risk.entities.contains(&entity_idx)
+                    && rebuilt.iter().any(|a| *a == risk.key_attribute)
+            })
             .filter_map(|(idx, risk)| Some((idx, scalar_hash(item.get(&risk.key_attribute)?)?)))
             .collect()
     }
@@ -575,35 +660,45 @@ impl KeyDeriver {
     fn note_at_risk_results(&mut self, plan: &Rederivation, item: &Item) {
         for (risk_idx, original) in &plan.at_risk_originals {
             let risk = &mut self.at_risk[*risk_idx];
-            if risk.capped {
-                continue;
-            }
             let Some(now) = item.get(&risk.key_attribute).and_then(scalar_hash) else {
                 continue;
             };
 
-            if !risk.seen_keys.contains_key(original) && risk.seen_keys.len() >= MAX_TRACKED_KEYS {
-                risk.capped = true;
-                continue;
-            }
-            let outcomes = risk.seen_keys.entry(*original).or_default();
-
-            // Every distinct outcome is kept, not just the first, or whether
-            // a break is noticed would depend on the order the export happens
-            // to be in.
-            let mut diverged_with: Vec<usize> = outcomes
-                .iter()
-                .filter(|(entity, result)| *entity != plan.entity && *result != now)
-                .map(|(entity, _)| *entity)
-                .collect();
-            if !outcomes.contains(&(plan.entity, now)) {
-                outcomes.push((plan.entity, now));
-            }
-            if !diverged_with.is_empty() {
-                diverged_with.push(plan.entity);
-                for entity in diverged_with {
-                    risk.diverged.insert(entity);
+            // A key already recorded is still compared after the cap. Only a
+            // key never seen before goes unchecked, and that is counted so
+            // the run can say the check was partial rather than clean.
+            if !risk.seen_keys.contains_key(original) {
+                if risk.seen_keys.len() >= MAX_TRACKED_KEYS {
+                    risk.unchecked += 1;
+                    continue;
                 }
+                risk.seen_keys.insert(*original, Vec::new());
+            }
+            let outcomes = risk.seen_keys.get_mut(original).expect("just inserted");
+
+            match outcomes.iter_mut().find(|o| o.entity == plan.entity) {
+                Some(mine) => mine.multiple |= mine.first != now,
+                None => outcomes.push(Outcome {
+                    entity: plan.entity,
+                    first: now,
+                    multiple: false,
+                }),
+            }
+
+            // Two entities disagree when their results differ, or when either
+            // produced more than one result, since one of those must differ
+            // from what the other produced.
+            let mut diverged: Vec<usize> = Vec::new();
+            for (i, a) in outcomes.iter().enumerate() {
+                for b in outcomes.iter().skip(i + 1) {
+                    if a.first != b.first || a.multiple || b.multiple {
+                        diverged.push(a.entity);
+                        diverged.push(b.entity);
+                    }
+                }
+            }
+            for entity in diverged {
+                risk.diverged.insert(entity);
             }
         }
     }
@@ -619,7 +714,6 @@ impl KeyDeriver {
         warnings: &mut Vec<String>,
     ) {
         let entity = &self.entities[plan.entity];
-        let mut rebuilt_primary = false;
         let mut rule_wins = Vec::new();
         for &idx in &plan.keys {
             let key = &entity.keys[idx];
@@ -634,9 +728,6 @@ impl KeyDeriver {
             match render(&key.segments, item) {
                 Some(value) => {
                     item.insert(key.attribute.clone(), AttributeValue::S(value));
-                    rebuilt_primary |= Some(key.attribute.as_str())
-                        == self.hash_attribute.as_deref()
-                        || Some(key.attribute.as_str()) == self.range_attribute.as_deref();
                 }
                 None => {
                     if self.warned_unrenderable.insert((plan.entity, idx)) {
@@ -660,15 +751,17 @@ impl KeyDeriver {
                 ));
             }
         }
-        if rebuilt_primary {
-            self.note_rebuilt_primary_key(item);
-        }
+
+        // Every item's primary key is recorded, not only a rebuilt one: a
+        // rebuilt key can land on a row that was left alone, and counting
+        // only rebuilds would miss the row that got overwritten.
+        self.note_primary_key(item);
         self.note_at_risk_results(plan, item);
     }
 
-    /// Remember a rebuilt primary key so a later item rendering the same one
-    /// is counted as a collision.
-    fn note_rebuilt_primary_key(&mut self, item: &Item) {
+    /// Remember this item's primary key so a later item landing on the same
+    /// one is counted as a collision.
+    fn note_primary_key(&mut self, item: &Item) {
         if self.collision_check_capped {
             return;
         }
@@ -723,16 +816,20 @@ impl KeyDeriver {
 
                 format!(
                     "{} took the same original {} to different values, so their keys no longer \
-                     agree and they will not join. Template '{}' reads {}: add {} to \
-                     [consistency] fields",
+                     agree and they will not join. Give both entities the same attribute name \
+                     for that value and add {} to [consistency] fields",
                     entity_list(&self.entities, &seen),
                     risk.key_attribute,
-                    risk.template,
-                    quoted_list(&risk.consistency_roots),
                     quoted_list(&risk.consistency_roots)
                 )
             })
             .collect()
+    }
+
+    /// Keys the join check could not take on after its cap, so the caller
+    /// can say the check was partial rather than clean.
+    pub fn unchecked_join_keys(&self) -> usize {
+        self.at_risk.iter().map(|risk| risk.unchecked).sum()
     }
 
     /// Number of items since the last call that matched no entity.
@@ -1360,7 +1457,7 @@ mod tests {
             KeyDeriver::new(&model(), &request(), &rules, &no_consistency()).unwrap();
         // sk and gs1pk of User both build from email
         assert_eq!(warnings.len(), 2, "{warnings:?}");
-        assert!(warnings[0].contains("collapse onto one row"));
+        assert!(warnings[0].contains("overwrites the last"), "{warnings:?}");
         assert!(warnings[0].contains("'email'"));
 
         let rules = [rule(
@@ -1570,10 +1667,11 @@ mod tests {
     }
 
     #[test]
-    fn unrelated_pairs_reading_the_same_attribute_name_are_separate_risks() {
-        // Account/Team share account#${id}; Project/Task share project#${id}.
-        // Same source name, two unrelated groups, so importing one from each
-        // must not read as a broken join between them.
+    fn unrelated_pairs_reading_the_same_attribute_name_never_shared_a_key() {
+        // Account/Team build account#${id}; Project/Task build project#${id}.
+        // They share a key attribute and a source name, so they warn together,
+        // but their key *values* never matched, so importing one from each
+        // must not read as a broken join.
         let model = model_with(vec![
             entity("Account", "account#${id}", Some("account#"), None),
             entity("Project", "project#${id}", Some("project#"), None),
@@ -1588,7 +1686,8 @@ mod tests {
         )];
         let (mut d, warnings) =
             KeyDeriver::new(&model, &request(), &rules, &no_consistency()).unwrap();
-        assert_eq!(warnings.len(), 2, "one per group: {warnings:?}");
+        // One group per key attribute; the four entities all build pk.
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
 
         // One entity from each group, sharing an original id.
         let mut run = |name: &str, pk: &str, sk: &str, becomes: &str| {
@@ -1633,11 +1732,7 @@ mod tests {
         let (mut d, warnings) =
             KeyDeriver::new(&model, &request(), &rules, &no_consistency()).unwrap();
         assert!(
-            warnings.iter().any(|w| w.contains("${contact.email}")),
-            "the template should be shown: {warnings:?}"
-        );
-        assert!(
-            warnings.iter().any(|w| w.contains("reads 'contact'")),
+            warnings.iter().any(|w| w.contains("('contact')")),
             "the root is what [consistency] honours: {warnings:?}"
         );
 
@@ -1806,6 +1901,245 @@ mod tests {
             "different tenants never shared a key: {:?}",
             d.join_breaks()
         );
+    }
+
+    #[test]
+    fn one_entity_repeating_a_key_keeps_a_bounded_summary() {
+        // Many orders share one customer key and each gets its own fake, so
+        // keeping every outcome would grow without limit and be rescanned
+        // per item. One summary row per entity is enough.
+        let mut d = shared_key_deriver();
+        for n in 0..50 {
+            run_item(
+                &mut d,
+                order_item("a@x.co"),
+                &format!("fake{n}@example.org"),
+            );
+        }
+
+        let outcomes: usize = d
+            .at_risk
+            .iter()
+            .map(|r| r.seen_keys.values().map(Vec::len).sum::<usize>())
+            .sum();
+        assert_eq!(outcomes, 1, "one row per entity per key, not per item");
+        assert!(
+            d.join_breaks().is_empty(),
+            "one entity disagreeing with itself is not a cross-entity break: {:?}",
+            d.join_breaks()
+        );
+
+        // The customer still finds the disagreement.
+        run_item(&mut d, customer_item("a@x.co"), "different@example.com");
+        assert_eq!(d.join_breaks().len(), 1);
+    }
+
+    #[test]
+    fn keys_seen_before_the_cap_are_still_checked_after_it() {
+        let mut d = shared_key_deriver();
+        // Record the customer, then fill the map to its cap.
+        run_item(&mut d, customer_item("a@x.co"), "fake1@example.com");
+        for risk in &mut d.at_risk {
+            while risk.seen_keys.len() < MAX_TRACKED_KEYS {
+                let filler = risk.seen_keys.len() as u64 + 1_000_000;
+                risk.seen_keys.insert(filler, Vec::new());
+            }
+        }
+
+        // A brand new key cannot be taken on, and is counted.
+        run_item(&mut d, order_item("b@y.co"), "fake2@example.org");
+        assert!(d.unchecked_join_keys() > 0, "the new key went unchecked");
+
+        // The key recorded before the cap is still compared.
+        run_item(&mut d, order_item("a@x.co"), "different@example.org");
+        assert_eq!(
+            d.join_breaks().len(),
+            1,
+            "a key seen before the cap must still be checked: {:?}",
+            d.join_breaks()
+        );
+    }
+
+    #[test]
+    fn a_join_across_two_different_templates_is_still_seen() {
+        // The canonical single-table join: the customer keys on its own
+        // address, the order keys on the customer's. Different template text,
+        // same partition. Matching on the text would miss it entirely.
+        let model = model_with(vec![
+            entity("Customer", "CUSTOMER#${email}", Some("PROFILE"), None),
+            entity(
+                "Order",
+                "CUSTOMER#${customerEmail}",
+                Some("ORDER#${id}"),
+                None,
+            ),
+        ]);
+        let rules = [
+            rule(
+                "email",
+                ValidatedAction::Fake {
+                    generator: "safe_email".into(),
+                },
+            ),
+            rule(
+                "customerEmail",
+                ValidatedAction::Fake {
+                    generator: "safe_email".into(),
+                },
+            ),
+        ];
+        let (mut d, warnings) =
+            KeyDeriver::new(&model, &request(), &rules, &no_consistency()).unwrap();
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert!(warnings[0].contains("entity 'Customer' and entity 'Order'"));
+
+        let mut run = |name: &str, source: &str, sk: &str, becomes: &str| {
+            let mut it = item(&[
+                ("_type", name),
+                ("pk", "CUSTOMER#a@x.co"),
+                ("sk", sk),
+                (source, "a@x.co"),
+                ("id", "1"),
+            ]);
+            let mut w = Vec::new();
+            let plan = d.plan(&it, &mut w).unwrap();
+            it.insert(source.to_string(), AttributeValue::S(becomes.to_string()));
+            d.apply(&plan, &no_rewrites(), &mut it, &mut w);
+        };
+        run("Customer", "email", "PROFILE", "fake1@example.com");
+        run("Order", "customerEmail", "ORDER#1", "fake2@example.org");
+
+        let breaks = d.join_breaks();
+        assert_eq!(breaks.len(), 1, "{breaks:?}");
+        assert!(breaks[0].contains("same attribute name"), "{breaks:?}");
+    }
+
+    #[test]
+    fn a_key_left_unrebuilt_is_not_reported_as_a_broken_join() {
+        // The documented shape: an Order holds its customer's key but carries
+        // no address of its own, so its pk cannot be rebuilt. That is a
+        // mismatch warning, not a join failure, and [consistency] could not
+        // fix it because there is nothing on the Order to anonymise.
+        let mut d = shared_key_deriver();
+
+        run_item(&mut d, customer_item("a@x.co"), "fake1@example.com");
+
+        let mut order = item(&[
+            ("_type", "Order"),
+            ("pk", "CUSTOMER#a@x.co"),
+            ("sk", "ORDER#1"),
+            ("orderId", "1"),
+        ]);
+        assert!(!order.contains_key("email"), "nothing to rebuild pk from");
+        let mut warnings = Vec::new();
+        let plan = d.plan(&order, &mut warnings).unwrap();
+        d.apply(&plan, &no_rewrites(), &mut order, &mut warnings);
+
+        assert!(
+            warnings.iter().any(|w| w.contains("does not reproduce pk")),
+            "the accurate diagnostic still fires: {warnings:?}"
+        );
+        assert!(
+            d.join_breaks().is_empty(),
+            "an unrebuilt key is not a divergence: {:?}",
+            d.join_breaks()
+        );
+        assert_eq!(
+            order["pk"],
+            AttributeValue::S("CUSTOMER#a@x.co".to_string())
+        );
+    }
+
+    #[test]
+    fn an_index_the_table_does_not_have_is_reported() {
+        let model = model_with(vec![EntityDefinition {
+            name: "User".to_string(),
+            pk_template: "user#${id}".to_string(),
+            sk_template: Some("user#".to_string()),
+            type_attribute: None,
+            // OneTable's default name for the index, which the table calls GSI1.
+            gsi_mappings: vec![GsiMapping {
+                index_name: "gs1".to_string(),
+                pk_template: String::new(),
+                sk_template: Some("user#${email}".to_string()),
+            }],
+            description: None,
+        }]);
+        let (_, warnings) = KeyDeriver::new(&model, &request(), &[], &no_consistency()).unwrap();
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.contains("index 'gs1' that table 'App' does not")),
+            "{warnings:?}"
+        );
+    }
+
+    #[test]
+    fn a_local_secondary_index_is_reported_as_not_rebuilt() {
+        let mut request = request();
+        request.local_secondary_indexes = Some(
+            serde_json::from_value(serde_json::json!([{
+                "IndexName": "LSI1",
+                "KeySchema": [
+                    {"AttributeName": "pk", "KeyType": "HASH"},
+                    {"AttributeName": "ls1sk", "KeyType": "RANGE"}
+                ],
+                "Projection": {"ProjectionType": "ALL"}
+            }]))
+            .unwrap(),
+        );
+        let (_, warnings) = KeyDeriver::new(&model(), &request, &[], &no_consistency()).unwrap();
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.contains("local secondary index") && w.contains("not rebuilt")),
+            "{warnings:?}"
+        );
+    }
+
+    #[test]
+    fn null_on_a_key_source_is_reported_as_retaining_not_collapsing() {
+        let rules = [rule("email", ValidatedAction::Null)];
+        let (_, warnings) =
+            KeyDeriver::new(&model(), &request(), &rules, &no_consistency()).unwrap();
+        assert!(!warnings.is_empty());
+        for w in &warnings {
+            assert!(
+                w.contains("keeps the key value it arrived with"),
+                "null retains, it does not collapse: {w}"
+            );
+            assert!(!w.contains("overwrites the last"), "{w}");
+        }
+    }
+
+    #[test]
+    fn a_rebuilt_key_landing_on_an_untouched_row_is_a_collision() {
+        // An item that matches no entity keeps its key and is invisible to a
+        // collision set that only records rebuilds, so the row it loses goes
+        // uncounted.
+        let mut d = deriver();
+        let mut warnings = Vec::new();
+
+        let stranger = item(&[("pk", "account#acc1"), ("sk", "user#[REDACTED]")]);
+        assert!(
+            d.plan(&stranger, &mut warnings).is_none(),
+            "matches nothing"
+        );
+        d.note_primary_key(&stranger);
+
+        let mut user = user();
+        let plan = d.plan(&user, &mut warnings).unwrap();
+        user.insert(
+            "email".to_string(),
+            AttributeValue::S("[REDACTED]".to_string()),
+        );
+        d.apply(&plan, &no_rewrites(), &mut user, &mut warnings);
+        assert_eq!(
+            user["sk"],
+            AttributeValue::S("user#[REDACTED]".to_string()),
+            "the rebuilt key lands on the stranger's"
+        );
+        assert_eq!(d.take_collisions().0, 1);
     }
 
     #[test]

--- a/src/import/keys.rs
+++ b/src/import/keys.rs
@@ -143,14 +143,20 @@ struct TemplatedKey {
 }
 
 impl TemplatedKey {
+    /// The attribute paths the template reads, in full, so a nested
+    /// `${contact.email}` is followed rather than collapsed to `contact`.
+    fn source_paths(&self) -> impl Iterator<Item = &Vec<PathElement>> {
+        self.segments.iter().filter_map(|s| match s {
+            Segment::Var { path, .. } => Some(path),
+            Segment::Literal(_) => None,
+        })
+    }
+
     /// Top-level attribute names the template reads.
     fn sources(&self) -> impl Iterator<Item = &str> {
-        self.segments.iter().filter_map(|s| match s {
-            Segment::Var { path, .. } => match path.first() {
-                Some(PathElement::Attribute(name)) => Some(name.as_str()),
-                _ => None,
-            },
-            Segment::Literal(_) => None,
+        self.source_paths().filter_map(|path| match path.first() {
+            Some(PathElement::Attribute(name)) => Some(name.as_str()),
+            _ => None,
         })
     }
 }
@@ -174,7 +180,10 @@ struct EntityKeys {
 /// entities' keys disagree and the join between them is lost.
 #[derive(Debug)]
 struct AtRisk {
-    attribute: String,
+    /// The attribute path the shared templates read.
+    source: Vec<PathElement>,
+    /// That path written out, for the message.
+    source_name: String,
     /// Entity indices that build a key from it, in model order.
     entities: Vec<usize>,
     /// Original value hash -> (entity that carried it, what it anonymised
@@ -260,8 +269,8 @@ impl KeyDeriver {
         let mut warnings = Vec::new();
 
         let mut entities = Vec::with_capacity(model.entities.len());
-        let mut entity_key_shapes: Vec<Vec<(String, String, Vec<String>)>> =
-            Vec::with_capacity(model.entities.len());
+        type KeyShape = (String, String, Vec<Vec<PathElement>>);
+        let mut entity_key_shapes: Vec<Vec<KeyShape>> = Vec::with_capacity(model.entities.len());
         for entity in &model.entities {
             let mut match_keys = Vec::new();
             push_key(&mut match_keys, entity, hash, Some(&entity.pk_template))?;
@@ -327,7 +336,7 @@ impl KeyDeriver {
                         (
                             key.attribute.clone(),
                             key.template.clone(),
-                            key.sources().map(String::from).collect(),
+                            key.source_paths().cloned().collect(),
                         )
                     })
                     .collect(),
@@ -385,38 +394,44 @@ impl KeyDeriver {
         // attribute name alone is what keeps this off entities that merely
         // reuse a name: `account#${id}` and `project#${id}` are different
         // entities' own ids, and never had a join to lose.
-        let mut shared: Vec<(String, Vec<usize>)> = Vec::new();
+        // Grouped by the key and its template as well as the source, so two
+        // unrelated pairs that happen to read an attribute of the same name
+        // stay separate: A and B sharing `account#${id}` have nothing to do
+        // with C and D sharing `project#${id}`.
+        type RiskKey = (String, String, Vec<PathElement>);
+        let mut shared: Vec<(RiskKey, Vec<usize>)> = Vec::new();
         for (idx, shape) in entity_key_shapes.iter().enumerate() {
             for (attribute, template, sources) in shape {
-                let also_built_by: Vec<usize> = entity_key_shapes
-                    .iter()
-                    .enumerate()
-                    .filter(|(other, other_shape)| {
-                        *other != idx
-                            && other_shape
-                                .iter()
-                                .any(|(a, t, _)| a == attribute && t == template)
-                    })
-                    .map(|(other, _)| other)
-                    .collect();
-                if also_built_by.is_empty() {
+                let shared_with_another =
+                    entity_key_shapes
+                        .iter()
+                        .enumerate()
+                        .any(|(other, other_shape)| {
+                            other != idx
+                                && other_shape
+                                    .iter()
+                                    .any(|(a, t, _)| a == attribute && t == template)
+                        });
+                if !shared_with_another {
                     continue;
                 }
                 for source in sources {
+                    let Some(PathElement::Attribute(root)) = source.first() else {
+                        continue;
+                    };
                     // An attribute no rule rewrites keeps its value, so the
                     // two keys still agree however they were built.
-                    if consistency_fields.contains(source)
-                        || !rule_targets.contains(source.as_str())
-                    {
+                    if consistency_fields.contains(root) || !rule_targets.contains(root.as_str()) {
                         continue;
                     }
-                    match shared.iter_mut().find(|(name, _)| name == source) {
+                    let risk_key = (attribute.clone(), template.clone(), source.clone());
+                    match shared.iter_mut().find(|(k, _)| *k == risk_key) {
                         Some((_, users)) => {
                             if !users.contains(&idx) {
                                 users.push(idx);
                             }
                         }
-                        None => shared.push((source.clone(), vec![idx])),
+                        None => shared.push((risk_key, vec![idx])),
                     }
                 }
             }
@@ -425,20 +440,26 @@ impl KeyDeriver {
             users.sort();
         }
         shared.retain(|(_, users)| users.len() > 1);
-        shared.sort_by(|a, b| a.0.cmp(&b.0));
+        // Deterministic order for the warnings: key attribute, then
+        // template, then the source path written out.
+        shared.sort_by(|a, b| {
+            (&a.0.0, &a.0.1, path_display(&a.0.2)).cmp(&(&b.0.0, &b.0.1, path_display(&b.0.2)))
+        });
 
         let at_risk: Vec<AtRisk> = shared
             .into_iter()
-            .map(|(attribute, entities_using)| {
+            .map(|((_, _, source), entities_using)| {
+                let source_name = path_display(&source);
                 warnings.push(format!(
                     "{} both build keys from '{}', which is not in [consistency] fields: \
                      if they both appear in this import their keys will not agree and \
                      the entities will not join",
                     entity_list(&entities, &entities_using),
-                    attribute
+                    source_name
                 ));
                 AtRisk {
-                    attribute,
+                    source,
+                    source_name,
                     entities: entities_using,
                     seen_values: std::collections::HashMap::new(),
                     diverged: HashSet::new(),
@@ -521,7 +542,7 @@ impl KeyDeriver {
             .iter()
             .enumerate()
             .filter(|(_, risk)| risk.entities.contains(&entity_idx) && !risk.capped)
-            .filter_map(|(idx, risk)| Some((idx, scalar_hash(item.get(&risk.attribute)?)?)))
+            .filter_map(|(idx, risk)| Some((idx, scalar_hash(&resolve_path(item, &risk.source)?)?)))
             .collect()
     }
 
@@ -535,7 +556,10 @@ impl KeyDeriver {
             if risk.capped {
                 continue;
             }
-            let Some(now) = item.get(&risk.attribute).and_then(scalar_hash) else {
+            let Some(now) = resolve_path(item, &risk.source)
+                .as_ref()
+                .and_then(scalar_hash)
+            else {
                 continue;
             };
             match risk.seen_values.get(original) {
@@ -629,10 +653,24 @@ impl KeyDeriver {
             .into_iter()
             .flatten()
         {
-            if let Some(AttributeValue::S(s)) = item.get(attribute) {
-                s.hash(&mut hasher);
+            // Type tag as well as value: a numeric key is as much part of the
+            // identity as a string one, and leaving it out reports two
+            // distinct rows as an overwrite.
+            match item.get(attribute) {
+                Some(AttributeValue::S(s)) => {
+                    1u8.hash(&mut hasher);
+                    s.hash(&mut hasher);
+                }
+                Some(AttributeValue::N(n)) => {
+                    2u8.hash(&mut hasher);
+                    n.hash(&mut hasher);
+                }
+                Some(AttributeValue::B(b)) => {
+                    3u8.hash(&mut hasher);
+                    b.hash(&mut hasher);
+                }
+                _ => 0u8.hash(&mut hasher),
             }
-            0u8.hash(&mut hasher);
         }
         if !self.rebuilt_keys.insert(hasher.finish()) {
             self.collisions += 1;
@@ -658,8 +696,8 @@ impl KeyDeriver {
                     "{} anonymised a shared value of '{}' differently, so their keys no longer \
                      agree and they will not join. Add '{}' to [consistency] fields",
                     entity_list(&self.entities, &seen),
-                    risk.attribute,
-                    risk.attribute
+                    risk.source_name,
+                    risk.source_name
                 )
             })
             .collect()
@@ -714,6 +752,23 @@ impl KeyDeriver {
     }
 }
 
+/// A document path written back out, for a message.
+fn path_display(path: &[PathElement]) -> String {
+    let mut out = String::new();
+    for element in path {
+        match element {
+            PathElement::Attribute(name) => {
+                if !out.is_empty() {
+                    out.push('.');
+                }
+                out.push_str(name);
+            }
+            PathElement::Index(i) => out.push_str(&format!("[{i}]")),
+        }
+    }
+    out
+}
+
 /// Hash a scalar attribute value, or `None` for anything a key cannot hold.
 fn scalar_hash(value: &AttributeValue) -> Option<u64> {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
@@ -758,6 +813,11 @@ fn push_key(
     let (Some(attribute), Some(template)) = (attribute, template) else {
         return Ok(());
     };
+    if template.is_empty() {
+        // No template at all (a plain attribute key). Nothing to rebuild, and
+        // nothing that could tell one entity from another.
+        return Ok(());
+    }
     let segments = parse_template(template)
         .map_err(|e| format!("entity '{}', {attribute}: {e}", entity.name))?;
     keys.push(TemplatedKey {
@@ -1439,6 +1499,161 @@ mod tests {
         // A key reading a plain attribute is fine.
         let model = model_with(vec![entity("User", "user#${email}", Some("profile"), None)]);
         assert!(KeyDeriver::new(&model, &request(), &email_rule(), &no_consistency()).is_ok());
+    }
+
+    #[test]
+    fn a_gsi_sort_key_is_rebuilt_when_its_hash_key_is_a_plain_attribute() {
+        // GSI1 hashes on a plain tenantId and sorts on user#${email}. The
+        // sort key still has to be rebuilt, or the address survives in it.
+        let model = model_with(vec![EntityDefinition {
+            name: "User".to_string(),
+            pk_template: "user#${id}".to_string(),
+            sk_template: Some("user#".to_string()),
+            type_attribute: None,
+            gsi_mappings: vec![GsiMapping {
+                index_name: "GSI1".to_string(),
+                pk_template: String::new(),
+                sk_template: Some("user#${email}".to_string()),
+            }],
+            description: None,
+        }]);
+        let (mut d, _) = KeyDeriver::new(&model, &request(), &[], &no_consistency()).unwrap();
+        assert!(
+            tracked(&d, 0).contains(&"gs1sk"),
+            "the GSI sort key must be tracked: {:?}",
+            tracked(&d, 0)
+        );
+
+        let mut warnings = Vec::new();
+        let mut user = item(&[
+            ("pk", "user#u1"),
+            ("sk", "user#"),
+            ("gs1sk", "user#alice@real.co.uk"),
+            ("id", "u1"),
+            ("email", "alice@real.co.uk"),
+        ]);
+        let plan = d.plan(&user, &mut warnings).unwrap();
+        user.insert(
+            "email".to_string(),
+            AttributeValue::S("fake@example.org".to_string()),
+        );
+        d.apply(&plan, &no_rewrites(), &mut user, &mut warnings);
+        assert_eq!(
+            user["gs1sk"],
+            AttributeValue::S("user#fake@example.org".to_string())
+        );
+    }
+
+    #[test]
+    fn unrelated_pairs_reading_the_same_attribute_name_are_separate_risks() {
+        // Account/Team share account#${id}; Project/Task share project#${id}.
+        // Same source name, two unrelated groups, so importing one from each
+        // must not read as a broken join between them.
+        let model = model_with(vec![
+            entity("Account", "account#${id}", Some("account#"), None),
+            entity("Project", "project#${id}", Some("project#"), None),
+            entity("Team", "account#${id}", Some("team#"), None),
+            entity("Task", "project#${id}", Some("task#"), None),
+        ]);
+        let rules = [rule(
+            "id",
+            ValidatedAction::Fake {
+                generator: "word".into(),
+            },
+        )];
+        let (mut d, warnings) =
+            KeyDeriver::new(&model, &request(), &rules, &no_consistency()).unwrap();
+        assert_eq!(warnings.len(), 2, "one per group: {warnings:?}");
+
+        // One entity from each group, sharing an original id.
+        let mut run = |name: &str, pk: &str, sk: &str, becomes: &str| {
+            let mut it = item(&[("_type", name), ("pk", pk), ("sk", sk), ("id", "shared")]);
+            let mut w = Vec::new();
+            let plan = d.plan(&it, &mut w).unwrap();
+            it.insert("id".to_string(), AttributeValue::S(becomes.to_string()));
+            d.apply(&plan, &no_rewrites(), &mut it, &mut w);
+        };
+        run("Account", "account#shared", "account#", "anon1");
+        run("Project", "project#shared", "project#", "anon2");
+
+        assert!(
+            d.join_breaks().is_empty(),
+            "different groups never joined: {:?}",
+            d.join_breaks()
+        );
+    }
+
+    #[test]
+    fn a_nested_template_source_is_tracked_for_join_breaks() {
+        let model = model_with(vec![
+            entity(
+                "Customer",
+                "CUSTOMER#${contact.email}",
+                Some("PROFILE"),
+                None,
+            ),
+            entity(
+                "Order",
+                "CUSTOMER#${contact.email}",
+                Some("ORDER#${id}"),
+                None,
+            ),
+        ]);
+        let rules = [rule(
+            "contact",
+            ValidatedAction::Fake {
+                generator: "safe_email".into(),
+            },
+        )];
+        let (mut d, warnings) =
+            KeyDeriver::new(&model, &request(), &rules, &no_consistency()).unwrap();
+        assert!(
+            warnings.iter().any(|w| w.contains("'contact.email'")),
+            "the nested path should be named: {warnings:?}"
+        );
+
+        let contact = |email: &str| {
+            let mut map = std::collections::HashMap::new();
+            map.insert("email".to_string(), AttributeValue::S(email.to_string()));
+            AttributeValue::M(map)
+        };
+        let mut run = |name: &str, sk: &str, becomes: &str| {
+            let mut it = item(&[("_type", name), ("pk", "CUSTOMER#a@x.co"), ("sk", sk)]);
+            it.insert("contact".to_string(), contact("a@x.co"));
+            let mut w = Vec::new();
+            let plan = d.plan(&it, &mut w).unwrap();
+            it.insert("contact".to_string(), contact(becomes));
+            d.apply(&plan, &no_rewrites(), &mut it, &mut w);
+        };
+        run("Customer", "PROFILE", "fake1@example.com");
+        run("Order", "ORDER#1", "fake2@example.org");
+
+        let breaks = d.join_breaks();
+        assert_eq!(breaks.len(), 1, "{breaks:?}");
+        assert!(breaks[0].contains("'contact.email'"), "{breaks:?}");
+    }
+
+    #[test]
+    fn a_numeric_partition_key_is_part_of_the_collision_fingerprint() {
+        let model = model_with(vec![entity("Row", "${n}", Some("user#${email}"), None)]);
+        let (mut d, _) = KeyDeriver::new(&model, &request(), &[], &no_consistency()).unwrap();
+        let mut warnings = Vec::new();
+
+        // Two rows differing only by a numeric pk: distinct, not a collision.
+        for n in ["1", "2"] {
+            let mut it = Item::new();
+            it.insert("_type".to_string(), AttributeValue::S("Row".to_string()));
+            it.insert("pk".to_string(), AttributeValue::N(n.to_string()));
+            it.insert("n".to_string(), AttributeValue::N(n.to_string()));
+            it.insert(
+                "sk".to_string(),
+                AttributeValue::S("user#a@x.co".to_string()),
+            );
+            it.insert("email".to_string(), AttributeValue::S("a@x.co".to_string()));
+            let plan = d.plan(&it, &mut warnings).unwrap();
+            d.apply(&plan, &no_rewrites(), &mut it, &mut warnings);
+        }
+        assert_eq!(d.take_collisions(), (0, false));
     }
 
     /// Run one item through the pipeline the way the importer does: plan,

--- a/src/import/keys.rs
+++ b/src/import/keys.rs
@@ -163,6 +163,18 @@ struct EntityKeys {
     keys: Vec<TemplatedKey>,
 }
 
+/// An attribute more than one entity builds a key from, which is not in
+/// `[consistency] fields`. Anonymising it independently per item means the
+/// entities' keys disagree and the join between them is lost.
+#[derive(Debug)]
+struct AtRisk {
+    attribute: String,
+    /// Entity indices that build a key from it, in model order.
+    entities: Vec<usize>,
+    /// Entity indices actually seen in the data so far.
+    observed: HashSet<usize>,
+}
+
 /// Which of an item's keys can be rebuilt after the rules run.
 #[derive(Debug)]
 pub struct Rederivation {
@@ -190,6 +202,10 @@ pub struct KeyDeriver {
     warned_unrenderable: HashSet<(usize, usize)>,
     /// Items that matched no entity, reported once per table.
     unmatched: usize,
+    /// Attribute -> the entities that build a key from it, for attributes
+    /// more than one entity keys on that are not consistency-tracked. Their
+    /// keys cannot agree, so the entities stop joining.
+    at_risk: Vec<AtRisk>,
     /// Hashes of every rebuilt primary key, to spot collisions.
     rebuilt_keys: HashSet<u64>,
     /// Rebuilt items whose primary key repeated an earlier rebuilt key.
@@ -214,6 +230,7 @@ impl KeyDeriver {
         model: &DataModel,
         request: &CreateTableRequest,
         rules: &[ValidatedRule],
+        consistency_fields: &HashSet<String>,
     ) -> Result<(Self, Vec<String>), String> {
         let hash = partition_key_name(&request.key_schema);
         let range = sort_key_name(&request.key_schema);
@@ -223,6 +240,8 @@ impl KeyDeriver {
         let mut warnings = Vec::new();
 
         let mut entities = Vec::with_capacity(model.entities.len());
+        let mut entity_key_shapes: Vec<Vec<(String, String, Vec<String>)>> =
+            Vec::with_capacity(model.entities.len());
         for entity in &model.entities {
             let mut keys = Vec::new();
             push_key(&mut keys, entity, hash, Some(&entity.pk_template))?;
@@ -245,6 +264,20 @@ impl KeyDeriver {
                     mapping.sk_template.as_deref(),
                 )?;
             }
+
+            // Recorded before the rule-target retain below: this is a
+            // property of the model's templates, not of what survives.
+            entity_key_shapes.push(
+                keys.iter()
+                    .map(|key| {
+                        (
+                            key.attribute.clone(),
+                            key.template.clone(),
+                            key.sources().map(String::from).collect(),
+                        )
+                    })
+                    .collect(),
+            );
 
             keys.retain(|key| {
                 let targeted = rule_targets.contains(key.attribute.as_str());
@@ -287,6 +320,77 @@ impl KeyDeriver {
             });
         }
 
+        // Two entities that build the *same* key attribute from the *same*
+        // template are asserting their keys agree, which is how a
+        // single-table design keeps a customer and its orders in one
+        // partition. If a rule rewrites an attribute that template reads and
+        // it is not consistency-tracked, each entity anonymises it
+        // independently and the two stop agreeing.
+        //
+        // Matching on the (attribute, template) pair rather than on the
+        // attribute name alone is what keeps this off entities that merely
+        // reuse a name: `account#${id}` and `project#${id}` are different
+        // entities' own ids, and never had a join to lose.
+        let mut shared: Vec<(String, Vec<usize>)> = Vec::new();
+        for (idx, shape) in entity_key_shapes.iter().enumerate() {
+            for (attribute, template, sources) in shape {
+                let also_built_by: Vec<usize> = entity_key_shapes
+                    .iter()
+                    .enumerate()
+                    .filter(|(other, other_shape)| {
+                        *other != idx
+                            && other_shape
+                                .iter()
+                                .any(|(a, t, _)| a == attribute && t == template)
+                    })
+                    .map(|(other, _)| other)
+                    .collect();
+                if also_built_by.is_empty() {
+                    continue;
+                }
+                for source in sources {
+                    // An attribute no rule rewrites keeps its value, so the
+                    // two keys still agree however they were built.
+                    if consistency_fields.contains(source)
+                        || !rule_targets.contains(source.as_str())
+                    {
+                        continue;
+                    }
+                    match shared.iter_mut().find(|(name, _)| name == source) {
+                        Some((_, users)) => {
+                            if !users.contains(&idx) {
+                                users.push(idx);
+                            }
+                        }
+                        None => shared.push((source.clone(), vec![idx])),
+                    }
+                }
+            }
+        }
+        for (_, users) in shared.iter_mut() {
+            users.sort();
+        }
+        shared.retain(|(_, users)| users.len() > 1);
+        shared.sort_by(|a, b| a.0.cmp(&b.0));
+
+        let at_risk: Vec<AtRisk> = shared
+            .into_iter()
+            .map(|(attribute, entities_using)| {
+                warnings.push(format!(
+                    "{} both build keys from '{}', which is not in [consistency] fields: \
+                     if they both appear in this import their keys will not agree and \
+                     the entities will not join",
+                    entity_list(&entities, &entities_using),
+                    attribute
+                ));
+                AtRisk {
+                    attribute,
+                    entities: entities_using,
+                    observed: HashSet::new(),
+                }
+            })
+            .collect();
+
         let mut type_attributes: Vec<String> =
             entities.iter().map(|e| e.type_attribute.clone()).collect();
         type_attributes.sort();
@@ -301,6 +405,7 @@ impl KeyDeriver {
                 warned_mismatch: HashSet::new(),
                 warned_unrenderable: HashSet::new(),
                 unmatched: 0,
+                at_risk,
                 rebuilt_keys: HashSet::new(),
                 collisions: 0,
                 collision_check_capped: false,
@@ -320,6 +425,12 @@ impl KeyDeriver {
             self.unmatched += 1;
             return None;
         };
+        for risk in &mut self.at_risk {
+            if risk.entities.contains(&entity_idx) {
+                risk.observed.insert(entity_idx);
+            }
+        }
+
         let entity = &self.entities[entity_idx];
 
         let mut keys = Vec::new();
@@ -407,6 +518,31 @@ impl KeyDeriver {
         }
     }
 
+    /// Attributes whose entities have now both turned up in the data, so the
+    /// join between them is actually broken rather than merely at risk.
+    ///
+    /// Checked once the items have been read rather than up front: the model
+    /// says the two entities *can* collide, but an import holding only one of
+    /// them has no join to lose, and failing there would earn a bypass flag.
+    pub fn join_breaks(&self) -> Vec<String> {
+        self.at_risk
+            .iter()
+            .filter(|risk| risk.observed.len() > 1)
+            .map(|risk| {
+                let mut seen: Vec<usize> = risk.observed.iter().copied().collect();
+                seen.sort();
+                format!(
+                    "{} were both imported and both build keys from '{}', which is not in \
+                     [consistency] fields, so the same value anonymised differently for each \
+                     and they no longer join. Add '{}' to [consistency] fields",
+                    entity_list(&self.entities, &seen),
+                    risk.attribute,
+                    risk.attribute
+                )
+            })
+            .collect()
+    }
+
     /// Number of items since the last call that matched no entity.
     pub fn take_unmatched(&mut self) -> usize {
         std::mem::take(&mut self.unmatched)
@@ -450,6 +586,19 @@ impl KeyDeriver {
             });
             all_match && present > 0
         })
+    }
+}
+
+/// "entity 'A' and entity 'B'", for a warning.
+fn entity_list(entities: &[EntityKeys], indices: &[usize]) -> String {
+    let names: Vec<String> = indices
+        .iter()
+        .map(|i| format!("entity '{}'", entities[*i].name))
+        .collect();
+    match names.split_last() {
+        Some((last, [])) => last.clone(),
+        Some((last, rest)) => format!("{} and {last}", rest.join(", ")),
+        None => String::new(),
     }
 }
 
@@ -594,8 +743,13 @@ mod tests {
         }
     }
 
+    fn no_consistency() -> HashSet<String> {
+        HashSet::new()
+    }
+
     fn deriver() -> KeyDeriver {
-        let (deriver, warnings) = KeyDeriver::new(&model(), &request(), &[]).unwrap();
+        let (deriver, warnings) =
+            KeyDeriver::new(&model(), &request(), &[], &no_consistency()).unwrap();
         assert!(warnings.is_empty(), "{warnings:?}");
         deriver
     }
@@ -655,6 +809,7 @@ mod tests {
             &model_with(vec![entity("Bad", "x#${id", None, None)]),
             &request(),
             &[],
+            &no_consistency(),
         )
         .unwrap_err();
         assert!(err.contains("entity 'Bad', pk"), "{err}");
@@ -700,7 +855,8 @@ mod tests {
             Some("order#${orderNo:5}"),
             None,
         )]);
-        let (mut d, warnings) = KeyDeriver::new(&model, &request(), &[]).unwrap();
+        let (mut d, warnings) =
+            KeyDeriver::new(&model, &request(), &[], &no_consistency()).unwrap();
         assert!(warnings.is_empty(), "{warnings:?}");
 
         let mut item_warnings = Vec::new();
@@ -756,7 +912,7 @@ mod tests {
     fn gsi_mapping_without_a_matching_index_is_skipped() {
         let mut request = request();
         request.global_secondary_indexes = None;
-        let (d, _) = KeyDeriver::new(&model(), &request, &[]).unwrap();
+        let (d, _) = KeyDeriver::new(&model(), &request, &[], &no_consistency()).unwrap();
         assert_eq!(tracked(&d, 1), vec!["pk", "sk"]);
     }
 
@@ -900,14 +1056,15 @@ mod tests {
             key_schema("PK", KeyType::HASH),
             key_schema("SK", KeyType::RANGE),
         ];
-        let (d, _) = KeyDeriver::new(&model(), &request, &[]).unwrap();
+        let (d, _) = KeyDeriver::new(&model(), &request, &[], &no_consistency()).unwrap();
         assert_eq!(tracked(&d, 1), vec!["PK", "SK", "gs1pk"]);
     }
 
     #[test]
     fn a_rule_on_a_key_attribute_wins_over_the_template() {
         let rules = [rule("sk", ValidatedAction::Redact)];
-        let (mut d, warnings) = KeyDeriver::new(&model(), &request(), &rules).unwrap();
+        let (mut d, warnings) =
+            KeyDeriver::new(&model(), &request(), &rules, &no_consistency()).unwrap();
         assert_eq!(tracked(&d, 1), vec!["pk", "gs1pk"]);
         assert_eq!(warnings.len(), 1, "{warnings:?}");
         assert!(warnings[0].contains("targets key attribute 'sk' directly"));
@@ -927,7 +1084,8 @@ mod tests {
     #[test]
     fn a_constant_action_on_a_key_source_is_reported_up_front() {
         let rules = [rule("email", ValidatedAction::Redact)];
-        let (_, warnings) = KeyDeriver::new(&model(), &request(), &rules).unwrap();
+        let (_, warnings) =
+            KeyDeriver::new(&model(), &request(), &rules, &no_consistency()).unwrap();
         // sk and gs1pk of User both build from email
         assert_eq!(warnings.len(), 2, "{warnings:?}");
         assert!(warnings[0].contains("collapse onto one row"));
@@ -939,8 +1097,143 @@ mod tests {
                 generator: "safe_email".into(),
             },
         )];
-        let (_, warnings) = KeyDeriver::new(&model(), &request(), &rules).unwrap();
+        let (_, warnings) =
+            KeyDeriver::new(&model(), &request(), &rules, &no_consistency()).unwrap();
         assert!(warnings.is_empty(), "{warnings:?}");
+    }
+
+    /// Two entities keyed on the same attribute, as a single-table design
+    /// puts a customer and its orders in one partition.
+    fn shared_key_model() -> DataModel {
+        model_with(vec![
+            entity("Customer", "CUSTOMER#${email}", Some("PROFILE"), None),
+            entity("Order", "CUSTOMER#${email}", Some("ORDER#${orderId}"), None),
+        ])
+    }
+
+    /// The check only fires for an attribute a rule actually rewrites.
+    fn email_rule() -> [ValidatedRule; 1] {
+        [rule(
+            "email",
+            ValidatedAction::Fake {
+                generator: "safe_email".into(),
+            },
+        )]
+    }
+
+    #[test]
+    fn a_shared_key_attribute_outside_consistency_warns_up_front() {
+        let (deriver, warnings) = KeyDeriver::new(
+            &shared_key_model(),
+            &request(),
+            &email_rule(),
+            &no_consistency(),
+        )
+        .unwrap();
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert!(warnings[0].contains("entity 'Customer' and entity 'Order'"));
+        assert!(warnings[0].contains("'email'"));
+        assert!(warnings[0].contains("will not join"));
+        // Nothing seen yet, so nothing is broken yet.
+        assert!(deriver.join_breaks().is_empty());
+    }
+
+    #[test]
+    fn listing_the_attribute_in_consistency_silences_it() {
+        let consistency: HashSet<String> = ["email".to_string()].into_iter().collect();
+        let (_, warnings) =
+            KeyDeriver::new(&shared_key_model(), &request(), &email_rule(), &consistency).unwrap();
+        assert!(warnings.is_empty(), "{warnings:?}");
+    }
+
+    #[test]
+    fn an_attribute_no_rule_rewrites_is_not_at_risk() {
+        // Same shared template, but nothing anonymises email, so the two
+        // keys still agree in the output.
+        let (_, warnings) =
+            KeyDeriver::new(&shared_key_model(), &request(), &[], &no_consistency()).unwrap();
+        assert!(warnings.is_empty(), "{warnings:?}");
+    }
+
+    #[test]
+    fn entities_reusing_an_attribute_name_on_different_keys_are_not_at_risk() {
+        // Account keys pk on its own id, Task keys sk on its own id. Same
+        // attribute name, different keys and templates, no join between them.
+        let model = model_with(vec![
+            entity("Account", "account#${id}", Some("account#"), None),
+            entity("Task", "task#${projectId}", Some("task#${id}"), None),
+        ]);
+        let rules = [rule(
+            "id",
+            ValidatedAction::Fake {
+                generator: "word".into(),
+            },
+        )];
+        let (_, warnings) = KeyDeriver::new(&model, &request(), &rules, &no_consistency()).unwrap();
+        assert!(warnings.is_empty(), "{warnings:?}");
+    }
+
+    #[test]
+    fn one_entity_alone_is_not_a_broken_join() {
+        let (mut d, _) = KeyDeriver::new(
+            &shared_key_model(),
+            &request(),
+            &email_rule(),
+            &no_consistency(),
+        )
+        .unwrap();
+        let mut warnings = Vec::new();
+
+        for n in 0..3 {
+            let customer = item(&[
+                ("_type", "Customer"),
+                ("pk", &format!("CUSTOMER#c{n}@x.co")),
+                ("sk", "PROFILE"),
+                ("email", &format!("c{n}@x.co")),
+            ]);
+            d.plan(&customer, &mut warnings).unwrap();
+        }
+
+        assert!(
+            d.join_breaks().is_empty(),
+            "a slice holding one entity has no join to lose: {:?}",
+            d.join_breaks()
+        );
+    }
+
+    #[test]
+    fn both_entities_turning_up_is_a_broken_join() {
+        let (mut d, _) = KeyDeriver::new(
+            &shared_key_model(),
+            &request(),
+            &email_rule(),
+            &no_consistency(),
+        )
+        .unwrap();
+        let mut warnings = Vec::new();
+
+        let customer = item(&[
+            ("_type", "Customer"),
+            ("pk", "CUSTOMER#a@x.co"),
+            ("sk", "PROFILE"),
+            ("email", "a@x.co"),
+        ]);
+        d.plan(&customer, &mut warnings).unwrap();
+        assert!(d.join_breaks().is_empty(), "one entity so far");
+
+        let order = item(&[
+            ("_type", "Order"),
+            ("pk", "CUSTOMER#a@x.co"),
+            ("sk", "ORDER#1"),
+            ("email", "a@x.co"),
+            ("orderId", "1"),
+        ]);
+        d.plan(&order, &mut warnings).unwrap();
+
+        let breaks = d.join_breaks();
+        assert_eq!(breaks.len(), 1, "{breaks:?}");
+        assert!(breaks[0].contains("entity 'Customer' and entity 'Order'"));
+        assert!(breaks[0].contains("Add 'email' to [consistency] fields"));
     }
 
     #[test]

--- a/src/import/keys.rs
+++ b/src/import/keys.rs
@@ -23,7 +23,7 @@ use crate::schema::{DataModel, EntityDefinition};
 use crate::types::{AttributeValue, Item};
 use crate::validation::{partition_key_name, sort_key_name};
 
-use super::config::{ValidatedAction, ValidatedRule, matches_item, parse_path};
+use super::config::{ValidatedAction, ValidatedRule, parse_path};
 
 /// Rebuilt primary keys are remembered (as hashes) to spot two items
 /// collapsing onto one row. Past this many the check stops, and says so.
@@ -160,7 +160,13 @@ impl TemplatedKey {
 struct EntityKeys {
     name: String,
     type_attribute: String,
+    /// Keys with at least one variable: the ones worth rebuilding.
     keys: Vec<TemplatedKey>,
+    /// Every key the entity templates, constant ones included. Used to tell
+    /// entities apart when an item carries no type attribute, where a
+    /// constant `sk = "PROFILE"` is often the only thing separating two
+    /// entities that share a partition template.
+    match_keys: Vec<TemplatedKey>,
 }
 
 /// An attribute more than one entity builds a key from, which is not in
@@ -171,12 +177,14 @@ struct AtRisk {
     attribute: String,
     /// Entity indices that build a key from it, in model order.
     entities: Vec<usize>,
-    /// Hash of each value seen, against the entity that carried it. A second
-    /// entity carrying a value already seen is the join, observed in the data
-    /// rather than inferred from the model.
-    seen_values: std::collections::HashMap<u64, usize>,
-    /// Entities that were found to share a value with another entity.
-    sharing: HashSet<usize>,
+    /// Original value hash -> (entity that carried it, what it anonymised
+    /// to). A second entity carrying the same original is the join; a
+    /// *different* anonymised result is the join actually breaking. A
+    /// deterministic action such as hash agrees by construction, and a rule
+    /// that matched neither item changes nothing, so both stay quiet.
+    seen_values: std::collections::HashMap<u64, (usize, u64)>,
+    /// Entities found to have anonymised a shared value differently.
+    diverged: HashSet<usize>,
     /// Set once `seen_values` hit its cap and stopped tracking.
     capped: bool,
 }
@@ -186,6 +194,9 @@ struct AtRisk {
 pub struct Rederivation {
     entity: usize,
     keys: Vec<usize>,
+    /// (at-risk index, hash of the value this item arrived with), so `apply`
+    /// can see whether two entities anonymised a shared value differently.
+    at_risk_originals: Vec<(usize, u64)>,
 }
 
 /// Rebuilds templated keys for the items of one table.
@@ -208,10 +219,6 @@ pub struct KeyDeriver {
     warned_unrenderable: HashSet<(usize, usize)>,
     /// Items that matched no entity, reported once per table.
     unmatched: usize,
-    /// Key attributes some rule rewrites directly. Whether the rule wins is
-    /// decided per item, since its condition may not match every entity that
-    /// builds that key.
-    rule_targeted: HashSet<String>,
     /// (entity index, key index) pairs where a rule took the key instead of
     /// its template, reported once.
     warned_rule_wins: HashSet<(usize, usize)>,
@@ -256,26 +263,60 @@ impl KeyDeriver {
         let mut entity_key_shapes: Vec<Vec<(String, String, Vec<String>)>> =
             Vec::with_capacity(model.entities.len());
         for entity in &model.entities {
-            let mut keys = Vec::new();
-            push_key(&mut keys, entity, hash, Some(&entity.pk_template))?;
-            push_key(&mut keys, entity, range, entity.sk_template.as_deref())?;
+            let mut match_keys = Vec::new();
+            push_key(&mut match_keys, entity, hash, Some(&entity.pk_template))?;
+            push_key(
+                &mut match_keys,
+                entity,
+                range,
+                entity.sk_template.as_deref(),
+            )?;
 
             for mapping in &entity.gsi_mappings {
                 let Some(gsi) = gsis.iter().find(|g| g.index_name == mapping.index_name) else {
                     continue;
                 };
                 push_key(
-                    &mut keys,
+                    &mut match_keys,
                     entity,
                     partition_key_name(&gsi.key_schema),
                     Some(&mapping.pk_template),
                 )?;
                 push_key(
-                    &mut keys,
+                    &mut match_keys,
                     entity,
                     sort_key_name(&gsi.key_schema),
                     mapping.sk_template.as_deref(),
                 )?;
+            }
+
+            let keys: Vec<TemplatedKey> = match_keys
+                .iter()
+                .filter(|key| {
+                    key.segments
+                        .iter()
+                        .any(|s| matches!(s, Segment::Var { .. }))
+                })
+                .cloned()
+                .collect();
+
+            // A key built from another templated key would have to be
+            // rendered in dependency order, and rendering it first copies the
+            // pre-anonymisation value. Refuse rather than leave that to luck.
+            for key in &keys {
+                for source in key.sources() {
+                    if keys
+                        .iter()
+                        .any(|other| other.attribute == source && other.attribute != key.attribute)
+                    {
+                        return Err(format!(
+                            "entity '{}': template '{}' for {} reads key attribute '{}', which is \
+                             itself built from a template; import cannot order those safely, so \
+                             build both keys from plain attributes instead",
+                            entity.name, key.template, key.attribute, source
+                        ));
+                    }
+                }
             }
 
             // Recorded before the rule-target retain below: this is a
@@ -329,6 +370,7 @@ impl KeyDeriver {
                 name: entity.name.clone(),
                 type_attribute: type_attribute(model, entity),
                 keys,
+                match_keys,
             });
         }
 
@@ -399,7 +441,7 @@ impl KeyDeriver {
                     attribute,
                     entities: entities_using,
                     seen_values: std::collections::HashMap::new(),
-                    sharing: HashSet::new(),
+                    diverged: HashSet::new(),
                     capped: false,
                 }
             })
@@ -416,7 +458,6 @@ impl KeyDeriver {
                 type_attributes,
                 hash_attribute: hash.map(String::from),
                 range_attribute: range.map(String::from),
-                rule_targeted: rule_targets.iter().map(|s| s.to_string()).collect(),
                 warned_mismatch: HashSet::new(),
                 warned_unrenderable: HashSet::new(),
                 warned_rule_wins: HashSet::new(),
@@ -436,36 +477,17 @@ impl KeyDeriver {
     /// item arrived with. Any key the template does not reproduce is left
     /// alone and reported (once per entity and key). An item that matches no
     /// entity is counted for [`take_unmatched`](Self::take_unmatched).
-    pub fn plan(
-        &mut self,
-        item: &Item,
-        rules: &[ValidatedRule],
-        warnings: &mut Vec<String>,
-    ) -> Option<Rederivation> {
+    pub fn plan(&mut self, item: &Item, warnings: &mut Vec<String>) -> Option<Rederivation> {
         let Some(entity_idx) = self.resolve_entity(item) else {
             self.unmatched += 1;
             return None;
         };
-        self.note_at_risk_values(entity_idx, item);
+        let at_risk_originals = self.at_risk_originals(entity_idx, item);
 
         let entity = &self.entities[entity_idx];
 
-        let mut rule_wins = Vec::new();
         let mut keys = Vec::new();
         for (idx, key) in entity.keys.iter().enumerate() {
-            // A rule that rewrites this key attribute wins over the template,
-            // but only on the items its condition actually matches. Deciding
-            // that per entity would leave the key unrebuilt on every item the
-            // rule never touches, real value intact.
-            if self.rule_targeted.contains(&key.attribute)
-                && rules.iter().any(|rule| {
-                    rule_target(rule) == Some(key.attribute.as_str()) && matches_item(rule, item)
-                })
-            {
-                rule_wins.push(idx);
-                continue;
-            }
-
             let Some(current) = item.get(&key.attribute) else {
                 // A sparse index key: nothing to rebuild.
                 continue;
@@ -486,54 +508,49 @@ impl KeyDeriver {
             }
         }
 
-        for idx in rule_wins {
-            if self.warned_rule_wins.insert((entity_idx, idx)) {
-                let key = &self.entities[entity_idx].keys[idx];
-                warnings.push(format!(
-                    "entity '{}': a rule rewrote {} directly, so it was not rebuilt from \
-                     template '{}'",
-                    self.entities[entity_idx].name, key.attribute, key.template
-                ));
-            }
-        }
-
         Some(Rederivation {
             entity: entity_idx,
             keys,
+            at_risk_originals,
         })
     }
 
-    /// Record this item's values for any at-risk attribute, so a value two
-    /// entities both carry is spotted. Presence of both entities is not
-    /// enough: two entities keyed on the same template with no value in
-    /// common never had a join to lose.
-    fn note_at_risk_values(&mut self, entity_idx: usize, item: &Item) {
-        for risk in &mut self.at_risk {
-            if !risk.entities.contains(&entity_idx) || risk.capped {
+    /// The value this item arrived with for each at-risk attribute, hashed.
+    fn at_risk_originals(&self, entity_idx: usize, item: &Item) -> Vec<(usize, u64)> {
+        self.at_risk
+            .iter()
+            .enumerate()
+            .filter(|(_, risk)| risk.entities.contains(&entity_idx) && !risk.capped)
+            .filter_map(|(idx, risk)| Some((idx, scalar_hash(item.get(&risk.attribute)?)?)))
+            .collect()
+    }
+
+    /// After the rules ran: compare what this item's at-risk values became
+    /// against what an earlier item of a different entity made of the same
+    /// original. Two entities that agree, because the action is
+    /// deterministic or because no rule matched, are left alone.
+    fn note_at_risk_results(&mut self, plan: &Rederivation, item: &Item) {
+        for (risk_idx, original) in &plan.at_risk_originals {
+            let risk = &mut self.at_risk[*risk_idx];
+            if risk.capped {
                 continue;
             }
-            let Some(value) = item.get(&risk.attribute) else {
+            let Some(now) = item.get(&risk.attribute).and_then(scalar_hash) else {
                 continue;
             };
-            let mut hasher = std::collections::hash_map::DefaultHasher::new();
-            match value {
-                AttributeValue::S(s) => s.hash(&mut hasher),
-                AttributeValue::N(n) => n.hash(&mut hasher),
-                _ => continue,
-            }
-            let key = hasher.finish();
-            match risk.seen_values.get(&key) {
-                Some(previous) if *previous != entity_idx => {
-                    risk.sharing.insert(*previous);
-                    risk.sharing.insert(entity_idx);
+            match risk.seen_values.get(original) {
+                Some((previous_entity, previous_now)) => {
+                    if *previous_entity != plan.entity && *previous_now != now {
+                        risk.diverged.insert(*previous_entity);
+                        risk.diverged.insert(plan.entity);
+                    }
                 }
-                Some(_) => {}
                 None => {
                     if risk.seen_values.len() >= MAX_TRACKED_KEYS {
                         risk.capped = true;
                         continue;
                     }
-                    risk.seen_values.insert(key, entity_idx);
+                    risk.seen_values.insert(*original, (plan.entity, now));
                 }
             }
         }
@@ -542,11 +559,26 @@ impl KeyDeriver {
     /// After the rules run: render every planned key from the item's current
     /// attributes. A key whose template no longer renders (a rule nulled or
     /// removed an attribute it needs) is left unchanged and reported.
-    pub fn apply(&mut self, plan: &Rederivation, item: &mut Item, warnings: &mut Vec<String>) {
+    pub fn apply(
+        &mut self,
+        plan: &Rederivation,
+        rewritten_by_rules: &HashSet<String>,
+        item: &mut Item,
+        warnings: &mut Vec<String>,
+    ) {
         let entity = &self.entities[plan.entity];
         let mut rebuilt_primary = false;
+        let mut rule_wins = Vec::new();
         for &idx in &plan.keys {
             let key = &entity.keys[idx];
+            // A rule that actually rewrote this key wins over its template.
+            // Taken from what the rules did rather than from what their
+            // conditions predicted: each rule sees the item as the rules
+            // before it left it, so a prediction made up front can be wrong.
+            if rewritten_by_rules.contains(&key.attribute) {
+                rule_wins.push(idx);
+                continue;
+            }
             match render(&key.segments, item) {
                 Some(value) => {
                     item.insert(key.attribute.clone(), AttributeValue::S(value));
@@ -566,9 +598,20 @@ impl KeyDeriver {
                 }
             }
         }
+        for idx in rule_wins {
+            if self.warned_rule_wins.insert((plan.entity, idx)) {
+                let key = &self.entities[plan.entity].keys[idx];
+                warnings.push(format!(
+                    "entity '{}': a rule rewrote {} directly, so it was not rebuilt from \
+                     template '{}'",
+                    self.entities[plan.entity].name, key.attribute, key.template
+                ));
+            }
+        }
         if rebuilt_primary {
             self.note_rebuilt_primary_key(item);
         }
+        self.note_at_risk_results(plan, item);
     }
 
     /// Remember a rebuilt primary key so a later item rendering the same one
@@ -607,14 +650,13 @@ impl KeyDeriver {
     pub fn join_breaks(&self) -> Vec<String> {
         self.at_risk
             .iter()
-            .filter(|risk| risk.sharing.len() > 1)
+            .filter(|risk| risk.diverged.len() > 1)
             .map(|risk| {
-                let mut seen: Vec<usize> = risk.sharing.iter().copied().collect();
+                let mut seen: Vec<usize> = risk.diverged.iter().copied().collect();
                 seen.sort();
                 format!(
-                    "{} share a value of '{}', which is not in [consistency] fields, so it \
-                     anonymised differently for each and their keys no longer agree. \
-                     Add '{}' to [consistency] fields",
+                    "{} anonymised a shared value of '{}' differently, so their keys no longer \
+                     agree and they will not join. Add '{}' to [consistency] fields",
                     entity_list(&self.entities, &seen),
                     risk.attribute,
                     risk.attribute
@@ -656,17 +698,31 @@ impl KeyDeriver {
 
         self.entities.iter().position(|e| {
             let mut present = 0;
-            let all_match = e.keys.iter().all(|key| match item.get(&key.attribute) {
-                None => true,
-                Some(AttributeValue::S(s)) => {
-                    present += 1;
-                    render(&key.segments, item).as_deref() == Some(s.as_str())
-                }
-                Some(_) => false,
-            });
+            let all_match = e
+                .match_keys
+                .iter()
+                .all(|key| match item.get(&key.attribute) {
+                    None => true,
+                    Some(AttributeValue::S(s)) => {
+                        present += 1;
+                        render(&key.segments, item).as_deref() == Some(s.as_str())
+                    }
+                    Some(_) => false,
+                });
             all_match && present > 0
         })
     }
+}
+
+/// Hash a scalar attribute value, or `None` for anything a key cannot hold.
+fn scalar_hash(value: &AttributeValue) -> Option<u64> {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    match value {
+        AttributeValue::S(s) => s.hash(&mut hasher),
+        AttributeValue::N(n) => n.hash(&mut hasher),
+        _ => return None,
+    }
+    Some(hasher.finish())
 }
 
 /// "entity 'A' and entity 'B'", for a warning.
@@ -690,7 +746,9 @@ fn rule_target(rule: &ValidatedRule) -> Option<&str> {
     }
 }
 
-/// Track `attribute` when a template exists for it and mentions a variable.
+/// Record `attribute`'s template. Constant templates are kept too: they do
+/// not need rebuilding, but they are often the only thing telling two
+/// entities apart when an item carries no type attribute.
 fn push_key(
     keys: &mut Vec<TemplatedKey>,
     entity: &EntityDefinition,
@@ -702,13 +760,11 @@ fn push_key(
     };
     let segments = parse_template(template)
         .map_err(|e| format!("entity '{}', {attribute}: {e}", entity.name))?;
-    if segments.iter().any(|s| matches!(s, Segment::Var { .. })) {
-        keys.push(TemplatedKey {
-            attribute: attribute.to_string(),
-            template: template.to_string(),
-            segments,
-        });
-    }
+    keys.push(TemplatedKey {
+        attribute: attribute.to_string(),
+        template: template.to_string(),
+        segments,
+    });
     Ok(())
 }
 
@@ -824,6 +880,10 @@ mod tests {
     }
 
     fn no_consistency() -> HashSet<String> {
+        HashSet::new()
+    }
+
+    fn no_rewrites() -> HashSet<String> {
         HashSet::new()
     }
 
@@ -947,12 +1007,12 @@ mod tests {
             ("customerId", "cust1"),
             ("orderNo", "42"),
         ]);
-        let plan = d.plan(&order, &[], &mut item_warnings).unwrap();
+        let plan = d.plan(&order, &mut item_warnings).unwrap();
         assert!(item_warnings.is_empty(), "{item_warnings:?}");
         assert_eq!(plan.keys.len(), 2);
 
         order.insert("orderNo".to_string(), AttributeValue::S("7".to_string()));
-        d.apply(&plan, &mut order, &mut item_warnings);
+        d.apply(&plan, &no_rewrites(), &mut order, &mut item_warnings);
         assert_eq!(order["sk"], AttributeValue::S("order#00007".to_string()));
     }
 
@@ -1002,7 +1062,7 @@ mod tests {
         let mut warnings = Vec::new();
         let mut user = user();
 
-        let plan = d.plan(&user, &[], &mut warnings).unwrap();
+        let plan = d.plan(&user, &mut warnings).unwrap();
         assert!(warnings.is_empty(), "{warnings:?}");
         assert_eq!(plan.keys.len(), 3);
 
@@ -1010,7 +1070,7 @@ mod tests {
             "email".to_string(),
             AttributeValue::S("fake@example.org".to_string()),
         );
-        d.apply(&plan, &mut user, &mut warnings);
+        d.apply(&plan, &no_rewrites(), &mut user, &mut warnings);
 
         assert_eq!(user["pk"], AttributeValue::S("account#acc1".to_string()));
         assert_eq!(
@@ -1039,14 +1099,14 @@ mod tests {
                 ("accountId", "acc1"),
                 ("email", "alice@example.com"),
             ]);
-            let plan = d.plan(&user, &[], &mut warnings).unwrap();
+            let plan = d.plan(&user, &mut warnings).unwrap();
             assert_eq!(plan.keys.len(), 1, "only pk reproduces");
 
             user.insert(
                 "email".to_string(),
                 AttributeValue::S(format!("fake{n}@example.org")),
             );
-            d.apply(&plan, &mut user, &mut warnings);
+            d.apply(&plan, &no_rewrites(), &mut user, &mut warnings);
             assert_eq!(user["sk"], AttributeValue::S("legacy-profile".to_string()));
         }
 
@@ -1067,7 +1127,7 @@ mod tests {
         let mut user = user();
         user.remove("gs1pk");
         user.remove("gs1sk");
-        let plan = d.plan(&user, &[], &mut warnings).unwrap();
+        let plan = d.plan(&user, &mut warnings).unwrap();
         assert_eq!(plan.keys.len(), 2);
         assert!(warnings.is_empty(), "{warnings:?}");
     }
@@ -1085,14 +1145,14 @@ mod tests {
             ("accountId", "acc1"),
             ("email", "alice@example.com"),
         ]);
-        d.plan(&legacy, &[], &mut warnings).unwrap();
+        d.plan(&legacy, &mut warnings).unwrap();
         assert_eq!(warnings.len(), 1);
 
         // Second item: sk on-template, but the rule nulls email so it cannot render.
         let mut user = user();
-        let plan = d.plan(&user, &[], &mut warnings).unwrap();
+        let plan = d.plan(&user, &mut warnings).unwrap();
         user.insert("email".to_string(), AttributeValue::NULL(true));
-        d.apply(&plan, &mut user, &mut warnings);
+        d.apply(&plan, &no_rewrites(), &mut user, &mut warnings);
 
         assert_eq!(
             user["sk"],
@@ -1115,15 +1175,15 @@ mod tests {
             ("accountId", "acc1"),
             ("email", "alice@example.com"),
         ]);
-        let plan = d.plan(&user, &[], &mut warnings).unwrap();
+        let plan = d.plan(&user, &mut warnings).unwrap();
         assert_eq!(d.entities[plan.entity].name, "User");
 
         let account = item(&[("pk", "account#acc1"), ("sk", "account#"), ("id", "acc1")]);
-        let plan = d.plan(&account, &[], &mut warnings).unwrap();
+        let plan = d.plan(&account, &mut warnings).unwrap();
         assert_eq!(d.entities[plan.entity].name, "Account");
 
         let stranger = item(&[("pk", "thing#1"), ("sk", "meta")]);
-        assert!(d.plan(&stranger, &[], &mut warnings).is_none());
+        assert!(d.plan(&stranger, &mut warnings).is_none());
         assert_eq!(d.take_unmatched(), 1);
         assert_eq!(d.take_unmatched(), 0);
         assert!(warnings.is_empty(), "{warnings:?}");
@@ -1152,12 +1212,14 @@ mod tests {
 
         let mut item_warnings = Vec::new();
         let mut user = user();
-        let plan = d.plan(&user, &rules, &mut item_warnings).unwrap();
+        let plan = d.plan(&user, &mut item_warnings).unwrap();
+        // The rules rewrote sk, so the deriver must leave it alone.
         user.insert(
             "sk".to_string(),
             AttributeValue::S("[REDACTED]".to_string()),
         );
-        d.apply(&plan, &mut user, &mut item_warnings);
+        let rewritten: HashSet<String> = ["sk".to_string()].into_iter().collect();
+        d.apply(&plan, &rewritten, &mut user, &mut item_warnings);
         assert_eq!(user["sk"], AttributeValue::S("[REDACTED]".to_string()));
         assert!(
             item_warnings
@@ -1191,13 +1253,13 @@ mod tests {
         let mut warnings = Vec::new();
         let mut user = user();
         assert!(!user.contains_key("accountName"), "the rule must not match");
-        let plan = d.plan(&user, &rules, &mut warnings).unwrap();
+        let plan = d.plan(&user, &mut warnings).unwrap();
 
         user.insert(
             "email".to_string(),
             AttributeValue::S("fake@example.org".to_string()),
         );
-        d.apply(&plan, &mut user, &mut warnings);
+        d.apply(&plan, &no_rewrites(), &mut user, &mut warnings);
 
         assert_eq!(
             user["sk"],
@@ -1316,7 +1378,7 @@ mod tests {
                 ("sk", "PROFILE"),
                 ("email", &format!("c{n}@x.co")),
             ]);
-            d.plan(&customer, &email_rule(), &mut warnings).unwrap();
+            d.plan(&customer, &mut warnings).unwrap();
         }
 
         assert!(
@@ -1327,7 +1389,11 @@ mod tests {
     }
 
     #[test]
-    fn both_entities_turning_up_is_a_broken_join() {
+    fn a_constant_key_template_still_tells_two_entities_apart() {
+        // Customer and Order share a partition template and differ only by a
+        // constant sk. With no type attribute to go on, matching that ignored
+        // constant templates would resolve an Order as a Customer and leave
+        // the Order's sk holding whatever it arrived with.
         let (mut d, _) = KeyDeriver::new(
             &shared_key_model(),
             &request(),
@@ -1337,23 +1403,92 @@ mod tests {
         .unwrap();
         let mut warnings = Vec::new();
 
-        let customer = item(&[
-            ("_type", "Customer"),
+        let mut order = item(&[
             ("pk", "CUSTOMER#a@x.co"),
-            ("sk", "PROFILE"),
+            ("sk", "ORDER#ref-a@x.co"),
             ("email", "a@x.co"),
+            ("orderId", "ref-a@x.co"),
         ]);
-        d.plan(&customer, &email_rule(), &mut warnings).unwrap();
+        assert!(
+            !order.contains_key("_type"),
+            "no discriminator to fall back on"
+        );
+
+        let plan = d.plan(&order, &mut warnings).unwrap();
+        assert_eq!(d.entities[plan.entity].name, "Order");
+
+        order.insert("orderId".to_string(), AttributeValue::S("anon".to_string()));
+        d.apply(&plan, &no_rewrites(), &mut order, &mut warnings);
+        assert_eq!(
+            order["sk"],
+            AttributeValue::S("ORDER#anon".to_string()),
+            "the Order's own sk must be rebuilt"
+        );
+    }
+
+    #[test]
+    fn a_key_built_from_another_templated_key_is_refused() {
+        // pk reads sk, and sk is itself templated. Rendering pk first copies
+        // the pre-anonymisation sk, so refuse rather than order by luck.
+        let model = model_with(vec![entity("User", "${sk}", Some("user#${email}"), None)]);
+        let err =
+            KeyDeriver::new(&model, &request(), &email_rule(), &no_consistency()).unwrap_err();
+        assert!(err.contains("reads key attribute 'sk'"), "{err}");
+        assert!(err.contains("itself built from a template"), "{err}");
+
+        // A key reading a plain attribute is fine.
+        let model = model_with(vec![entity("User", "user#${email}", Some("profile"), None)]);
+        assert!(KeyDeriver::new(&model, &request(), &email_rule(), &no_consistency()).is_ok());
+    }
+
+    /// Run one item through the pipeline the way the importer does: plan,
+    /// let the rules rewrite `email` to `becomes`, then apply.
+    fn run_item(d: &mut KeyDeriver, mut item: Item, becomes: &str) {
+        let mut warnings = Vec::new();
+        let plan = d.plan(&item, &mut warnings).unwrap();
+        item.insert("email".to_string(), AttributeValue::S(becomes.to_string()));
+        d.apply(&plan, &no_rewrites(), &mut item, &mut warnings);
+    }
+
+    fn shared_key_deriver() -> KeyDeriver {
+        KeyDeriver::new(
+            &shared_key_model(),
+            &request(),
+            &email_rule(),
+            &no_consistency(),
+        )
+        .unwrap()
+        .0
+    }
+
+    fn customer_item(email: &str) -> Item {
+        item(&[
+            ("_type", "Customer"),
+            ("pk", &format!("CUSTOMER#{email}")),
+            ("sk", "PROFILE"),
+            ("email", email),
+        ])
+    }
+
+    fn order_item(email: &str) -> Item {
+        item(&[
+            ("_type", "Order"),
+            ("pk", &format!("CUSTOMER#{email}")),
+            ("sk", "ORDER#1"),
+            ("email", email),
+            ("orderId", "1"),
+        ])
+    }
+
+    #[test]
+    fn two_entities_anonymising_a_shared_value_differently_is_a_broken_join() {
+        let mut d = shared_key_deriver();
+
+        run_item(&mut d, customer_item("a@x.co"), "fake1@example.com");
         assert!(d.join_breaks().is_empty(), "one entity so far");
 
-        let order = item(&[
-            ("_type", "Order"),
-            ("pk", "CUSTOMER#a@x.co"),
-            ("sk", "ORDER#1"),
-            ("email", "a@x.co"),
-            ("orderId", "1"),
-        ]);
-        d.plan(&order, &email_rule(), &mut warnings).unwrap();
+        // Same original address, a different fake: the join is gone.
+        run_item(&mut d, order_item("a@x.co"), "fake2@example.org");
 
         let breaks = d.join_breaks();
         assert_eq!(breaks.len(), 1, "{breaks:?}");
@@ -1362,34 +1497,25 @@ mod tests {
     }
 
     #[test]
+    fn a_shared_value_anonymised_the_same_way_still_joins() {
+        // What a deterministic action such as hash does, or the consistency
+        // map, or a rule that matched neither item: same in, same out.
+        let mut d = shared_key_deriver();
+        run_item(&mut d, customer_item("a@x.co"), "same@example.com");
+        run_item(&mut d, order_item("a@x.co"), "same@example.com");
+        assert!(
+            d.join_breaks().is_empty(),
+            "both agreed, so the join survives: {:?}",
+            d.join_breaks()
+        );
+    }
+
+    #[test]
     fn both_entities_with_no_value_in_common_is_not_a_broken_join() {
-        let (mut d, _) = KeyDeriver::new(
-            &shared_key_model(),
-            &request(),
-            &email_rule(),
-            &no_consistency(),
-        )
-        .unwrap();
-        let mut warnings = Vec::new();
-
-        let customer = item(&[
-            ("_type", "Customer"),
-            ("pk", "CUSTOMER#a@x.co"),
-            ("sk", "PROFILE"),
-            ("email", "a@x.co"),
-        ]);
-        d.plan(&customer, &email_rule(), &mut warnings).unwrap();
-
+        let mut d = shared_key_deriver();
+        run_item(&mut d, customer_item("a@x.co"), "fake1@example.com");
         // A different address, so these two never joined.
-        let order = item(&[
-            ("_type", "Order"),
-            ("pk", "CUSTOMER#b@y.co"),
-            ("sk", "ORDER#1"),
-            ("email", "b@y.co"),
-            ("orderId", "1"),
-        ]);
-        d.plan(&order, &email_rule(), &mut warnings).unwrap();
-
+        run_item(&mut d, order_item("b@y.co"), "fake2@example.org");
         assert!(
             d.join_breaks().is_empty(),
             "both entities present but no shared value: {:?}",
@@ -1409,12 +1535,12 @@ mod tests {
                 ("accountId", "acc1"),
                 ("email", &format!("u{n}@example.com")),
             ]);
-            let plan = d.plan(&user, &[], &mut warnings).unwrap();
+            let plan = d.plan(&user, &mut warnings).unwrap();
             user.insert(
                 "email".to_string(),
                 AttributeValue::S("[REDACTED]".to_string()),
             );
-            d.apply(&plan, &mut user, &mut warnings);
+            d.apply(&plan, &no_rewrites(), &mut user, &mut warnings);
             assert_eq!(user["sk"], AttributeValue::S("user#[REDACTED]".to_string()));
         }
         assert_eq!(d.take_collisions(), (2, false));

--- a/src/import/keys.rs
+++ b/src/import/keys.rs
@@ -1,0 +1,969 @@
+//! Key re-derivation from a data model's entity templates.
+//!
+//! In a single-table design the key attributes are built from other
+//! attributes (`user#${email}`), so anonymising `email` on its own leaves the
+//! real value sitting in `sk` and every GSI key built from it. With a data
+//! model loaded, the importer works out which of an item's keys its entity
+//! builds from templates, lets the rules rewrite the attributes, then renders
+//! those keys again from the anonymised attributes. The entity prefix
+//! survives, and key and attribute agree by construction.
+//!
+//! A key is only rewritten when its template reproduces the value the item
+//! arrived with. A key the template cannot reproduce is left as it is and
+//! reported once per entity and key, so a template that does not describe
+//! the data never silently rewrites a key. Warnings never quote a key's
+//! value: the whole point of the run is that those values leave.
+
+use std::collections::HashSet;
+use std::hash::{Hash, Hasher};
+
+use crate::actions::create_table::CreateTableRequest;
+use crate::expressions::{PathElement, resolve_path};
+use crate::schema::{DataModel, EntityDefinition};
+use crate::types::{AttributeValue, Item};
+use crate::validation::{partition_key_name, sort_key_name};
+
+use super::config::{ValidatedAction, ValidatedRule, parse_path};
+
+/// Rebuilt primary keys are remembered (as hashes) to spot two items
+/// collapsing onto one row. Past this many the check stops, and says so.
+pub(super) const MAX_TRACKED_KEYS: usize = 1_000_000;
+
+/// One piece of a `${name}` template.
+#[derive(Debug, Clone, PartialEq)]
+enum Segment {
+    Literal(String),
+    /// A `${path}` reference, resolved against the item like an attribute
+    /// path (`address.city` reaches into a map), with OneTable's optional
+    /// `${path:length:pad}` sort padding.
+    Var {
+        path: Vec<PathElement>,
+        pad: Option<Padding>,
+    },
+}
+
+/// OneTable's `${name:length:pad}` padding, used to keep numbers sortable
+/// as strings. The rendered value is prefixed with `fill` until it is at
+/// least `length` characters, and `fill` defaults to `0`.
+#[derive(Debug, Clone, PartialEq)]
+struct Padding {
+    length: usize,
+    fill: String,
+}
+
+impl Padding {
+    fn apply(&self, value: &str) -> String {
+        let mut out = value.to_string();
+        if self.fill.is_empty() {
+            return out;
+        }
+        while out.chars().count() < self.length {
+            out.insert_str(0, &self.fill);
+        }
+        out
+    }
+}
+
+/// Split a template such as `user#${email}` into literal and variable parts.
+///
+/// Follows OneTable's own `${name}` and `${name:length:pad}` forms, and its
+/// dotted paths. An unclosed `${` is rejected rather than treated as text,
+/// since it would otherwise leave a key untracked without a word said.
+fn parse_template(template: &str) -> Result<Vec<Segment>, String> {
+    let mut segments = Vec::new();
+    let mut rest = template;
+    while let Some(start) = rest.find("${") {
+        let Some(len) = rest[start..].find('}') else {
+            return Err(format!("template '{template}' has an unclosed '${{'"));
+        };
+        if start > 0 {
+            segments.push(Segment::Literal(rest[..start].to_string()));
+        }
+        let var = &rest[start + 2..start + len];
+
+        let mut parts = var.split(':');
+        let name = parts.next().unwrap_or(var);
+        let pad = match parts.next() {
+            Some(length) => {
+                let length: usize = length.trim().parse().map_err(|_| {
+                    format!(
+                        "template '{template}': '{length}' in '${{{var}}}' is not a length; \
+                         the form is '${{name:length:pad}}'"
+                    )
+                })?;
+                Some(Padding {
+                    length,
+                    fill: parts.next().unwrap_or("0").to_string(),
+                })
+            }
+            None => None,
+        };
+
+        let path = parse_path(name)
+            .map_err(|e| format!("template '{template}' has an invalid reference '{name}': {e}"))?;
+        segments.push(Segment::Var { path, pad });
+        rest = &rest[start + len + 1..];
+    }
+    if !rest.is_empty() {
+        segments.push(Segment::Literal(rest.to_string()));
+    }
+    Ok(segments)
+}
+
+/// Render a template from the item's attributes. `None` when a referenced
+/// attribute is missing or is not a scalar the key can hold.
+fn render(segments: &[Segment], item: &Item) -> Option<String> {
+    let mut out = String::new();
+    for segment in segments {
+        match segment {
+            Segment::Literal(s) => out.push_str(s),
+            Segment::Var { path, pad } => {
+                let rendered = match resolve_path(item, path)? {
+                    AttributeValue::S(s) => s,
+                    AttributeValue::N(n) => n,
+                    AttributeValue::BOOL(b) => if b { "true" } else { "false" }.to_string(),
+                    _ => return None,
+                };
+                match pad {
+                    Some(pad) => out.push_str(&pad.apply(&rendered)),
+                    None => out.push_str(&rendered),
+                }
+            }
+        }
+    }
+    Some(out)
+}
+
+/// A key attribute an entity builds from a template with at least one variable.
+#[derive(Debug, Clone)]
+struct TemplatedKey {
+    attribute: String,
+    template: String,
+    segments: Vec<Segment>,
+}
+
+impl TemplatedKey {
+    /// Top-level attribute names the template reads.
+    fn sources(&self) -> impl Iterator<Item = &str> {
+        self.segments.iter().filter_map(|s| match s {
+            Segment::Var { path, .. } => match path.first() {
+                Some(PathElement::Attribute(name)) => Some(name.as_str()),
+                _ => None,
+            },
+            Segment::Literal(_) => None,
+        })
+    }
+}
+
+/// The templated keys of one entity, resolved against one table's key schema.
+#[derive(Debug, Clone)]
+struct EntityKeys {
+    name: String,
+    type_attribute: String,
+    keys: Vec<TemplatedKey>,
+}
+
+/// Which of an item's keys can be rebuilt after the rules run.
+#[derive(Debug)]
+pub struct Rederivation {
+    entity: usize,
+    keys: Vec<usize>,
+}
+
+/// Rebuilds templated keys for the items of one table.
+#[derive(Debug)]
+pub struct KeyDeriver {
+    entities: Vec<EntityKeys>,
+    /// Every distinct type attribute the entities use, usually just the
+    /// model's default, so an item is looked up once per attribute rather
+    /// than once per entity.
+    type_attributes: Vec<String>,
+    /// Primary key attribute names, for the collision check.
+    hash_attribute: Option<String>,
+    range_attribute: Option<String>,
+    /// (entity index, key index) pairs whose template failed to reproduce
+    /// a value, reported once so a whole table of off-template items
+    /// produces one warning rather than one per item.
+    warned_mismatch: HashSet<(usize, usize)>,
+    /// (entity index, key index) pairs that could not be rendered after the
+    /// rules ran, reported once.
+    warned_unrenderable: HashSet<(usize, usize)>,
+    /// Items that matched no entity, reported once per table.
+    unmatched: usize,
+    /// Hashes of every rebuilt primary key, to spot collisions.
+    rebuilt_keys: HashSet<u64>,
+    /// Rebuilt items whose primary key repeated an earlier rebuilt key.
+    collisions: usize,
+    /// Set once `rebuilt_keys` hit its cap and stopped tracking.
+    collision_check_capped: bool,
+}
+
+impl KeyDeriver {
+    /// Resolve the model's templates against the table's key schema: the
+    /// primary key from `KeySchema`, and each GSI mapping against the index
+    /// of the same name. Templates without a variable never change, so they
+    /// are not tracked.
+    ///
+    /// The rules are consulted too. A rule that targets a key attribute
+    /// directly wins over the template, and that key is not rebuilt. A rule
+    /// that redacts, nulls or masks an attribute a key is built from is
+    /// reported, because every item would then render the same key and
+    /// collapse onto one row. Both are returned as warnings alongside the
+    /// deriver; a template that cannot be parsed is an error.
+    pub fn new(
+        model: &DataModel,
+        request: &CreateTableRequest,
+        rules: &[ValidatedRule],
+    ) -> Result<(Self, Vec<String>), String> {
+        let hash = partition_key_name(&request.key_schema);
+        let range = sort_key_name(&request.key_schema);
+        let gsis = request.global_secondary_indexes.as_deref().unwrap_or(&[]);
+
+        let rule_targets: HashSet<&str> = rules.iter().filter_map(rule_target).collect();
+        let mut warnings = Vec::new();
+
+        let mut entities = Vec::with_capacity(model.entities.len());
+        for entity in &model.entities {
+            let mut keys = Vec::new();
+            push_key(&mut keys, entity, hash, Some(&entity.pk_template))?;
+            push_key(&mut keys, entity, range, entity.sk_template.as_deref())?;
+
+            for mapping in &entity.gsi_mappings {
+                let Some(gsi) = gsis.iter().find(|g| g.index_name == mapping.index_name) else {
+                    continue;
+                };
+                push_key(
+                    &mut keys,
+                    entity,
+                    partition_key_name(&gsi.key_schema),
+                    Some(&mapping.pk_template),
+                )?;
+                push_key(
+                    &mut keys,
+                    entity,
+                    sort_key_name(&gsi.key_schema),
+                    mapping.sk_template.as_deref(),
+                )?;
+            }
+
+            keys.retain(|key| {
+                let targeted = rule_targets.contains(key.attribute.as_str());
+                if targeted {
+                    warnings.push(format!(
+                        "a rule targets key attribute '{}' directly, so it is not rebuilt \
+                         from entity '{}' template '{}'; the rule's value is kept as written",
+                        key.attribute, entity.name, key.template
+                    ));
+                }
+                !targeted
+            });
+
+            for key in &keys {
+                for rule in rules {
+                    let Some(target) = rule_target(rule) else {
+                        continue;
+                    };
+                    let collapses = match rule.action {
+                        ValidatedAction::Redact | ValidatedAction::Null => "every",
+                        ValidatedAction::Mask { .. } => "most",
+                        ValidatedAction::Fake { .. } | ValidatedAction::Hash { .. } => continue,
+                    };
+                    if key.sources().any(|source| source == target) {
+                        warnings.push(format!(
+                            "a rule replaces '{target}' with a constant, and entity '{}' builds \
+                             {} from template '{}': {collapses} item of that entity would render \
+                             the same key and collapse onto one row. Use fake or hash for an \
+                             attribute a key is built from",
+                            entity.name, key.attribute, key.template
+                        ));
+                    }
+                }
+            }
+
+            entities.push(EntityKeys {
+                name: entity.name.clone(),
+                type_attribute: type_attribute(model, entity),
+                keys,
+            });
+        }
+
+        let mut type_attributes: Vec<String> =
+            entities.iter().map(|e| e.type_attribute.clone()).collect();
+        type_attributes.sort();
+        type_attributes.dedup();
+
+        Ok((
+            Self {
+                entities,
+                type_attributes,
+                hash_attribute: hash.map(String::from),
+                range_attribute: range.map(String::from),
+                warned_mismatch: HashSet::new(),
+                warned_unrenderable: HashSet::new(),
+                unmatched: 0,
+                rebuilt_keys: HashSet::new(),
+                collisions: 0,
+                collision_check_capped: false,
+            },
+            warnings,
+        ))
+    }
+
+    /// Before the rules run: decide which of the item's keys will be rebuilt.
+    ///
+    /// A key qualifies when the entity's template reproduces the value the
+    /// item arrived with. Any key the template does not reproduce is left
+    /// alone and reported (once per entity and key). An item that matches no
+    /// entity is counted for [`take_unmatched`](Self::take_unmatched).
+    pub fn plan(&mut self, item: &Item, warnings: &mut Vec<String>) -> Option<Rederivation> {
+        let Some(entity_idx) = self.resolve_entity(item) else {
+            self.unmatched += 1;
+            return None;
+        };
+        let entity = &self.entities[entity_idx];
+
+        let mut keys = Vec::new();
+        for (idx, key) in entity.keys.iter().enumerate() {
+            let Some(current) = item.get(&key.attribute) else {
+                // A sparse index key: nothing to rebuild.
+                continue;
+            };
+            let reproduced = match current {
+                AttributeValue::S(s) => render(&key.segments, item).as_deref() == Some(s.as_str()),
+                _ => false,
+            };
+            if reproduced {
+                keys.push(idx);
+            } else if self.warned_mismatch.insert((entity_idx, idx)) {
+                warnings.push(format!(
+                    "entity '{}': template '{}' does not reproduce {} on at least one item \
+                     (the attributes it names are missing, not scalars, or the key was \
+                     built differently); such keys are left unchanged",
+                    entity.name, key.template, key.attribute
+                ));
+            }
+        }
+
+        Some(Rederivation {
+            entity: entity_idx,
+            keys,
+        })
+    }
+
+    /// After the rules run: render every planned key from the item's current
+    /// attributes. A key whose template no longer renders (a rule nulled or
+    /// removed an attribute it needs) is left unchanged and reported.
+    pub fn apply(&mut self, plan: &Rederivation, item: &mut Item, warnings: &mut Vec<String>) {
+        let entity = &self.entities[plan.entity];
+        let mut rebuilt_primary = false;
+        for &idx in &plan.keys {
+            let key = &entity.keys[idx];
+            match render(&key.segments, item) {
+                Some(value) => {
+                    item.insert(key.attribute.clone(), AttributeValue::S(value));
+                    rebuilt_primary |= Some(key.attribute.as_str())
+                        == self.hash_attribute.as_deref()
+                        || Some(key.attribute.as_str()) == self.range_attribute.as_deref();
+                }
+                None => {
+                    if self.warned_unrenderable.insert((plan.entity, idx)) {
+                        warnings.push(format!(
+                            "entity '{}': cannot rebuild {} from template '{}' after the rules \
+                             ran (an attribute it needs is no longer a string or number); \
+                             the original key value is left in place",
+                            entity.name, key.attribute, key.template
+                        ));
+                    }
+                }
+            }
+        }
+        if rebuilt_primary {
+            self.note_rebuilt_primary_key(item);
+        }
+    }
+
+    /// Remember a rebuilt primary key so a later item rendering the same one
+    /// is counted as a collision.
+    fn note_rebuilt_primary_key(&mut self, item: &Item) {
+        if self.collision_check_capped {
+            return;
+        }
+        if self.rebuilt_keys.len() >= MAX_TRACKED_KEYS {
+            self.collision_check_capped = true;
+            return;
+        }
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        for attribute in [&self.hash_attribute, &self.range_attribute]
+            .into_iter()
+            .flatten()
+        {
+            if let Some(AttributeValue::S(s)) = item.get(attribute) {
+                s.hash(&mut hasher);
+            }
+            0u8.hash(&mut hasher);
+        }
+        if !self.rebuilt_keys.insert(hasher.finish()) {
+            self.collisions += 1;
+        }
+    }
+
+    /// Number of items since the last call that matched no entity.
+    pub fn take_unmatched(&mut self) -> usize {
+        std::mem::take(&mut self.unmatched)
+    }
+
+    /// Rebuilt items whose primary key repeated an earlier rebuilt key, and
+    /// whether the check stopped early because the table was too large to
+    /// track in full.
+    pub fn take_collisions(&mut self) -> (usize, bool) {
+        (
+            std::mem::take(&mut self.collisions),
+            self.collision_check_capped,
+        )
+    }
+
+    /// Find the item's entity: by its type attribute first, otherwise the
+    /// first entity whose templates reproduce every key the item carries.
+    fn resolve_entity(&self, item: &Item) -> Option<usize> {
+        for type_attribute in &self.type_attributes {
+            let Some(AttributeValue::S(type_value)) = item.get(type_attribute) else {
+                continue;
+            };
+            let by_type = self
+                .entities
+                .iter()
+                .position(|e| e.name == *type_value && e.type_attribute == *type_attribute);
+            if by_type.is_some() {
+                return by_type;
+            }
+        }
+
+        self.entities.iter().position(|e| {
+            let mut present = 0;
+            let all_match = e.keys.iter().all(|key| match item.get(&key.attribute) {
+                None => true,
+                Some(AttributeValue::S(s)) => {
+                    present += 1;
+                    render(&key.segments, item).as_deref() == Some(s.as_str())
+                }
+                Some(_) => false,
+            });
+            all_match && present > 0
+        })
+    }
+}
+
+/// The top-level attribute a rule rewrites.
+fn rule_target(rule: &ValidatedRule) -> Option<&str> {
+    match rule.path.first() {
+        Some(PathElement::Attribute(name)) => Some(name.as_str()),
+        _ => None,
+    }
+}
+
+/// Track `attribute` when a template exists for it and mentions a variable.
+fn push_key(
+    keys: &mut Vec<TemplatedKey>,
+    entity: &EntityDefinition,
+    attribute: Option<&str>,
+    template: Option<&str>,
+) -> Result<(), String> {
+    let (Some(attribute), Some(template)) = (attribute, template) else {
+        return Ok(());
+    };
+    let segments = parse_template(template)
+        .map_err(|e| format!("entity '{}', {attribute}: {e}", entity.name))?;
+    if segments.iter().any(|s| matches!(s, Segment::Var { .. })) {
+        keys.push(TemplatedKey {
+            attribute: attribute.to_string(),
+            template: template.to_string(),
+            segments,
+        });
+    }
+    Ok(())
+}
+
+fn type_attribute(model: &DataModel, entity: &EntityDefinition) -> String {
+    entity
+        .type_attribute
+        .clone()
+        .unwrap_or_else(|| model.type_attribute.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::expressions::condition;
+    use crate::schema::GsiMapping;
+    use crate::types::{KeySchemaElement, KeyType};
+
+    fn item(pairs: &[(&str, &str)]) -> Item {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), AttributeValue::S(v.to_string())))
+            .collect()
+    }
+
+    fn entity(
+        name: &str,
+        pk: &str,
+        sk: Option<&str>,
+        gsi: Option<(&str, Option<&str>)>,
+    ) -> EntityDefinition {
+        EntityDefinition {
+            name: name.to_string(),
+            pk_template: pk.to_string(),
+            sk_template: sk.map(String::from),
+            type_attribute: None,
+            gsi_mappings: gsi
+                .map(|(pk, sk)| {
+                    vec![GsiMapping {
+                        index_name: "GSI1".to_string(),
+                        pk_template: pk.to_string(),
+                        sk_template: sk.map(String::from),
+                    }]
+                })
+                .unwrap_or_default(),
+            description: None,
+        }
+    }
+
+    fn model() -> DataModel {
+        DataModel {
+            schema_format: "onetable:1.1.0".to_string(),
+            type_attribute: "_type".to_string(),
+            entities: vec![
+                entity("Account", "account#${id}", Some("account#"), None),
+                entity(
+                    "User",
+                    "account#${accountId}",
+                    Some("user#${email}"),
+                    Some(("user#${email}", Some("user#"))),
+                ),
+            ],
+        }
+    }
+
+    fn model_with(entities: Vec<EntityDefinition>) -> DataModel {
+        DataModel {
+            schema_format: "onetable:1.1.0".to_string(),
+            type_attribute: "_type".to_string(),
+            entities,
+        }
+    }
+
+    fn request() -> CreateTableRequest {
+        serde_json::from_value(serde_json::json!({
+            "TableName": "App",
+            "KeySchema": [
+                {"AttributeName": "pk", "KeyType": "HASH"},
+                {"AttributeName": "sk", "KeyType": "RANGE"}
+            ],
+            "AttributeDefinitions": [
+                {"AttributeName": "pk", "AttributeType": "S"},
+                {"AttributeName": "sk", "AttributeType": "S"},
+                {"AttributeName": "gs1pk", "AttributeType": "S"},
+                {"AttributeName": "gs1sk", "AttributeType": "S"}
+            ],
+            "GlobalSecondaryIndexes": [{
+                "IndexName": "GSI1",
+                "KeySchema": [
+                    {"AttributeName": "gs1pk", "KeyType": "HASH"},
+                    {"AttributeName": "gs1sk", "KeyType": "RANGE"}
+                ],
+                "Projection": {"ProjectionType": "ALL"}
+            }]
+        }))
+        .unwrap()
+    }
+
+    fn key_schema(name: &str, kind: KeyType) -> KeySchemaElement {
+        KeySchemaElement {
+            attribute_name: name.to_string(),
+            key_type: kind,
+        }
+    }
+
+    fn rule(path: &str, action: ValidatedAction) -> ValidatedRule {
+        ValidatedRule {
+            condition: condition::parse("attribute_exists(pk)").unwrap(),
+            names: None,
+            values: None,
+            path: parse_path(path).unwrap(),
+            action,
+        }
+    }
+
+    fn deriver() -> KeyDeriver {
+        let (deriver, warnings) = KeyDeriver::new(&model(), &request(), &[]).unwrap();
+        assert!(warnings.is_empty(), "{warnings:?}");
+        deriver
+    }
+
+    fn tracked(deriver: &KeyDeriver, entity: usize) -> Vec<&str> {
+        deriver.entities[entity]
+            .keys
+            .iter()
+            .map(|k| k.attribute.as_str())
+            .collect()
+    }
+
+    fn user() -> Item {
+        item(&[
+            ("_type", "User"),
+            ("pk", "account#acc1"),
+            ("sk", "user#alice@example.com"),
+            ("gs1pk", "user#alice@example.com"),
+            ("gs1sk", "user#"),
+            ("accountId", "acc1"),
+            ("email", "alice@example.com"),
+        ])
+    }
+
+    #[test]
+    fn template_splits_into_literals_and_variables() {
+        let var = |p: &str| Segment::Var {
+            path: parse_path(p).unwrap(),
+            pad: None,
+        };
+        assert_eq!(
+            parse_template("project#${status}#${name}").unwrap(),
+            vec![
+                Segment::Literal("project#".to_string()),
+                var("status"),
+                Segment::Literal("#".to_string()),
+                var("name"),
+            ]
+        );
+        assert_eq!(
+            parse_template("account#").unwrap(),
+            vec![Segment::Literal("account#".to_string())]
+        );
+        assert_eq!(parse_template("${id}").unwrap(), vec![var("id")]);
+        assert_eq!(
+            parse_template("city#${address.city}").unwrap(),
+            vec![Segment::Literal("city#".to_string()), var("address.city")]
+        );
+    }
+
+    #[test]
+    fn template_rejects_an_unclosed_reference() {
+        let err = parse_template("user#${email").unwrap_err();
+        assert!(err.contains("unclosed"), "{err}");
+
+        let err = KeyDeriver::new(
+            &model_with(vec![entity("Bad", "x#${id", None, None)]),
+            &request(),
+            &[],
+        )
+        .unwrap_err();
+        assert!(err.contains("entity 'Bad', pk"), "{err}");
+    }
+
+    #[test]
+    fn template_pads_a_value_the_way_onetable_does() {
+        // ${name:length:pad}, pad defaulting to "0", prefixed until length
+        let segments = parse_template("order#${orderNo:5}").unwrap();
+        assert_eq!(
+            render(&segments, &item(&[("orderNo", "42")])).as_deref(),
+            Some("order#00042")
+        );
+
+        let segments = parse_template("order#${orderNo:4:x}").unwrap();
+        assert_eq!(
+            render(&segments, &item(&[("orderNo", "42")])).as_deref(),
+            Some("order#xx42")
+        );
+
+        // already at or over the length is left alone
+        let segments = parse_template("order#${orderNo:2}").unwrap();
+        assert_eq!(
+            render(&segments, &item(&[("orderNo", "12345")])).as_deref(),
+            Some("order#12345")
+        );
+
+        // padding applies to a number attribute too
+        let mut numeric = Item::new();
+        numeric.insert("n".to_string(), AttributeValue::N("7".to_string()));
+        let segments = parse_template("${n:3}").unwrap();
+        assert_eq!(render(&segments, &numeric).as_deref(), Some("007"));
+
+        let err = parse_template("order#${orderNo:wide}").unwrap_err();
+        assert!(err.contains("is not a length"), "{err}");
+    }
+
+    #[test]
+    fn a_padded_key_rebuilds_from_its_anonymised_source() {
+        let model = model_with(vec![entity(
+            "Order",
+            "order#${customerId}",
+            Some("order#${orderNo:5}"),
+            None,
+        )]);
+        let (mut d, warnings) = KeyDeriver::new(&model, &request(), &[]).unwrap();
+        assert!(warnings.is_empty(), "{warnings:?}");
+
+        let mut item_warnings = Vec::new();
+        let mut order = item(&[
+            ("_type", "Order"),
+            ("pk", "order#cust1"),
+            ("sk", "order#00042"),
+            ("customerId", "cust1"),
+            ("orderNo", "42"),
+        ]);
+        let plan = d.plan(&order, &mut item_warnings).unwrap();
+        assert!(item_warnings.is_empty(), "{item_warnings:?}");
+        assert_eq!(plan.keys.len(), 2);
+
+        order.insert("orderNo".to_string(), AttributeValue::S("7".to_string()));
+        d.apply(&plan, &mut order, &mut item_warnings);
+        assert_eq!(order["sk"], AttributeValue::S("order#00007".to_string()));
+    }
+
+    #[test]
+    fn render_uses_scalars_and_fails_on_anything_else() {
+        let segments = parse_template("user#${email}").unwrap();
+        assert_eq!(
+            render(&segments, &item(&[("email", "a@b.c")])).as_deref(),
+            Some("user#a@b.c")
+        );
+        assert_eq!(render(&segments, &item(&[])), None);
+
+        let mut nulled = Item::new();
+        nulled.insert("email".to_string(), AttributeValue::NULL(true));
+        assert_eq!(render(&segments, &nulled), None);
+    }
+
+    #[test]
+    fn render_reaches_into_nested_maps() {
+        let segments = parse_template("city#${address.city}").unwrap();
+        let mut address = std::collections::HashMap::new();
+        address.insert("city".to_string(), AttributeValue::S("Leeds".to_string()));
+        let mut it = Item::new();
+        it.insert("address".to_string(), AttributeValue::M(address));
+        assert_eq!(render(&segments, &it).as_deref(), Some("city#Leeds"));
+    }
+
+    #[test]
+    fn templated_keys_resolve_against_the_table_key_schema() {
+        let d = deriver();
+        // gs1sk is "user#" with no variable, so it is not tracked
+        assert_eq!(tracked(&d, 1), vec!["pk", "sk", "gs1pk"]);
+        assert_eq!(tracked(&d, 0), vec!["pk"]);
+    }
+
+    #[test]
+    fn gsi_mapping_without_a_matching_index_is_skipped() {
+        let mut request = request();
+        request.global_secondary_indexes = None;
+        let (d, _) = KeyDeriver::new(&model(), &request, &[]).unwrap();
+        assert_eq!(tracked(&d, 1), vec!["pk", "sk"]);
+    }
+
+    #[test]
+    fn rebuilds_keys_from_the_anonymised_attribute() {
+        let mut d = deriver();
+        let mut warnings = Vec::new();
+        let mut user = user();
+
+        let plan = d.plan(&user, &mut warnings).unwrap();
+        assert!(warnings.is_empty(), "{warnings:?}");
+        assert_eq!(plan.keys.len(), 3);
+
+        user.insert(
+            "email".to_string(),
+            AttributeValue::S("fake@example.org".to_string()),
+        );
+        d.apply(&plan, &mut user, &mut warnings);
+
+        assert_eq!(user["pk"], AttributeValue::S("account#acc1".to_string()));
+        assert_eq!(
+            user["sk"],
+            AttributeValue::S("user#fake@example.org".to_string())
+        );
+        assert_eq!(
+            user["gs1pk"],
+            AttributeValue::S("user#fake@example.org".to_string())
+        );
+        assert_eq!(user["gs1sk"], AttributeValue::S("user#".to_string()));
+        assert!(warnings.is_empty(), "{warnings:?}");
+        assert_eq!(d.take_collisions(), (0, false));
+    }
+
+    #[test]
+    fn a_key_the_template_does_not_reproduce_is_left_and_reported_once_without_its_value() {
+        let mut d = deriver();
+        let mut warnings = Vec::new();
+
+        for n in 0..3 {
+            let mut user = item(&[
+                ("_type", "User"),
+                ("pk", "account#acc1"),
+                ("sk", "legacy-profile"),
+                ("accountId", "acc1"),
+                ("email", "alice@example.com"),
+            ]);
+            let plan = d.plan(&user, &mut warnings).unwrap();
+            assert_eq!(plan.keys.len(), 1, "only pk reproduces");
+
+            user.insert(
+                "email".to_string(),
+                AttributeValue::S(format!("fake{n}@example.org")),
+            );
+            d.apply(&plan, &mut user, &mut warnings);
+            assert_eq!(user["sk"], AttributeValue::S("legacy-profile".to_string()));
+        }
+
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert!(warnings[0].contains("entity 'User'"));
+        assert!(warnings[0].contains("does not reproduce sk"));
+        assert!(
+            !warnings[0].contains("legacy-profile"),
+            "a warning must not quote the key value: {}",
+            warnings[0]
+        );
+    }
+
+    #[test]
+    fn a_sparse_index_key_is_not_a_mismatch() {
+        let mut d = deriver();
+        let mut warnings = Vec::new();
+        let mut user = user();
+        user.remove("gs1pk");
+        user.remove("gs1sk");
+        let plan = d.plan(&user, &mut warnings).unwrap();
+        assert_eq!(plan.keys.len(), 2);
+        assert!(warnings.is_empty(), "{warnings:?}");
+    }
+
+    #[test]
+    fn a_key_that_stops_rendering_after_the_rules_is_reported_even_after_a_mismatch() {
+        let mut d = deriver();
+        let mut warnings = Vec::new();
+
+        // First item: sk off-template, so the mismatch warning fires for (User, sk).
+        let legacy = item(&[
+            ("_type", "User"),
+            ("pk", "account#acc1"),
+            ("sk", "legacy-profile"),
+            ("accountId", "acc1"),
+            ("email", "alice@example.com"),
+        ]);
+        d.plan(&legacy, &mut warnings).unwrap();
+        assert_eq!(warnings.len(), 1);
+
+        // Second item: sk on-template, but the rule nulls email so it cannot render.
+        let mut user = user();
+        let plan = d.plan(&user, &mut warnings).unwrap();
+        user.insert("email".to_string(), AttributeValue::NULL(true));
+        d.apply(&plan, &mut user, &mut warnings);
+
+        assert_eq!(
+            user["sk"],
+            AttributeValue::S("user#alice@example.com".to_string())
+        );
+        // sk and gs1pk both build from email, so both report
+        assert_eq!(warnings.len(), 3, "{warnings:?}");
+        assert!(warnings[1].contains("cannot rebuild sk"), "{warnings:?}");
+        assert!(warnings[2].contains("cannot rebuild gs1pk"), "{warnings:?}");
+    }
+
+    #[test]
+    fn entity_falls_back_to_template_shape_without_a_type_attribute() {
+        let mut d = deriver();
+        let mut warnings = Vec::new();
+
+        let user = item(&[
+            ("pk", "account#acc1"),
+            ("sk", "user#alice@example.com"),
+            ("accountId", "acc1"),
+            ("email", "alice@example.com"),
+        ]);
+        let plan = d.plan(&user, &mut warnings).unwrap();
+        assert_eq!(d.entities[plan.entity].name, "User");
+
+        let account = item(&[("pk", "account#acc1"), ("sk", "account#"), ("id", "acc1")]);
+        let plan = d.plan(&account, &mut warnings).unwrap();
+        assert_eq!(d.entities[plan.entity].name, "Account");
+
+        let stranger = item(&[("pk", "thing#1"), ("sk", "meta")]);
+        assert!(d.plan(&stranger, &mut warnings).is_none());
+        assert_eq!(d.take_unmatched(), 1);
+        assert_eq!(d.take_unmatched(), 0);
+        assert!(warnings.is_empty(), "{warnings:?}");
+    }
+
+    #[test]
+    fn primary_key_names_come_from_the_key_schema_not_the_model() {
+        let mut request = request();
+        request.key_schema = vec![
+            key_schema("PK", KeyType::HASH),
+            key_schema("SK", KeyType::RANGE),
+        ];
+        let (d, _) = KeyDeriver::new(&model(), &request, &[]).unwrap();
+        assert_eq!(tracked(&d, 1), vec!["PK", "SK", "gs1pk"]);
+    }
+
+    #[test]
+    fn a_rule_on_a_key_attribute_wins_over_the_template() {
+        let rules = [rule("sk", ValidatedAction::Redact)];
+        let (mut d, warnings) = KeyDeriver::new(&model(), &request(), &rules).unwrap();
+        assert_eq!(tracked(&d, 1), vec!["pk", "gs1pk"]);
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert!(warnings[0].contains("targets key attribute 'sk' directly"));
+
+        let mut item_warnings = Vec::new();
+        let mut user = user();
+        let plan = d.plan(&user, &mut item_warnings).unwrap();
+        user.insert(
+            "sk".to_string(),
+            AttributeValue::S("[REDACTED]".to_string()),
+        );
+        d.apply(&plan, &mut user, &mut item_warnings);
+        assert_eq!(user["sk"], AttributeValue::S("[REDACTED]".to_string()));
+        assert!(item_warnings.is_empty(), "{item_warnings:?}");
+    }
+
+    #[test]
+    fn a_constant_action_on_a_key_source_is_reported_up_front() {
+        let rules = [rule("email", ValidatedAction::Redact)];
+        let (_, warnings) = KeyDeriver::new(&model(), &request(), &rules).unwrap();
+        // sk and gs1pk of User both build from email
+        assert_eq!(warnings.len(), 2, "{warnings:?}");
+        assert!(warnings[0].contains("collapse onto one row"));
+        assert!(warnings[0].contains("'email'"));
+
+        let rules = [rule(
+            "email",
+            ValidatedAction::Fake {
+                generator: "safe_email".into(),
+            },
+        )];
+        let (_, warnings) = KeyDeriver::new(&model(), &request(), &rules).unwrap();
+        assert!(warnings.is_empty(), "{warnings:?}");
+    }
+
+    #[test]
+    fn rebuilt_primary_keys_that_repeat_are_counted_as_collisions() {
+        let mut d = deriver();
+        let mut warnings = Vec::new();
+        for n in 0..3 {
+            let mut user = item(&[
+                ("_type", "User"),
+                ("pk", "account#acc1"),
+                ("sk", &format!("user#u{n}@example.com")),
+                ("accountId", "acc1"),
+                ("email", &format!("u{n}@example.com")),
+            ]);
+            let plan = d.plan(&user, &mut warnings).unwrap();
+            user.insert(
+                "email".to_string(),
+                AttributeValue::S("[REDACTED]".to_string()),
+            );
+            d.apply(&plan, &mut user, &mut warnings);
+            assert_eq!(user["sk"], AttributeValue::S("user#[REDACTED]".to_string()));
+        }
+        assert_eq!(d.take_collisions(), (2, false));
+        assert_eq!(d.take_collisions(), (0, false));
+    }
+}

--- a/src/import/keys.rs
+++ b/src/import/keys.rs
@@ -179,22 +179,28 @@ struct EntityKeys {
 /// `[consistency] fields`. Anonymising it independently per item means the
 /// entities' keys disagree and the join between them is lost.
 #[derive(Debug)]
+
 struct AtRisk {
-    /// The attribute path the shared templates read.
-    source: Vec<PathElement>,
-    /// That path written out, for the message.
-    source_name: String,
-    /// Entity indices that build a key from it, in model order.
+    /// The key attribute the shared template builds.
+    key_attribute: String,
+    /// The template itself, for the message.
+    template: String,
+    /// Root field names to put in `[consistency] fields`. Roots, because
+    /// that is what the consistency map is keyed on: advising `contact.email`
+    /// when only `contact` is honoured would send someone in a circle.
+    consistency_roots: Vec<String>,
+    /// Entity indices that build this key from this template, in model order.
     entities: Vec<usize>,
-    /// Original value hash -> (entity that carried it, what it anonymised
-    /// to). A second entity carrying the same original is the join; a
-    /// *different* anonymised result is the join actually breaking. A
-    /// deterministic action such as hash agrees by construction, and a rule
-    /// that matched neither item changes nothing, so both stay quiet.
-    seen_values: std::collections::HashMap<u64, (usize, u64)>,
-    /// Entities found to have anonymised a shared value differently.
+    /// Hash of the whole key value the item arrived with -> every (entity,
+    /// resulting key value) seen for it. Comparing the whole key, rather than
+    /// one attribute it reads, tells a real join from two composite keys that
+    /// merely share a component: `TENANT#a#x` and `TENANT#b#x` never agreed,
+    /// so they have nothing to lose. A deterministic action such as hash
+    /// takes both to the same place and stays quiet.
+    seen_keys: std::collections::HashMap<u64, Vec<(usize, u64)>>,
+    /// Entities found to have taken a shared key to different values.
     diverged: HashSet<usize>,
-    /// Set once `seen_values` hit its cap and stopped tracking.
+    /// Set once `seen_keys` hit its cap and stopped tracking.
     capped: bool,
 }
 
@@ -398,8 +404,13 @@ impl KeyDeriver {
         // unrelated pairs that happen to read an attribute of the same name
         // stay separate: A and B sharing `account#${id}` have nothing to do
         // with C and D sharing `project#${id}`.
-        type RiskKey = (String, String, Vec<PathElement>);
-        let mut shared: Vec<(RiskKey, Vec<usize>)> = Vec::new();
+        // Grouped by the key and its template, so two unrelated pairs that
+        // happen to read an attribute of the same name stay separate: A and B
+        // sharing `account#${id}` have nothing to do with C and D sharing
+        // `project#${id}`.
+        /// (key attribute, template) -> (entities building it, roots needing consistency)
+        type SharedGroups = Vec<((String, String), (Vec<usize>, Vec<String>))>;
+        let mut shared: SharedGroups = Vec::new();
         for (idx, shape) in entity_key_shapes.iter().enumerate() {
             for (attribute, template, sources) in shape {
                 let shared_with_another =
@@ -415,57 +426,68 @@ impl KeyDeriver {
                 if !shared_with_another {
                     continue;
                 }
-                for source in sources {
-                    let Some(PathElement::Attribute(root)) = source.first() else {
-                        continue;
-                    };
-                    // An attribute no rule rewrites keeps its value, so the
-                    // two keys still agree however they were built.
-                    if consistency_fields.contains(root) || !rule_targets.contains(root.as_str()) {
-                        continue;
-                    }
-                    let risk_key = (attribute.clone(), template.clone(), source.clone());
-                    match shared.iter_mut().find(|(k, _)| *k == risk_key) {
-                        Some((_, users)) => {
-                            if !users.contains(&idx) {
-                                users.push(idx);
+                // An attribute no rule rewrites keeps its value, so the two
+                // keys still agree however they were built.
+                let roots: Vec<String> = sources
+                    .iter()
+                    .filter_map(|source| match source.first() {
+                        Some(PathElement::Attribute(root)) => Some(root.clone()),
+                        _ => None,
+                    })
+                    .filter(|root| {
+                        !consistency_fields.contains(root) && rule_targets.contains(root.as_str())
+                    })
+                    .collect();
+                if roots.is_empty() {
+                    continue;
+                }
+                let group = (attribute.clone(), template.clone());
+                match shared.iter_mut().find(|(k, _)| *k == group) {
+                    Some((_, (users, known_roots))) => {
+                        if !users.contains(&idx) {
+                            users.push(idx);
+                        }
+                        for root in roots {
+                            if !known_roots.contains(&root) {
+                                known_roots.push(root);
                             }
                         }
-                        None => shared.push((risk_key, vec![idx])),
                     }
+                    None => shared.push((group, (vec![idx], roots))),
                 }
             }
         }
-        for (_, users) in shared.iter_mut() {
+        for (_, (users, roots)) in shared.iter_mut() {
             users.sort();
+            roots.sort();
         }
-        shared.retain(|(_, users)| users.len() > 1);
-        // Deterministic order for the warnings: key attribute, then
-        // template, then the source path written out.
-        shared.sort_by(|a, b| {
-            (&a.0.0, &a.0.1, path_display(&a.0.2)).cmp(&(&b.0.0, &b.0.1, path_display(&b.0.2)))
-        });
+        shared.retain(|(_, (users, _))| users.len() > 1);
+        shared.sort_by(|a, b| a.0.cmp(&b.0));
 
         let at_risk: Vec<AtRisk> = shared
             .into_iter()
-            .map(|((_, _, source), entities_using)| {
-                let source_name = path_display(&source);
-                warnings.push(format!(
-                    "{} both build keys from '{}', which is not in [consistency] fields: \
-                     if they both appear in this import their keys will not agree and \
-                     the entities will not join",
-                    entity_list(&entities, &entities_using),
-                    source_name
-                ));
-                AtRisk {
-                    source,
-                    source_name,
-                    entities: entities_using,
-                    seen_values: std::collections::HashMap::new(),
-                    diverged: HashSet::new(),
-                    capped: false,
-                }
-            })
+            .map(
+                |((key_attribute, template), (entities_using, consistency_roots))| {
+                    warnings.push(format!(
+                        "{} both build {} from template '{}', which reads {} outside \
+                     [consistency] fields: if they both appear in this import their keys \
+                     will not agree and the entities will not join",
+                        entity_list(&entities, &entities_using),
+                        key_attribute,
+                        template,
+                        quoted_list(&consistency_roots)
+                    ));
+                    AtRisk {
+                        key_attribute,
+                        template,
+                        consistency_roots,
+                        entities: entities_using,
+                        seen_keys: std::collections::HashMap::new(),
+                        diverged: HashSet::new(),
+                        capped: false,
+                    }
+                },
+            )
             .collect();
 
         let mut type_attributes: Vec<String> =
@@ -542,7 +564,7 @@ impl KeyDeriver {
             .iter()
             .enumerate()
             .filter(|(_, risk)| risk.entities.contains(&entity_idx) && !risk.capped)
-            .filter_map(|(idx, risk)| Some((idx, scalar_hash(&resolve_path(item, &risk.source)?)?)))
+            .filter_map(|(idx, risk)| Some((idx, scalar_hash(item.get(&risk.key_attribute)?)?)))
             .collect()
     }
 
@@ -556,25 +578,31 @@ impl KeyDeriver {
             if risk.capped {
                 continue;
             }
-            let Some(now) = resolve_path(item, &risk.source)
-                .as_ref()
-                .and_then(scalar_hash)
-            else {
+            let Some(now) = item.get(&risk.key_attribute).and_then(scalar_hash) else {
                 continue;
             };
-            match risk.seen_values.get(original) {
-                Some((previous_entity, previous_now)) => {
-                    if *previous_entity != plan.entity && *previous_now != now {
-                        risk.diverged.insert(*previous_entity);
-                        risk.diverged.insert(plan.entity);
-                    }
-                }
-                None => {
-                    if risk.seen_values.len() >= MAX_TRACKED_KEYS {
-                        risk.capped = true;
-                        continue;
-                    }
-                    risk.seen_values.insert(*original, (plan.entity, now));
+
+            if !risk.seen_keys.contains_key(original) && risk.seen_keys.len() >= MAX_TRACKED_KEYS {
+                risk.capped = true;
+                continue;
+            }
+            let outcomes = risk.seen_keys.entry(*original).or_default();
+
+            // Every distinct outcome is kept, not just the first, or whether
+            // a break is noticed would depend on the order the export happens
+            // to be in.
+            let mut diverged_with: Vec<usize> = outcomes
+                .iter()
+                .filter(|(entity, result)| *entity != plan.entity && *result != now)
+                .map(|(entity, _)| *entity)
+                .collect();
+            if !outcomes.contains(&(plan.entity, now)) {
+                outcomes.push((plan.entity, now));
+            }
+            if !diverged_with.is_empty() {
+                diverged_with.push(plan.entity);
+                for entity in diverged_with {
+                    risk.diverged.insert(entity);
                 }
             }
         }
@@ -692,12 +720,16 @@ impl KeyDeriver {
             .map(|risk| {
                 let mut seen: Vec<usize> = risk.diverged.iter().copied().collect();
                 seen.sort();
+
                 format!(
-                    "{} anonymised a shared value of '{}' differently, so their keys no longer \
-                     agree and they will not join. Add '{}' to [consistency] fields",
+                    "{} took the same original {} to different values, so their keys no longer \
+                     agree and they will not join. Template '{}' reads {}: add {} to \
+                     [consistency] fields",
                     entity_list(&self.entities, &seen),
-                    risk.source_name,
-                    risk.source_name
+                    risk.key_attribute,
+                    risk.template,
+                    quoted_list(&risk.consistency_roots),
+                    quoted_list(&risk.consistency_roots)
                 )
             })
             .collect()
@@ -752,21 +784,14 @@ impl KeyDeriver {
     }
 }
 
-/// A document path written back out, for a message.
-fn path_display(path: &[PathElement]) -> String {
-    let mut out = String::new();
-    for element in path {
-        match element {
-            PathElement::Attribute(name) => {
-                if !out.is_empty() {
-                    out.push('.');
-                }
-                out.push_str(name);
-            }
-            PathElement::Index(i) => out.push_str(&format!("[{i}]")),
-        }
+/// `'a'`, or `'a' and 'b'`, for a message.
+fn quoted_list(names: &[String]) -> String {
+    let quoted: Vec<String> = names.iter().map(|n| format!("'{n}'")).collect();
+    match quoted.split_last() {
+        Some((last, [])) => last.clone(),
+        Some((last, rest)) => format!("{} and {last}", rest.join(", ")),
+        None => String::new(),
     }
-    out
 }
 
 /// Hash a scalar attribute value, or `None` for anything a key cannot hold.
@@ -1608,8 +1633,12 @@ mod tests {
         let (mut d, warnings) =
             KeyDeriver::new(&model, &request(), &rules, &no_consistency()).unwrap();
         assert!(
-            warnings.iter().any(|w| w.contains("'contact.email'")),
-            "the nested path should be named: {warnings:?}"
+            warnings.iter().any(|w| w.contains("${contact.email}")),
+            "the template should be shown: {warnings:?}"
+        );
+        assert!(
+            warnings.iter().any(|w| w.contains("reads 'contact'")),
+            "the root is what [consistency] honours: {warnings:?}"
         );
 
         let contact = |email: &str| {
@@ -1630,7 +1659,10 @@ mod tests {
 
         let breaks = d.join_breaks();
         assert_eq!(breaks.len(), 1, "{breaks:?}");
-        assert!(breaks[0].contains("'contact.email'"), "{breaks:?}");
+        assert!(
+            breaks[0].contains("add 'contact' to [consistency] fields"),
+            "must name the root, which is what the consistency map keys on: {breaks:?}"
+        );
     }
 
     #[test]
@@ -1708,7 +1740,72 @@ mod tests {
         let breaks = d.join_breaks();
         assert_eq!(breaks.len(), 1, "{breaks:?}");
         assert!(breaks[0].contains("entity 'Customer' and entity 'Order'"));
-        assert!(breaks[0].contains("Add 'email' to [consistency] fields"));
+        assert!(breaks[0].contains("add 'email' to [consistency] fields"));
+    }
+
+    #[test]
+    fn a_break_is_found_whatever_order_the_export_is_in() {
+        // Two Orders share a customer. Only the second is rewritten, and the
+        // Customer arrives last. Keeping just the first outcome per original
+        // would let the Customer match the untouched one and pass.
+        let mut d = shared_key_deriver();
+
+        run_item(&mut d, order_item("a@x.co"), "a@x.co"); // unchanged
+        run_item(&mut d, order_item("a@x.co"), "fake@example.org"); // rewritten
+        run_item(&mut d, customer_item("a@x.co"), "a@x.co"); // unchanged
+
+        let breaks = d.join_breaks();
+        assert_eq!(
+            breaks.len(),
+            1,
+            "the rewritten order lost its customer: {breaks:?}"
+        );
+    }
+
+    #[test]
+    fn two_composite_keys_sharing_only_a_component_never_joined() {
+        // Both entities build pk from TENANT#${tenantId}#${email}. A customer
+        // in one tenant and an order in another share an address but never
+        // shared a partition, so different fakes cost them nothing.
+        let model = model_with(vec![
+            entity(
+                "Customer",
+                "TENANT#${tenantId}#${email}",
+                Some("PROFILE"),
+                None,
+            ),
+            entity(
+                "Order",
+                "TENANT#${tenantId}#${email}",
+                Some("ORDER#${id}"),
+                None,
+            ),
+        ]);
+        let (mut d, _) =
+            KeyDeriver::new(&model, &request(), &email_rule(), &no_consistency()).unwrap();
+
+        let mut run = |name: &str, tenant: &str, sk: &str, becomes: &str| {
+            let mut it = item(&[
+                ("_type", name),
+                ("pk", &format!("TENANT#{tenant}#a@x.co")),
+                ("sk", sk),
+                ("tenantId", tenant),
+                ("email", "a@x.co"),
+                ("id", "1"),
+            ]);
+            let mut w = Vec::new();
+            let plan = d.plan(&it, &mut w).unwrap();
+            it.insert("email".to_string(), AttributeValue::S(becomes.to_string()));
+            d.apply(&plan, &no_rewrites(), &mut it, &mut w);
+        };
+        run("Customer", "a", "PROFILE", "fake1@example.com");
+        run("Order", "b", "ORDER#1", "fake2@example.org");
+
+        assert!(
+            d.join_breaks().is_empty(),
+            "different tenants never shared a key: {:?}",
+            d.join_breaks()
+        );
     }
 
     #[test]

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -312,7 +312,7 @@ pub fn run_into(db: &Database, cmd: ImportCommand) -> Result<ImportSummary, Impo
                     let mut warnings = Vec::new();
                     let plan = key_deriver
                         .as_mut()
-                        .and_then(|d| d.plan(&item, &mut warnings));
+                        .and_then(|d| d.plan(&item, &rules, &mut warnings));
                     warnings.extend(anonymise::apply_rules(
                         &mut item,
                         &rules,

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -6,15 +6,18 @@
 //! ## Pipeline
 //!
 //! 1. Parse TOML config (validate all rules upfront)
-//! 2. Source table schemas from `--schema <file>`
+//! 2. Source table schemas from `--schema <file>`, and the data model from
+//!    `--data-model <file>` when keys are built from attributes
 //! 3. Create tables in output SQLite database
-//! 4. For each table: read JSON Lines → parse → anonymise → batch insert
+//! 4. For each table: read JSON Lines → parse → anonymise → rebuild templated
+//!    keys → batch insert
 //! 5. VACUUM (compact the SQLite file)
 //! 6. Optionally compress with zstd
 
 pub(crate) mod anonymise;
 pub(crate) mod config;
 pub(crate) mod consistency;
+pub(crate) mod keys;
 pub(crate) mod parser;
 pub(crate) mod schema;
 
@@ -63,6 +66,10 @@ pub struct ImportCommand {
     pub schema: std::path::PathBuf,
     /// Optional anonymisation rules TOML file.
     pub rules: Option<std::path::PathBuf>,
+    /// Optional OneTable schema. With it, keys built from attributes
+    /// (`user#${email}`) are rebuilt from the anonymised attributes after the
+    /// rules run, so the entity prefix survives and key and attribute agree.
+    pub data_model: Option<std::path::PathBuf>,
     /// Optional table name filter (comma-separated).
     pub tables: Option<Vec<String>>,
     /// Optional zstd compression of output (only valid with file output).
@@ -168,6 +175,21 @@ pub fn run_into(db: &Database, cmd: ImportCommand) -> Result<ImportSummary, Impo
         .unwrap_or_default();
     let mut consistency_map = ConsistencyMap::new();
 
+    let data_model = match cmd.data_model {
+        Some(ref path) => {
+            let model =
+                crate::schema::onetable::parse_onetable_file(path).map_err(ImportError::Config)?;
+            eprintln!(
+                "Loaded data model: {} ({} entities) from {}",
+                model.schema_format,
+                model.entities.len(),
+                path.display()
+            );
+            Some(model)
+        }
+        None => None,
+    };
+
     // 2. Load table schemas (returns both parsed schemas and raw JSON)
     let (schemas, schema_json) = schema::load_schemas(&cmd.schema)?;
     eprintln!(
@@ -228,9 +250,30 @@ pub fn run_into(db: &Database, cmd: ImportCommand) -> Result<ImportSummary, Impo
 
     let mut seen_warnings: HashSet<String> = HashSet::new();
 
+    if !rules.is_empty() && data_model.is_none() {
+        summary.warnings.push(
+            "rules rewrite attributes only: a key built from an attribute (CUSTOMER#${email}) \
+             keeps its original value. Pass --data-model <onetable.json> to rebuild keys \
+             from entity templates after anonymisation"
+                .to_string(),
+        );
+    }
+
     for (table_name, files) in &export_files {
         let table_schema = schema_map.get(table_name.as_str()).unwrap();
         let key_attrs = extract_key_attrs(&table_schema.create_request);
+        let mut key_deriver = match data_model.as_ref() {
+            Some(model) => {
+                let (deriver, warnings) =
+                    keys::KeyDeriver::new(model, &table_schema.create_request, &rules)
+                        .map_err(|e| ImportError::Config(format!("data model: {e}")))?;
+                for w in warnings {
+                    summary.warnings.push(format!("table '{table_name}': {w}"));
+                }
+                Some(deriver)
+            }
+            None => None,
+        };
 
         let file_count = files.len();
         eprintln!("Importing table '{}' ({} files)...", table_name, file_count);
@@ -259,15 +302,23 @@ pub fn run_into(db: &Database, cmd: ImportCommand) -> Result<ImportSummary, Impo
                     return;
                 }
 
-                // Apply anonymisation rules
+                // Apply anonymisation rules, then rebuild any key the data
+                // model says is built from the attributes just rewritten
                 if !rules.is_empty() {
-                    let warnings = anonymise::apply_rules(
+                    let mut warnings = Vec::new();
+                    let plan = key_deriver
+                        .as_mut()
+                        .and_then(|d| d.plan(&item, &mut warnings));
+                    warnings.extend(anonymise::apply_rules(
                         &mut item,
                         &rules,
                         &mut consistency_map,
                         &consistency_fields,
                         &key_attrs,
-                    );
+                    ));
+                    if let (Some(deriver), Some(plan)) = (key_deriver.as_mut(), plan) {
+                        deriver.apply(&plan, &mut item, &mut warnings);
+                    }
                     for w in warnings {
                         if !seen_warnings.contains(&w) {
                             seen_warnings.insert(w.clone());
@@ -320,6 +371,36 @@ pub fn run_into(db: &Database, cmd: ImportCommand) -> Result<ImportSummary, Impo
                 table_bytes += import_result.bytes_imported;
                 pb.set_message(format!("{}: {} items", table_name, table_items));
                 pb.tick();
+            }
+        }
+
+        if let Some(deriver) = key_deriver.as_mut() {
+            let unmatched = deriver.take_unmatched();
+            if unmatched > 0 {
+                summary.warnings.push(format!(
+                    "table '{}': {} items matched no entity in the data model \
+                     (no type attribute, and no entity's key templates reproduce their keys); \
+                     their keys were not rebuilt",
+                    table_name, unmatched
+                ));
+            }
+            let (collisions, capped) = deriver.take_collisions();
+            if collisions > 0 {
+                summary.warnings.push(format!(
+                    "table '{}': {} items rendered the same primary key as an earlier item \
+                     after their keys were rebuilt, and overwrote it; the output holds fewer \
+                     rows than the export. A rule is replacing an attribute a key is built \
+                     from with a constant",
+                    table_name, collisions
+                ));
+            }
+            if capped {
+                summary.warnings.push(format!(
+                    "table '{}': the rebuilt-key collision check stopped after {} keys; \
+                     later collisions in this table were not counted",
+                    table_name,
+                    keys::MAX_TRACKED_KEYS
+                ));
             }
         }
 

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -248,6 +248,33 @@ pub fn run_into(db: &Database, cmd: ImportCommand) -> Result<ImportSummary, Impo
         output_path: cmd.output.clone(),
     };
 
+    // Rebuilding keys can land two source items on one primary key, which is
+    // exactly the assumption `import_items_fresh` trades away: it skips the
+    // GSI delete-before-insert, so an overwritten base row would leave its
+    // old index entry behind and index queries would answer from a row that
+    // no longer exists. Without a data model the keys come straight from the
+    // export and are unique by construction, so the fast path stays.
+    // Keys can move two ways: rebuilt from a template, or rewritten by a rule
+    // that names a key attribute. Either can land two items on one primary
+    // key. Neither happens without rules, so a plain import keeps the fast
+    // path that assumes every key is unique.
+    let key_attr_names: HashSet<String> = schemas
+        .iter()
+        .flat_map(|s| extract_key_attrs(&s.create_request))
+        .collect();
+    let rules_touch_a_key = rules.iter().any(|rule| match rule.path.first() {
+        Some(crate::expressions::PathElement::Attribute(name)) => key_attr_names.contains(name),
+        _ => false,
+    });
+    let rebuilds_keys = !rules.is_empty() && (data_model.is_some() || rules_touch_a_key);
+    let insert_items = |table: &str, batch: Vec<crate::types::Item>| {
+        if rebuilds_keys {
+            db.import_items(table, batch, ImportOptions::default())
+        } else {
+            db.import_items_fresh(table, batch, ImportOptions::default())
+        }
+    };
+
     let mut seen_warnings: HashSet<String> = HashSet::new();
 
     if !rules.is_empty() && data_model.is_none() {
@@ -325,8 +352,12 @@ pub fn run_into(db: &Database, cmd: ImportCommand) -> Result<ImportSummary, Impo
                         deriver.apply(&plan, &rewritten, &mut item, &mut warnings);
                     }
                     for w in warnings {
-                        if !seen_warnings.contains(&w) {
-                            seen_warnings.insert(w.clone());
+                        // Prefixed with the table, both so the reader knows
+                        // where it came from and so the cross-table dedupe
+                        // below cannot swallow table B's copy of a warning
+                        // table A already raised.
+                        let w = format!("table '{table_name}': {w}");
+                        if seen_warnings.insert(w.clone()) {
                             summary.warnings.push(w);
                         }
                     }
@@ -336,7 +367,7 @@ pub fn run_into(db: &Database, cmd: ImportCommand) -> Result<ImportSummary, Impo
                 // Flush batch when full
                 if batch.len() >= BATCH_SIZE {
                     let chunk = std::mem::replace(&mut batch, Vec::with_capacity(BATCH_SIZE));
-                    match db.import_items_fresh(table_name, chunk, ImportOptions::default()) {
+                    match insert_items(table_name, chunk) {
                         Ok(result) => {
                             table_items += result.items_imported;
                             table_bytes += result.bytes_imported;
@@ -369,8 +400,7 @@ pub fn run_into(db: &Database, cmd: ImportCommand) -> Result<ImportSummary, Impo
 
             // Flush remaining items
             if !batch.is_empty() {
-                let import_result = db
-                    .import_items_fresh(table_name, batch, ImportOptions::default())
+                let import_result = insert_items(table_name, batch)
                     .map_err(|e| format!("Failed to import items into '{}': {e}", table_name))?;
                 table_items += import_result.items_imported;
                 table_bytes += import_result.bytes_imported;
@@ -395,6 +425,12 @@ pub fn run_into(db: &Database, cmd: ImportCommand) -> Result<ImportSummary, Impo
             // the run's time, not a half-anonymised database.
             let join_breaks = deriver.join_breaks();
             if let Some(first) = join_breaks.first() {
+                // The warnings collected so far are what explain the failure;
+                // returning without them leaves the operator with a verdict
+                // and no evidence.
+                for w in &summary.warnings {
+                    eprintln!("  - {w}");
+                }
                 return Err(ImportError::Config(format!(
                     "table '{}': {}{}",
                     table_name,
@@ -407,13 +443,27 @@ pub fn run_into(db: &Database, cmd: ImportCommand) -> Result<ImportSummary, Impo
                 )));
             }
 
+            let unchecked = deriver.unchecked_join_keys();
+            if unchecked > 0 {
+                summary.warnings.push(format!(
+                    "table '{}': the join check stopped taking on new keys after {}, so {} \
+                     were never checked; a broken join among those would not have been \
+                     caught. Keys seen before the cap were still checked",
+                    table_name,
+                    keys::MAX_TRACKED_KEYS,
+                    unchecked
+                ));
+            }
+
             let (collisions, capped) = deriver.take_collisions();
             if collisions > 0 {
                 summary.warnings.push(format!(
-                    "table '{}': {} items rendered the same primary key as an earlier item \
-                     after their keys were rebuilt, and overwrote it; the output holds fewer \
-                     rows than the export. A rule is replacing an attribute a key is built \
-                     from with a constant",
+                    "table '{}': {} items rendered the same primary key as an earlier item and \
+                     overwrote it, so the output holds fewer rows than the export. Either a \
+                     rule is replacing an attribute a key is built from with a constant, or a \
+                     fake generator is drawing the same value twice: its output space is small \
+                     enough that repeats are ordinary at a few hundred items, so prefer hash \
+                     for an attribute a key is built from",
                     table_name, collisions
                 ));
             }

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -264,9 +264,13 @@ pub fn run_into(db: &Database, cmd: ImportCommand) -> Result<ImportSummary, Impo
         let key_attrs = extract_key_attrs(&table_schema.create_request);
         let mut key_deriver = match data_model.as_ref() {
             Some(model) => {
-                let (deriver, warnings) =
-                    keys::KeyDeriver::new(model, &table_schema.create_request, &rules)
-                        .map_err(|e| ImportError::Config(format!("data model: {e}")))?;
+                let (deriver, warnings) = keys::KeyDeriver::new(
+                    model,
+                    &table_schema.create_request,
+                    &rules,
+                    &consistency_fields,
+                )
+                .map_err(|e| ImportError::Config(format!("data model: {e}")))?;
                 for w in warnings {
                     summary.warnings.push(format!("table '{table_name}': {w}"));
                 }
@@ -384,6 +388,24 @@ pub fn run_into(db: &Database, cmd: ImportCommand) -> Result<ImportSummary, Impo
                     table_name, unmatched
                 ));
             }
+            // Both entities of a shared key attribute turned up, so the join
+            // between them is broken in the output rather than merely at risk.
+            // Nothing is persisted on the error path, so failing here costs
+            // the run's time, not a half-anonymised database.
+            let join_breaks = deriver.join_breaks();
+            if let Some(first) = join_breaks.first() {
+                return Err(ImportError::Config(format!(
+                    "table '{}': {}{}",
+                    table_name,
+                    first,
+                    if join_breaks.len() > 1 {
+                        format!(" (and {} more)", join_breaks.len() - 1)
+                    } else {
+                        String::new()
+                    }
+                )));
+            }
+
             let (collisions, capped) = deriver.take_collisions();
             if collisions > 0 {
                 summary.warnings.push(format!(

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -312,16 +312,17 @@ pub fn run_into(db: &Database, cmd: ImportCommand) -> Result<ImportSummary, Impo
                     let mut warnings = Vec::new();
                     let plan = key_deriver
                         .as_mut()
-                        .and_then(|d| d.plan(&item, &rules, &mut warnings));
-                    warnings.extend(anonymise::apply_rules(
+                        .and_then(|d| d.plan(&item, &mut warnings));
+                    let (rule_warnings, rewritten) = anonymise::apply_rules(
                         &mut item,
                         &rules,
                         &mut consistency_map,
                         &consistency_fields,
                         &key_attrs,
-                    ));
+                    );
+                    warnings.extend(rule_warnings);
                     if let (Some(deriver), Some(plan)) = (key_deriver.as_mut(), plan) {
-                        deriver.apply(&plan, &mut item, &mut warnings);
+                        deriver.apply(&plan, &rewritten, &mut item, &mut warnings);
                     }
                     for w in warnings {
                         if !seen_warnings.contains(&w) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -248,6 +248,12 @@ struct ImportArgs {
     #[arg(long)]
     rules: Option<std::path::PathBuf>,
 
+    /// OneTable schema whose entity key templates rebuild pk, sk and GSI keys after anonymisation
+    ///
+    /// Also serves as the MCP data model when --mcp is set without --mcp-data-model.
+    #[arg(long, value_name = "PATH")]
+    data_model: Option<std::path::PathBuf>,
+
     /// Comma-separated list of table names to import (default: all)
     #[arg(long, value_delimiter = ',')]
     tables: Option<Vec<String>>,
@@ -914,6 +920,7 @@ fn build_import_command(args: &ImportArgs) -> dynoxide::import::ImportCommand {
         output: args.output.clone(),
         schema: args.schema.clone(),
         rules: args.rules.clone(),
+        data_model: args.data_model.clone(),
         tables: args.tables.clone(),
         compress: args.compress,
         force: args.force,
@@ -951,7 +958,8 @@ async fn run_import(args: ImportArgs) -> Result<(), Box<dyn std::error::Error>> 
         if wants_serve && wants_mcp {
             use tokio_util::sync::CancellationToken;
 
-            let mcp_data_model = load_data_model(args.mcp_data_model.as_ref())?;
+            let mcp_data_model =
+                load_data_model(args.mcp_data_model.as_ref().or(args.data_model.as_ref()))?;
             let mcp_config = dynoxide::mcp::McpConfig {
                 read_only: args.mcp_read_only,
                 data_model: mcp_data_model,
@@ -999,7 +1007,8 @@ async fn run_import(args: ImportArgs) -> Result<(), Box<dyn std::error::Error>> 
 
         #[cfg(feature = "mcp-server")]
         if wants_mcp {
-            let mcp_data_model = load_data_model(args.mcp_data_model.as_ref())?;
+            let mcp_data_model =
+                load_data_model(args.mcp_data_model.as_ref().or(args.data_model.as_ref()))?;
             let mcp_config = dynoxide::mcp::McpConfig {
                 data_model: mcp_data_model,
                 ..Default::default()

--- a/src/schema/onetable.rs
+++ b/src/schema/onetable.rs
@@ -57,15 +57,35 @@ pub fn parse_onetable(json: &str) -> Result<DataModel, String> {
 
     // Parse index definitions (skip "primary")
     let indexes = parse_indexes(&doc);
+    let primary = primary_key_attrs(&doc);
 
     // Parse models into entity definitions
-    let entities = parse_models(&doc, &type_attribute, &indexes);
+    let entities = parse_models(&doc, &type_attribute, &primary, &indexes);
 
     Ok(DataModel {
         schema_format: format.to_string(),
         type_attribute,
         entities,
     })
+}
+
+/// The model attributes that hold the primary key templates, from
+/// `indexes.primary` (`hash` and `sort`). OneTable defaults them to `pk`
+/// and `sk`, and so does this.
+fn primary_key_attrs(doc: &serde_json::Value) -> (String, Option<String>) {
+    let hash = doc
+        .pointer("/indexes/primary/hash")
+        .and_then(|v| v.as_str())
+        .unwrap_or("pk")
+        .to_string();
+    let sort = match doc.pointer("/indexes/primary") {
+        Some(primary) => primary
+            .get("sort")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        None => Some("sk".to_string()),
+    };
+    (hash, sort)
 }
 
 /// Parse the `indexes` section into a map of OneTable key -> IndexDef.
@@ -112,6 +132,7 @@ fn parse_indexes(doc: &serde_json::Value) -> HashMap<String, IndexDef> {
 fn parse_models(
     doc: &serde_json::Value,
     type_attribute: &str,
+    primary: &(String, Option<String>),
     indexes: &HashMap<String, IndexDef>,
 ) -> Vec<EntityDefinition> {
     let Some(models_obj) = doc.get("models").and_then(|v| v.as_object()) else {
@@ -120,7 +141,7 @@ fn parse_models(
 
     let mut entities: Vec<EntityDefinition> = models_obj
         .iter()
-        .map(|(name, model)| parse_single_model(name, model, type_attribute, indexes))
+        .map(|(name, model)| parse_single_model(name, model, type_attribute, primary, indexes))
         .collect();
 
     // Sort alphabetically for deterministic output
@@ -133,23 +154,26 @@ fn parse_single_model(
     name: &str,
     model: &serde_json::Value,
     type_attribute: &str,
+    (hash_attr, sort_attr): &(String, Option<String>),
     indexes: &HashMap<String, IndexDef>,
 ) -> EntityDefinition {
     let attrs = model.as_object();
 
-    // Extract primary key templates from "pk" and "sk" attributes
+    // Extract primary key templates from the attributes indexes.primary names
     let pk_template = attrs
-        .and_then(|m| m.get("pk"))
+        .and_then(|m| m.get(hash_attr))
         .and_then(|v| v.get("value"))
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string();
 
-    let sk_template = attrs
-        .and_then(|m| m.get("sk"))
-        .and_then(|v| v.get("value"))
-        .and_then(|v| v.as_str())
-        .map(String::from);
+    let sk_template = sort_attr.as_ref().and_then(|sort_attr| {
+        attrs
+            .and_then(|m| m.get(sort_attr))
+            .and_then(|v| v.get("value"))
+            .and_then(|v| v.as_str())
+            .map(String::from)
+    });
 
     // Resolve GSI participation by checking if this model defines attributes
     // matching any index's hash key attribute name
@@ -218,6 +242,45 @@ fn resolve_gsi_mappings(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn primary_key_templates_follow_indexes_primary() {
+        let model = parse_onetable(
+            r#"{
+                "format": "onetable:1.1.0",
+                "indexes": { "primary": { "hash": "PK", "sort": "SK" } },
+                "models": {
+                    "Account": {
+                        "PK": { "type": "string", "value": "account#${id}" },
+                        "SK": { "type": "string", "value": "account#" },
+                        "pk": { "type": "string", "value": "not-the-key" }
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(model.entities[0].pk_template, "account#${id}");
+        assert_eq!(model.entities[0].sk_template.as_deref(), Some("account#"));
+    }
+
+    #[test]
+    fn primary_key_without_a_sort_key_has_no_sk_template() {
+        let model = parse_onetable(
+            r#"{
+                "format": "onetable:1.1.0",
+                "indexes": { "primary": { "hash": "id" } },
+                "models": {
+                    "Thing": {
+                        "id": { "type": "string", "value": "thing#${name}" },
+                        "sk": { "type": "string", "value": "stray" }
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(model.entities[0].pk_template, "thing#${name}");
+        assert_eq!(model.entities[0].sk_template, None);
+    }
 
     const VALID_SCHEMA: &str = r#"{
         "version": "0.1.0",

--- a/src/schema/onetable.rs
+++ b/src/schema/onetable.rs
@@ -211,11 +211,16 @@ fn resolve_gsi_mappings(
     let mut mappings: Vec<GsiMapping> = indexes
         .values()
         .filter_map(|idx_def| {
-            // Check if this model has the hash key attribute with a value template
+            // A model participates in an index when it templates either key.
+            // A hash key that is a plain attribute (a tenant id, say) with a
+            // templated sort key is an ordinary shape, and dropping the whole
+            // index for it would hide the sort key from anything that reads
+            // the model, import included. Its pk_template is then empty.
             let pk_template = attrs
                 .get(&idx_def.hash_attr)
                 .and_then(|v| v.get("value"))
-                .and_then(|v| v.as_str())?;
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
 
             // Check for sort key template (optional)
             let sk_template = idx_def.sort_attr.as_ref().and_then(|sort_attr| {
@@ -225,6 +230,10 @@ fn resolve_gsi_mappings(
                     .and_then(|v| v.as_str())
                     .map(String::from)
             });
+
+            if pk_template.is_empty() && sk_template.is_none() {
+                return None;
+            }
 
             Some(GsiMapping {
                 index_name: idx_def.dynamo_name.clone(),
@@ -242,6 +251,56 @@ fn resolve_gsi_mappings(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn an_index_with_a_plain_hash_key_keeps_its_sort_template() {
+        let model = parse_onetable(
+            r#"{
+                "format": "onetable:1.1.0",
+                "indexes": {
+                    "primary": { "hash": "pk", "sort": "sk" },
+                    "gs1": { "hash": "tenantId", "sort": "gs1sk", "name": "GSI1" }
+                },
+                "models": {
+                    "User": {
+                        "pk": { "type": "string", "value": "user#${id}" },
+                        "sk": { "type": "string", "value": "user#" },
+                        "tenantId": { "type": "string" },
+                        "gs1sk": { "type": "string", "value": "user#${email}" },
+                        "id": { "type": "string" },
+                        "email": { "type": "string" }
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+        let gsi = &model.entities[0].gsi_mappings[0];
+        assert_eq!(gsi.index_name, "GSI1");
+        assert_eq!(gsi.pk_template, "", "the hash key is a plain attribute");
+        assert_eq!(gsi.sk_template.as_deref(), Some("user#${email}"));
+    }
+
+    #[test]
+    fn an_index_the_model_does_not_template_at_all_is_skipped() {
+        let model = parse_onetable(
+            r#"{
+                "format": "onetable:1.1.0",
+                "indexes": {
+                    "primary": { "hash": "pk", "sort": "sk" },
+                    "gs1": { "hash": "gs1pk", "sort": "gs1sk", "name": "GSI1" }
+                },
+                "models": {
+                    "User": {
+                        "pk": { "type": "string", "value": "user#${id}" },
+                        "sk": { "type": "string", "value": "user#" },
+                        "id": { "type": "string" }
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+        assert!(model.entities[0].gsi_mappings.is_empty());
+    }
 
     #[test]
     fn primary_key_templates_follow_indexes_primary() {

--- a/tests/import.rs
+++ b/tests/import.rs
@@ -1651,4 +1651,71 @@ action = { type = "fake", generator = "safe_email" }
             summary.warnings
         );
     }
+
+    #[test]
+    fn test_an_item_without_a_type_attribute_resolves_to_its_own_entity() {
+        // Customer and Order share a partition template and differ only by a
+        // constant sk. With no discriminator, resolving the Order as a
+        // Customer would leave its sort key holding the original value.
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("export");
+        let output = tmp.path().join("output.db");
+        let schema_file = tmp.path().join("schema.json");
+        let rules_file = tmp.path().join("rules.toml");
+        let model_file = tmp.path().join("model.json");
+
+        setup_export_dir(
+            &source,
+            "App",
+            &[
+                r#"{"Item": {"pk": {"S": "CUSTOMER#a@real.co.uk"}, "sk": {"S": "PROFILE"}, "email": {"S": "a@real.co.uk"}}}"#,
+                r#"{"Item": {"pk": {"S": "CUSTOMER#a@real.co.uk"}, "sk": {"S": "ORDER#ref-a@real.co.uk"}, "email": {"S": "a@real.co.uk"}, "orderId": {"S": "ref-a@real.co.uk"}}}"#,
+            ],
+        );
+        create_schema_file(&schema_file, &[simple_table_schema("App")]);
+        shared_key_model(&model_file);
+        std::fs::write(
+            &rules_file,
+            r#"
+[[rules]]
+match = "attribute_exists(email)"
+path = "email"
+action = { type = "fake", generator = "safe_email" }
+
+[[rules]]
+match = "attribute_exists(orderId)"
+path = "orderId"
+action = { type = "fake", generator = "word" }
+
+[consistency]
+fields = ["email"]
+"#,
+        )
+        .unwrap();
+
+        import::run(ImportCommand {
+            source,
+            output: Some(output.clone()),
+            schema: schema_file,
+            rules: Some(rules_file),
+            tables: None,
+            compress: false,
+            force: false,
+            continue_on_error: false,
+            data_model: Some(model_file),
+        })
+        .unwrap();
+
+        let db = dynoxide::Database::new(output.to_str().unwrap()).unwrap();
+        for item in scan_all(&db, "App") {
+            for value in item.values() {
+                if let dynoxide::AttributeValue::S(s) = value {
+                    assert!(
+                        !s.contains("a@real.co.uk"),
+                        "the original address survived in {s}"
+                    );
+                }
+            }
+        }
+    }
 }

--- a/tests/import.rs
+++ b/tests/import.rs
@@ -1436,4 +1436,125 @@ action = { type = "redact" }
         let user = &scan_all(&db, "App")[0];
         assert_eq!(string_attr(user, "sk"), "[REDACTED]");
     }
+
+    /// A OneTable model where Customer and Order both key on `email`, which
+    /// is what a single-table design does to keep them in one partition.
+    fn shared_key_model(path: &std::path::Path) {
+        std::fs::write(
+            path,
+            r#"{
+                "format": "onetable:1.1.0",
+                "indexes": { "primary": { "hash": "pk", "sort": "sk" } },
+                "params": { "typeField": "_type" },
+                "models": {
+                    "Customer": {
+                        "pk": { "type": "string", "value": "CUSTOMER#${email}" },
+                        "sk": { "type": "string", "value": "PROFILE" },
+                        "email": { "type": "string" }
+                    },
+                    "Order": {
+                        "pk": { "type": "string", "value": "CUSTOMER#${email}" },
+                        "sk": { "type": "string", "value": "ORDER#${orderId}" },
+                        "email": { "type": "string" },
+                        "orderId": { "type": "string" }
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+    }
+
+    const CUSTOMER_ITEM: &str = r#"{"Item": {"_type": {"S": "Customer"}, "pk": {"S": "CUSTOMER#a@x.co"}, "sk": {"S": "PROFILE"}, "email": {"S": "a@x.co"}}}"#;
+    const ORDER_ITEM: &str = r#"{"Item": {"_type": {"S": "Order"}, "pk": {"S": "CUSTOMER#a@x.co"}, "sk": {"S": "ORDER#1"}, "email": {"S": "a@x.co"}, "orderId": {"S": "1"}}}"#;
+
+    const FAKE_EMAIL_RULE: &str = r#"
+[[rules]]
+match = "attribute_exists(email)"
+path = "email"
+action = { type = "fake", generator = "safe_email" }
+"#;
+
+    fn shared_key_import(
+        tmp: &std::path::Path,
+        items: &[&str],
+        rules_toml: &str,
+    ) -> Result<import::ImportSummary, import::ImportError> {
+        let source = tmp.join("export");
+        let schema_file = tmp.join("schema.json");
+        let rules_file = tmp.join("rules.toml");
+        let model_file = tmp.join("model.json");
+
+        setup_export_dir(&source, "App", items);
+        create_schema_file(&schema_file, &[simple_table_schema("App")]);
+        std::fs::write(&rules_file, rules_toml).unwrap();
+        shared_key_model(&model_file);
+
+        import::run(ImportCommand {
+            source,
+            output: Some(tmp.join("output.db")),
+            schema: schema_file,
+            rules: Some(rules_file),
+            tables: None,
+            compress: false,
+            force: false,
+            continue_on_error: false,
+            data_model: Some(model_file),
+        })
+    }
+
+    #[test]
+    fn test_shared_key_attribute_without_consistency_fails_once_both_entities_appear() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = shared_key_import(tmp.path(), &[CUSTOMER_ITEM, ORDER_ITEM], FAKE_EMAIL_RULE)
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("entity 'Customer' and entity 'Order'"),
+            "{msg}"
+        );
+        assert!(msg.contains("Add 'email' to [consistency] fields"), "{msg}");
+
+        // Nothing is persisted on the error path.
+        assert!(
+            !tmp.path().join("output.db").exists(),
+            "a failed import must not leave a half-anonymised database"
+        );
+    }
+
+    #[test]
+    fn test_one_entity_alone_imports_without_a_consistency_block() {
+        let tmp = tempfile::tempdir().unwrap();
+        let summary = shared_key_import(tmp.path(), &[CUSTOMER_ITEM], FAKE_EMAIL_RULE)
+            .expect("a slice holding one entity has no join to lose");
+        assert_eq!(summary.total_items, 1);
+        assert!(
+            summary.warnings.iter().any(|w| w.contains("will not join")),
+            "the risk is still worth stating up front: {:?}",
+            summary.warnings
+        );
+    }
+
+    #[test]
+    fn test_listing_the_shared_attribute_in_consistency_imports_both_entities() {
+        let tmp = tempfile::tempdir().unwrap();
+        let rules = format!(
+            "{FAKE_EMAIL_RULE}\n[consistency]\nfields = [{}]\n",
+            "\"email\""
+        );
+        let summary = shared_key_import(tmp.path(), &[CUSTOMER_ITEM, ORDER_ITEM], &rules).unwrap();
+        assert_eq!(summary.total_items, 2);
+        assert!(
+            !summary.warnings.iter().any(|w| w.contains("will not join")),
+            "{:?}",
+            summary.warnings
+        );
+
+        // The order is still in its customer's partition.
+        let db = dynoxide::Database::new(tmp.path().join("output.db").to_str().unwrap()).unwrap();
+        let items = scan_all(&db, "App");
+        let pks: std::collections::HashSet<String> =
+            items.iter().map(|i| string_attr(i, "pk")).collect();
+        assert_eq!(pks.len(), 1, "customer and order should share a partition");
+        assert!(!pks.iter().next().unwrap().contains("a@x.co"));
+    }
 }

--- a/tests/import.rs
+++ b/tests/import.rs
@@ -1512,7 +1512,7 @@ action = { type = "fake", generator = "safe_email" }
             msg.contains("entity 'Customer' and entity 'Order'"),
             "{msg}"
         );
-        assert!(msg.contains("Add 'email' to [consistency] fields"), "{msg}");
+        assert!(msg.contains("add 'email' to [consistency] fields"), "{msg}");
 
         // Nothing is persisted on the error path.
         assert!(

--- a/tests/import.rs
+++ b/tests/import.rs
@@ -1557,4 +1557,98 @@ action = { type = "fake", generator = "safe_email" }
         assert_eq!(pks.len(), 1, "customer and order should share a partition");
         assert!(!pks.iter().next().unwrap().contains("a@x.co"));
     }
+
+    #[test]
+    fn test_a_key_rule_that_does_not_match_an_entity_does_not_block_its_rebuild() {
+        // The sk rule matches only Account items. A User's sk must still be
+        // rebuilt from its template, or the real address survives in the key
+        // while the attribute beside it is anonymised.
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("export");
+        let output = tmp.path().join("output.db");
+        let schema_file = tmp.path().join("schema.json");
+        let rules_file = tmp.path().join("rules.toml");
+
+        setup_export_dir(
+            &source,
+            "App",
+            &[
+                r#"{"Item": {"_type": {"S": "User"}, "pk": {"S": "account#acc1"}, "sk": {"S": "user#alice@real.co.uk"}, "accountId": {"S": "acc1"}, "email": {"S": "alice@real.co.uk"}}}"#,
+                r#"{"Item": {"_type": {"S": "Account"}, "pk": {"S": "account#acc1"}, "sk": {"S": "account#"}, "id": {"S": "acc1"}, "accountName": {"S": "Acme"}}}"#,
+            ],
+        );
+        create_schema_file(&schema_file, &[single_table_schema("App")]);
+        std::fs::write(
+            &rules_file,
+            r#"
+[[rules]]
+match = "attribute_exists(accountName)"
+path = "sk"
+action = { type = "redact" }
+
+[[rules]]
+match = "attribute_exists(email)"
+path = "email"
+action = { type = "fake", generator = "safe_email" }
+"#,
+        )
+        .unwrap();
+
+        import::run(ImportCommand {
+            source,
+            output: Some(output.clone()),
+            schema: schema_file,
+            rules: Some(rules_file),
+            tables: None,
+            compress: false,
+            force: false,
+            continue_on_error: false,
+            data_model: Some(onetable_fixture()),
+        })
+        .unwrap();
+
+        let db = dynoxide::Database::new(output.to_str().unwrap()).unwrap();
+        let items = scan_all(&db, "App");
+        let user = items
+            .iter()
+            .find(|i| string_attr(i, "_type") == "User")
+            .unwrap();
+
+        let email = string_attr(user, "email");
+        assert_ne!(email, "alice@real.co.uk");
+        assert_eq!(
+            string_attr(user, "sk"),
+            format!("user#{email}"),
+            "sk must be rebuilt: the sk rule never matched this item"
+        );
+
+        // Belt and braces: the real address is nowhere in the output.
+        for item in &items {
+            for value in item.values() {
+                if let dynoxide::AttributeValue::S(s) = value {
+                    assert!(!s.contains("alice@real.co.uk"), "leaked in {s}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_two_entities_with_no_shared_value_import_without_a_consistency_block() {
+        // Both entities present and keyed on the same template, but no
+        // address in common, so there was never a join to lose.
+        let tmp = tempfile::tempdir().unwrap();
+        let unrelated_order = r#"{"Item": {"_type": {"S": "Order"}, "pk": {"S": "CUSTOMER#b@y.co"}, "sk": {"S": "ORDER#1"}, "email": {"S": "b@y.co"}, "orderId": {"S": "1"}}}"#;
+        let summary = shared_key_import(
+            tmp.path(),
+            &[CUSTOMER_ITEM, unrelated_order],
+            FAKE_EMAIL_RULE,
+        )
+        .expect("no shared value means no broken join");
+        assert_eq!(summary.total_items, 2);
+        assert!(
+            summary.warnings.iter().any(|w| w.contains("will not join")),
+            "the risk is still worth stating up front: {:?}",
+            summary.warnings
+        );
+    }
 }

--- a/tests/import.rs
+++ b/tests/import.rs
@@ -86,6 +86,7 @@ mod tests {
             compress: false,
             force: false,
             continue_on_error: false,
+            data_model: None,
         })
         .unwrap();
 
@@ -142,6 +143,7 @@ mod tests {
             compress: false,
             force: false,
             continue_on_error: false,
+            data_model: None,
         })
         .unwrap();
 
@@ -182,6 +184,7 @@ mod tests {
             compress: false,
             force: false,
             continue_on_error: false,
+            data_model: None,
         })
         .unwrap();
 
@@ -234,6 +237,7 @@ action = { type = "redact" }
             compress: false,
             force: false,
             continue_on_error: false,
+            data_model: None,
         })
         .unwrap();
 
@@ -315,6 +319,7 @@ fields = ["email"]
             compress: false,
             force: false,
             continue_on_error: false,
+            data_model: None,
         })
         .unwrap();
 
@@ -379,6 +384,7 @@ fields = ["email"]
             compress: false,
             force: false,
             continue_on_error: false,
+            data_model: None,
         })
         .unwrap();
 
@@ -411,6 +417,7 @@ fields = ["email"]
             compress: true,
             force: false,
             continue_on_error: false,
+            data_model: None,
         })
         .unwrap();
 
@@ -449,6 +456,7 @@ fields = ["email"]
             compress: false,
             force: false,
             continue_on_error: false,
+            data_model: None,
         });
 
         assert!(result.is_err());
@@ -959,6 +967,7 @@ fields = ["email"]
                 output: None,
                 schema: schema_file,
                 rules: None,
+                data_model: None,
                 tables: None,
                 compress: false,
                 force: false,
@@ -985,5 +994,446 @@ fields = ["email"]
             })
             .unwrap();
         assert_eq!(scan.count, 2);
+    }
+
+    /// Single-table schema with a GSI1 on gs1pk/gs1sk, matching the OneTable
+    /// fixture in tests/fixtures/onetable-test-schema.json.
+    fn single_table_schema(table_name: &str) -> serde_json::Value {
+        serde_json::json!({
+            "Table": {
+                "TableName": table_name,
+                "KeySchema": [
+                    {"AttributeName": "pk", "KeyType": "HASH"},
+                    {"AttributeName": "sk", "KeyType": "RANGE"}
+                ],
+                "AttributeDefinitions": [
+                    {"AttributeName": "pk", "AttributeType": "S"},
+                    {"AttributeName": "sk", "AttributeType": "S"},
+                    {"AttributeName": "gs1pk", "AttributeType": "S"},
+                    {"AttributeName": "gs1sk", "AttributeType": "S"}
+                ],
+                "GlobalSecondaryIndexes": [
+                    {
+                        "IndexName": "GSI1",
+                        "KeySchema": [
+                            {"AttributeName": "gs1pk", "KeyType": "HASH"},
+                            {"AttributeName": "gs1sk", "KeyType": "RANGE"}
+                        ],
+                        "Projection": {"ProjectionType": "ALL"}
+                    }
+                ]
+            }
+        })
+    }
+
+    fn onetable_fixture() -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/onetable-test-schema.json")
+    }
+
+    fn scan_all(db: &dynoxide::Database, table: &str) -> Vec<dynoxide::Item> {
+        db.scan(dynoxide::actions::scan::ScanRequest {
+            table_name: table.to_string(),
+            ..Default::default()
+        })
+        .unwrap()
+        .items
+        .unwrap()
+    }
+
+    fn string_attr(item: &dynoxide::Item, name: &str) -> String {
+        match item.get(name) {
+            Some(dynoxide::AttributeValue::S(s)) => s.clone(),
+            other => panic!("{name} should be a string, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_rule_values_scope_a_match_by_key_prefix() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("export");
+        let output = tmp.path().join("output.db");
+        let schema_file = tmp.path().join("schema.json");
+        let rules_file = tmp.path().join("rules.toml");
+
+        setup_export_dir(
+            &source,
+            "App",
+            &[
+                r#"{"Item": {"pk": {"S": "CUSTOMER#1"}, "sk": {"S": "PROFILE"}, "notes": {"S": "customer notes"}}}"#,
+                r#"{"Item": {"pk": {"S": "ORDER#1"}, "sk": {"S": "PROFILE"}, "notes": {"S": "order notes"}}}"#,
+            ],
+        );
+        create_schema_file(&schema_file, &[simple_table_schema("App")]);
+
+        std::fs::write(
+            &rules_file,
+            r#"
+[[rules]]
+match = "begins_with(pk, :prefix)"
+values = { ":prefix" = "CUSTOMER#" }
+path = "notes"
+action = { type = "redact" }
+"#,
+        )
+        .unwrap();
+
+        let summary = import::run(ImportCommand {
+            source,
+            output: Some(output.clone()),
+            schema: schema_file,
+            rules: Some(rules_file),
+            tables: None,
+            compress: false,
+            force: false,
+            continue_on_error: false,
+            data_model: None,
+        })
+        .unwrap();
+        assert_eq!(summary.total_items, 2);
+
+        let db = dynoxide::Database::new(output.to_str().unwrap()).unwrap();
+        for item in scan_all(&db, "App") {
+            let pk = string_attr(&item, "pk");
+            let notes = string_attr(&item, "notes");
+            if pk.starts_with("CUSTOMER#") {
+                assert_eq!(notes, "[REDACTED]", "rule should reach the customer item");
+            } else {
+                assert_eq!(notes, "order notes", "rule must not reach the order item");
+            }
+        }
+    }
+
+    #[test]
+    fn test_rule_values_must_cover_every_reference() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("export");
+        let schema_file = tmp.path().join("schema.json");
+        let rules_file = tmp.path().join("rules.toml");
+
+        setup_export_dir(
+            &source,
+            "App",
+            &[r#"{"Item": {"pk": {"S": "CUSTOMER#1"}, "sk": {"S": "PROFILE"}}}"#],
+        );
+        create_schema_file(&schema_file, &[simple_table_schema("App")]);
+        std::fs::write(
+            &rules_file,
+            r#"
+[[rules]]
+match = "begins_with(pk, :prefix)"
+path = "sk"
+action = { type = "redact" }
+"#,
+        )
+        .unwrap();
+
+        let err = import::run(ImportCommand {
+            source,
+            output: Some(tmp.path().join("output.db")),
+            schema: schema_file,
+            rules: Some(rules_file),
+            tables: None,
+            compress: false,
+            force: false,
+            continue_on_error: false,
+            data_model: None,
+        })
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Rule 1"), "{msg}");
+        assert!(msg.contains(":prefix"), "{msg}");
+    }
+
+    #[test]
+    fn test_data_model_rederives_keys_from_anonymised_attributes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("export");
+        let output = tmp.path().join("output.db");
+        let schema_file = tmp.path().join("schema.json");
+        let rules_file = tmp.path().join("rules.toml");
+
+        setup_export_dir(
+            &source,
+            "App",
+            &[
+                r#"{"Item": {"_type": {"S": "User"}, "pk": {"S": "account#acc1"}, "sk": {"S": "user#alice@example.com"}, "gs1pk": {"S": "user#alice@example.com"}, "gs1sk": {"S": "user#"}, "accountId": {"S": "acc1"}, "email": {"S": "alice@example.com"}, "role": {"S": "admin"}}}"#,
+                r#"{"Item": {"_type": {"S": "Account"}, "pk": {"S": "account#acc1"}, "sk": {"S": "account#"}, "id": {"S": "acc1"}, "name": {"S": "Acme"}}}"#,
+            ],
+        );
+        create_schema_file(&schema_file, &[single_table_schema("App")]);
+        std::fs::write(
+            &rules_file,
+            r#"
+[[rules]]
+match = "attribute_exists(email)"
+path = "email"
+action = { type = "fake", generator = "safe_email" }
+"#,
+        )
+        .unwrap();
+
+        let summary = import::run(ImportCommand {
+            source,
+            output: Some(output.clone()),
+            schema: schema_file,
+            rules: Some(rules_file),
+            tables: None,
+            compress: false,
+            force: false,
+            continue_on_error: false,
+            data_model: Some(onetable_fixture()),
+        })
+        .unwrap();
+        assert_eq!(summary.total_items, 2);
+        assert!(
+            summary.warnings.is_empty(),
+            "keys that reproduce from their templates warn about nothing: {:?}",
+            summary.warnings
+        );
+
+        let db = dynoxide::Database::new(output.to_str().unwrap()).unwrap();
+        let items = scan_all(&db, "App");
+        let user = items
+            .iter()
+            .find(|i| string_attr(i, "_type") == "User")
+            .unwrap();
+        let account = items
+            .iter()
+            .find(|i| string_attr(i, "_type") == "Account")
+            .unwrap();
+
+        let email = string_attr(user, "email");
+        assert_ne!(email, "alice@example.com");
+        assert_eq!(string_attr(user, "pk"), "account#acc1");
+        assert_eq!(string_attr(user, "sk"), format!("user#{email}"));
+        assert_eq!(string_attr(user, "gs1pk"), format!("user#{email}"));
+        assert_eq!(string_attr(user, "gs1sk"), "user#");
+
+        assert_eq!(string_attr(account, "pk"), "account#acc1");
+        assert_eq!(string_attr(account, "sk"), "account#");
+        assert_eq!(string_attr(account, "name"), "Acme");
+    }
+
+    #[test]
+    fn test_data_model_leaves_a_key_its_template_does_not_reproduce() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("export");
+        let output = tmp.path().join("output.db");
+        let schema_file = tmp.path().join("schema.json");
+        let rules_file = tmp.path().join("rules.toml");
+
+        // sk does not follow the User template, so it must be left alone and
+        // reported rather than silently rewritten.
+        setup_export_dir(
+            &source,
+            "App",
+            &[
+                r#"{"Item": {"_type": {"S": "User"}, "pk": {"S": "account#acc1"}, "sk": {"S": "legacy-profile"}, "accountId": {"S": "acc1"}, "email": {"S": "alice@example.com"}}}"#,
+            ],
+        );
+        create_schema_file(&schema_file, &[single_table_schema("App")]);
+        std::fs::write(
+            &rules_file,
+            r#"
+[[rules]]
+match = "attribute_exists(email)"
+path = "email"
+action = { type = "fake", generator = "safe_email" }
+"#,
+        )
+        .unwrap();
+
+        let summary = import::run(ImportCommand {
+            source,
+            output: Some(output.clone()),
+            schema: schema_file,
+            rules: Some(rules_file),
+            tables: None,
+            compress: false,
+            force: false,
+            continue_on_error: false,
+            data_model: Some(onetable_fixture()),
+        })
+        .unwrap();
+
+        let mismatch = summary
+            .warnings
+            .iter()
+            .find(|w| w.contains("entity 'User'") && w.contains("does not reproduce sk"))
+            .unwrap_or_else(|| panic!("expected a mismatch warning: {:?}", summary.warnings));
+        assert!(
+            !mismatch.contains("legacy-profile"),
+            "a warning must not quote the key value: {mismatch}"
+        );
+
+        let db = dynoxide::Database::new(output.to_str().unwrap()).unwrap();
+        let user = &scan_all(&db, "App")[0];
+        assert_eq!(string_attr(user, "sk"), "legacy-profile");
+        assert_ne!(string_attr(user, "email"), "alice@example.com");
+    }
+
+    #[test]
+    fn test_rules_without_data_model_warn_that_keys_are_not_rewritten() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("export");
+        let output = tmp.path().join("output.db");
+        let schema_file = tmp.path().join("schema.json");
+        let rules_file = tmp.path().join("rules.toml");
+
+        setup_export_dir(
+            &source,
+            "App",
+            &[
+                r#"{"Item": {"pk": {"S": "CUSTOMER#alice@example.com"}, "sk": {"S": "PROFILE"}, "email": {"S": "alice@example.com"}}}"#,
+            ],
+        );
+        create_schema_file(&schema_file, &[simple_table_schema("App")]);
+        std::fs::write(
+            &rules_file,
+            r#"
+[[rules]]
+match = "attribute_exists(email)"
+path = "email"
+action = { type = "fake", generator = "safe_email" }
+"#,
+        )
+        .unwrap();
+
+        let summary = import::run(ImportCommand {
+            source,
+            output: Some(output),
+            schema: schema_file,
+            rules: Some(rules_file),
+            tables: None,
+            compress: false,
+            force: false,
+            continue_on_error: false,
+            data_model: None,
+        })
+        .unwrap();
+
+        assert!(
+            summary.warnings.iter().any(|w| w.contains("--data-model")),
+            "expected the keys-not-rewritten notice: {:?}",
+            summary.warnings
+        );
+    }
+
+    #[test]
+    fn test_data_model_reports_rows_collapsing_under_a_constant_action() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("export");
+        let output = tmp.path().join("output.db");
+        let schema_file = tmp.path().join("schema.json");
+        let rules_file = tmp.path().join("rules.toml");
+
+        setup_export_dir(
+            &source,
+            "App",
+            &[
+                r#"{"Item": {"_type": {"S": "User"}, "pk": {"S": "account#acc1"}, "sk": {"S": "user#alice@example.com"}, "accountId": {"S": "acc1"}, "email": {"S": "alice@example.com"}}}"#,
+                r#"{"Item": {"_type": {"S": "User"}, "pk": {"S": "account#acc1"}, "sk": {"S": "user#bob@example.com"}, "accountId": {"S": "acc1"}, "email": {"S": "bob@example.com"}}}"#,
+            ],
+        );
+        create_schema_file(&schema_file, &[single_table_schema("App")]);
+        std::fs::write(
+            &rules_file,
+            r#"
+[[rules]]
+match = "attribute_exists(email)"
+path = "email"
+action = { type = "redact" }
+"#,
+        )
+        .unwrap();
+
+        let summary = import::run(ImportCommand {
+            source,
+            output: Some(output.clone()),
+            schema: schema_file,
+            rules: Some(rules_file),
+            tables: None,
+            compress: false,
+            force: false,
+            continue_on_error: false,
+            data_model: Some(onetable_fixture()),
+        })
+        .unwrap();
+
+        assert!(
+            summary
+                .warnings
+                .iter()
+                .any(|w| w.contains("collapse onto one row")),
+            "expected the up-front constant-action warning: {:?}",
+            summary.warnings
+        );
+        assert!(
+            summary
+                .warnings
+                .iter()
+                .any(|w| w.contains("1 items rendered the same primary key")),
+            "expected the collision count: {:?}",
+            summary.warnings
+        );
+
+        let db = dynoxide::Database::new(output.to_str().unwrap()).unwrap();
+        let items = scan_all(&db, "App");
+        assert_eq!(items.len(), 1);
+        assert_eq!(string_attr(&items[0], "sk"), "user#[REDACTED]");
+    }
+
+    #[test]
+    fn test_data_model_lets_a_rule_on_a_key_win() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("export");
+        let output = tmp.path().join("output.db");
+        let schema_file = tmp.path().join("schema.json");
+        let rules_file = tmp.path().join("rules.toml");
+
+        setup_export_dir(
+            &source,
+            "App",
+            &[
+                r#"{"Item": {"_type": {"S": "User"}, "pk": {"S": "account#acc1"}, "sk": {"S": "user#alice@example.com"}, "accountId": {"S": "acc1"}, "email": {"S": "alice@example.com"}}}"#,
+            ],
+        );
+        create_schema_file(&schema_file, &[single_table_schema("App")]);
+        std::fs::write(
+            &rules_file,
+            r#"
+[[rules]]
+match = "attribute_exists(sk)"
+path = "sk"
+action = { type = "redact" }
+"#,
+        )
+        .unwrap();
+
+        let summary = import::run(ImportCommand {
+            source,
+            output: Some(output.clone()),
+            schema: schema_file,
+            rules: Some(rules_file),
+            tables: None,
+            compress: false,
+            force: false,
+            continue_on_error: false,
+            data_model: Some(onetable_fixture()),
+        })
+        .unwrap();
+        assert!(
+            summary
+                .warnings
+                .iter()
+                .any(|w| w.contains("targets key attribute 'sk' directly")),
+            "{:?}",
+            summary.warnings
+        );
+
+        let db = dynoxide::Database::new(output.to_str().unwrap()).unwrap();
+        let user = &scan_all(&db, "App")[0];
+        assert_eq!(string_attr(user, "sk"), "[REDACTED]");
     }
 }

--- a/tests/import.rs
+++ b/tests/import.rs
@@ -1010,7 +1010,9 @@ fields = ["email"]
                     {"AttributeName": "pk", "AttributeType": "S"},
                     {"AttributeName": "sk", "AttributeType": "S"},
                     {"AttributeName": "gs1pk", "AttributeType": "S"},
-                    {"AttributeName": "gs1sk", "AttributeType": "S"}
+                    {"AttributeName": "gs1sk", "AttributeType": "S"},
+                    {"AttributeName": "gs2pk", "AttributeType": "S"},
+                    {"AttributeName": "gs2sk", "AttributeType": "S"}
                 ],
                 "GlobalSecondaryIndexes": [
                     {
@@ -1020,6 +1022,14 @@ fields = ["email"]
                             {"AttributeName": "gs1sk", "KeyType": "RANGE"}
                         ],
                         "Projection": {"ProjectionType": "ALL"}
+                    },
+                    {
+                        "IndexName": "GSI2",
+                        "KeySchema": [
+                            {"AttributeName": "gs2pk", "KeyType": "HASH"},
+                            {"AttributeName": "gs2sk", "KeyType": "RANGE"}
+                        ],
+                        "Projection": {"ProjectionType": "KEYS_ONLY"}
                     }
                 ]
             }
@@ -1365,7 +1375,7 @@ action = { type = "redact" }
             summary
                 .warnings
                 .iter()
-                .any(|w| w.contains("collapse onto one row")),
+                .any(|w| w.contains("overwrites the last")),
             "expected the up-front constant-action warning: {:?}",
             summary.warnings
         );
@@ -1717,5 +1727,112 @@ fields = ["email"]
                 }
             }
         }
+    }
+
+    #[test]
+    fn test_a_rebuilt_key_collision_across_batches_leaves_no_stale_index_row() {
+        // Two items in separate export files collapse onto one primary key
+        // once their redacted email is rebuilt into it, but keep distinct GSI
+        // keys. The overwritten item's index row must go with it, or a GSI
+        // query answers from a base row that no longer exists.
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("export");
+        let output = tmp.path().join("output.db");
+        let schema_file = tmp.path().join("schema.json");
+        let rules_file = tmp.path().join("rules.toml");
+        let model_file = tmp.path().join("model.json");
+
+        let data_dir = source.join("App").join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+        for (file, email, order) in [
+            ("00000000.json", "a@x.co", "1"),
+            ("00000001.json", "b@y.co", "2"),
+        ] {
+            std::fs::write(
+                data_dir.join(file),
+                format!(
+                    r#"{{"Item": {{"_type": {{"S": "Order"}}, "pk": {{"S": "CUSTOMER#{email}"}}, "sk": {{"S": "ORDER"}}, "gs1pk": {{"S": "ORDER#{order}"}}, "gs1sk": {{"S": "ORDER"}}, "email": {{"S": "{email}"}}, "orderId": {{"S": "{order}"}}}}}}"#
+                ) + "\n",
+            )
+            .unwrap();
+        }
+
+        create_schema_file(&schema_file, &[single_table_schema("App")]);
+        std::fs::write(
+            &model_file,
+            r#"{
+                "format": "onetable:1.1.0",
+                "indexes": {
+                    "primary": { "hash": "pk", "sort": "sk" },
+                    "gs1": { "hash": "gs1pk", "sort": "gs1sk", "name": "GSI1" }
+                },
+                "params": { "typeField": "_type" },
+                "models": {
+                    "Order": {
+                        "pk": { "type": "string", "value": "CUSTOMER#${email}" },
+                        "sk": { "type": "string", "value": "ORDER" },
+                        "gs1pk": { "type": "string", "value": "ORDER#${orderId}" },
+                        "gs1sk": { "type": "string", "value": "ORDER" },
+                        "email": { "type": "string" },
+                        "orderId": { "type": "string" }
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+        std::fs::write(
+            &rules_file,
+            r#"
+[[rules]]
+match = "attribute_exists(email)"
+path = "email"
+action = { type = "redact" }
+"#,
+        )
+        .unwrap();
+
+        let summary = import::run(ImportCommand {
+            source,
+            output: Some(output.clone()),
+            schema: schema_file,
+            rules: Some(rules_file),
+            tables: None,
+            compress: false,
+            force: false,
+            continue_on_error: false,
+            data_model: Some(model_file),
+        })
+        .unwrap();
+        assert!(
+            summary
+                .warnings
+                .iter()
+                .any(|w| w.contains("rendered the same primary key")),
+            "the collapse should still be reported: {:?}",
+            summary.warnings
+        );
+
+        let db = dynoxide::Database::new(output.to_str().unwrap()).unwrap();
+        let base = scan_all(&db, "App");
+        assert_eq!(base.len(), 1, "the two collapsed onto one row");
+
+        let indexed = db
+            .scan(dynoxide::actions::scan::ScanRequest {
+                table_name: "App".to_string(),
+                index_name: Some("GSI1".to_string()),
+                ..Default::default()
+            })
+            .unwrap()
+            .items
+            .unwrap();
+        assert_eq!(
+            indexed.len(),
+            1,
+            "the overwritten item's index row must go with it, got {indexed:?}"
+        );
+        assert_eq!(
+            string_attr(&indexed[0], "gs1pk"),
+            string_attr(&base[0], "gs1pk")
+        );
     }
 }


### PR DESCRIPTION
## What this changes

Two gaps in `dynoxide import --rules` on single-table exports, found while putting the anonymised-import story in front of a real single-table schema.

**Keys built from attributes are now rebuilt after anonymisation (#201).** Rules rewrite whole attribute values, so a rule on `email` left the real address inside `pk = "CUSTOMER#<email>"` and every GSI key derived from it, and the import reported success. Pointing a rule at `pk` instead replaced the whole value and lost the `CUSTOMER#` prefix. `import --data-model <onetable.json>` takes the same OneTable schema the MCP server already parses. For each item the importer resolves the entity, notes which of `pk`, `sk` and the GSI keys are built from a template such as `user#${email}`, applies the rules to the attributes, then renders those keys again from the anonymised values. The prefix survives and key and attribute agree by construction, which also settles the per-field consistency question: the key is derived from the attribute rather than anonymised alongside it.

The guards around that matter as much as the rebuild:

- A key is only rewritten when its template reproduces the value the item arrived with. Anything else is left alone and reported once per entity and key, without quoting the value, since removing those values is the point of the run.
- A rule naming a key attribute directly wins over its template, and the import says so rather than silently re-deriving over the top of it.
- `redact`, `null` and `mask` produce one output for every input, so using them on an attribute a key is built from would render an identical key for every item of that entity and overwrite the previous row. That is reported before any data is read, and collisions are counted if the import goes ahead.
- Templates take plain `${name}` references and may reach into a map. An unclosed `${` or OneTable's unsupported `${name:length:pad}` formatting fails the import rather than leaving a key quietly unrebuilt.

**Rules take `values` and `names` tables (#200).** Match expressions only ever accepted `:name` references, and the docs showed `begins_with(pk, 'USER#')`, which the parser rejects. Rules now carry `values = { ":prefix" = "USER#" }` and `names = { "#n" = "name" }`, so a rule can be scoped by key prefix and can reach an attribute whose name is a reserved word. The rules file is validated up front, reusing the same operand-type and reference checks the request path already runs, so a mismatch fails there with DynamoDB's own message instead of silently matching nothing. Teaching the shared condition parser to accept inline literals would have made the emulator accept expressions DynamoDB does not, so the values table is the route taken.

**An import that would silently break a join now fails (#202).** Filed as a follow-up and folded in here, because it guards the exact failure this PR's machinery creates. When two entities build the same key from the same template, an anonymised attribute that template reads has to be in `[consistency] fields`, or each entity anonymises it independently and their keys stop agreeing. Every count stays correct, every key stays well formed and every value is genuinely fake, so nothing in the output says anything is wrong. The only symptom is that a query for a customer's orders comes back empty.

The model and the rules are enough to warn up front, but the failure waits until items of both entities have actually been imported. An import holding one entity's slice has no join to lose, and a check that fires on legitimate use earns a bypass flag, which would make it a warning wearing an error's clothes. Nothing is persisted on the error path, so failing late costs the run's time rather than leaving a half-anonymised database. Matching on the key and its template rather than the attribute name keeps it off entities that merely reuse a name, and an attribute no rule rewrites is not at risk.

That it errors while the row collapse only warns is deliberate, and the reason is detectability rather than damage. A collapse announces itself: the row count is short and the collisions are counted. A broken join announces nothing.

Also fixed along the way: a OneTable schema whose primary key is not literally `pk` / `sk` came back with an empty `pk_template`, because the parser read those attribute names rather than the ones `indexes.primary` names. That reached the MCP data model as well as import.

`ImportCommand` gains a `data_model` field for library callers. `--data-model` on import also serves as the MCP data model when `--mcp` is set without `--mcp-data-model`.

Closes #200
Closes #201
Closes #202

## Checklist

- [x] Tests added or updated
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` pass locally
- [x] `CHANGELOG.md` updated if this is a user-visible change
- [x] Linked issue, discussion, or a short note explaining the
  motivation
- [x] I agree my contribution is licensed under the project's terms
  (MIT License and Apache License, Version 2.0)
