### PR TITLE
fix: make fake generators repeatable, and give them room not to collide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   data changed. Without it the previous per-run randomness stands, so existing
   rules files are unaffected. A seeded rule does not need its field listed in
   `[consistency]`, because the derivation already guarantees one input maps to
-  one output. An empty variable is rejected, as it is for the hash salt and for
-  the same reason: the seed is what stops anyone holding the original data
-  reproducing the mapping
+  one output. An empty variable is rejected: the seed is what stops anyone
+  holding the original data reproducing the mapping, so it needs to be a
+  randomly generated value rather than a memorable one.
+
+  Two limits are stated rather than glossed. The promise holds for a fixed
+  build, because neither the random stream nor the generator word lists
+  guarantee identical output across dependency upgrades. And only scalar
+  values are derived: a map, list or set has no stable byte order to hash, so
+  those draw fresh even with a seed set rather than claim a repeatability they
+  cannot deliver. Mixing rule shapes on one consistency field is reported,
+  since a seeded rule bypasses the map an unseeded one depends on
   ([#203](https://github.com/nubo-db/dynoxide/issues/203)).
 
 ### Fixed
@@ -30,9 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   collapse onto the same key and one row overwrites the other, which was
   measured at four collisions in three hundred items. Generated addresses now
   carry a derived suffix in the local part, which keeps them recognisably
-  addresses and takes the space past a hundred billion. The other generators
-  keep their pools, so `word`, `first_name` and the rest remain unsuitable for
-  an attribute a key is built from.
+  addresses and takes the space to around 1.7e23. That is a probabilistic
+  bound and not a guarantee, which is why the suffix is a full 64 bits: a
+  shorter one would still give roughly a one in a hundred chance of some
+  duplicate across a million distinct inputs, an ordinary export size. The
+  collision counter stays as the backstop. The other generators keep their
+  pools, so `word`, `first_name` and the rest remain unsuitable for an
+  attribute a key is built from.
 
 ## [1.1.0] - 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `fake` rules take an optional `seed_env`, naming an environment variable
+  holding a secret. With it the generated value becomes a function of the
+  original, so the same input gives the same output on every run and an
+  anonymised export committed as a test fixture only changes where the source
+  data changed. Without it the previous per-run randomness stands, so existing
+  rules files are unaffected. A seeded rule does not need its field listed in
+  `[consistency]`, because the derivation already guarantees one input maps to
+  one output. An empty variable is rejected, as it is for the hash salt and for
+  the same reason: the seed is what stops anyone holding the original data
+  reproducing the mapping
+  ([#203](https://github.com/nubo-db/dynoxide/issues/203)).
+
+### Fixed
+
+- Generated email addresses no longer collide at ordinary sizes.
+  `safe_email` drew from roughly nine thousand values, a first name against
+  three `example.` domains, so a few hundred items produced repeats. A repeat
+  is not cosmetic: where the attribute is one a key is built from, two people
+  collapse onto the same key and one row overwrites the other, which was
+  measured at four collisions in three hundred items. Generated addresses now
+  carry a derived suffix in the local part, which keeps them recognisably
+  addresses and takes the space past a hundred billion. The other generators
+  keep their pools, so `word`, `first_name` and the rest remain unsuitable for
+  an attribute a key is built from.
+
 ## [1.1.0] - 2026-09-03
 
 ### Behaviour changes

--- a/docs/import.md
+++ b/docs/import.md
@@ -85,10 +85,63 @@ ANON_SALT=my-secret-salt dynoxide import \
 | `fake` | Replace with generated data (`safe_email`, `name`, `phone_number`, `address`, `company_name`, `sentence`, `word`, `first_name`, `last_name`) |
 | `mask` | Keep last N characters, mask the rest (`keep_last`, `mask_char`) |
 | `hash` | SHA-256 hash with salt from env var (`salt_env`, required) |
+| | `fake` also takes an optional `seed_env`, below |
 | `redact` | Replace with `[REDACTED]` |
 | `null` | Replace with NULL |
 
 **Consistency:** Fields listed in `[consistency].fields` produce the same anonymised value across all tables in a single import run. Same input + same salt = same output.
+
+### Making `fake` repeatable
+
+By default `fake` draws a new value every time it runs, so importing the same
+export twice gives two different sets of names and addresses. That is fine for
+a throwaway database and awkward for one committed as a test fixture, where
+every refresh rewrites values that did not change and buries any real
+difference in churn.
+
+Give the rule a `seed_env` and the generated value becomes a function of the
+original:
+
+```toml
+[[rules]]
+match = "attribute_exists(email)"
+path = "email"
+action = { type = "fake", generator = "safe_email", seed_env = "ANON_SEED" }
+```
+
+```sh
+ANON_SEED=a-secret-value dynoxide import ...
+```
+
+The same input and the same seed give the same output on every run, so a
+fixture only changes where the source data did. A different seed gives an
+entirely different mapping.
+
+**The seed is a secret, for the same reason the hash salt is.** Without it,
+anyone holding the original data could re-run the import and reproduce the
+mapping from real value to fake one, which undoes the anonymisation. An empty
+variable is rejected rather than accepted quietly, since that is the shape an
+unset CI secret takes.
+
+A seeded rule does not need its field in `[consistency]`. The derivation
+already guarantees one input maps to one output everywhere.
+
+### Generated values and collisions
+
+`safe_email` used to produce roughly nine thousand possible addresses, a first
+name against three `example.` domains. That is small enough that a few hundred
+items produce repeats, and a repeat is not cosmetic: if the attribute is one a
+key is built from, two people collapse onto the same key and one row overwrites
+the other.
+
+Generated addresses now carry a derived suffix in the local part, so
+`alice@example.com` becomes something of the form
+`juvenal.3f2a91b8@example.com`. It is still an address, and there is enough
+room that repeats do not happen at any realistic size.
+
+The other generators keep their pools. `word`, `first_name` and the rest are
+small, so prefer `hash` or a seeded `safe_email` for anything a key is built
+from.
 
 ## Options
 

--- a/docs/import.md
+++ b/docs/import.md
@@ -117,14 +117,37 @@ The same input and the same seed give the same output on every run, so a
 fixture only changes where the source data did. A different seed gives an
 entirely different mapping.
 
-**The seed is a secret, for the same reason the hash salt is.** Without it,
-anyone holding the original data could re-run the import and reproduce the
-mapping from real value to fake one, which undoes the anonymisation. An empty
-variable is rejected rather than accepted quietly, since that is the shape an
-unset CI secret takes.
+The promise is scoped to a fixed build. The value is produced by a generator
+drawing from a seeded random stream, and neither the stream nor the generator's
+word lists promise to stay identical across upgrades of those dependencies. So
+the same dynoxide gives the same answer every time, and a future dynoxide may
+not. Refresh a fixture in one go rather than expecting values to survive an
+upgrade untouched.
+
+Only scalar values are derived. A map, list or set has no stable byte order to
+hash, so those draw fresh each time even with a seed set, rather than claim a
+repeatability they cannot deliver.
+
+**The seed is a secret, for the same reason the hash salt is.** Anyone holding
+both the original data and the seed can re-run the import and reproduce the
+mapping from real value to fake one, which undoes the anonymisation. Use a
+randomly generated value, not a memorable one: a short or guessable seed can be
+searched offline against a handful of known pairs. An empty variable is
+rejected rather than accepted quietly, since that is the shape an unset CI
+secret takes.
+
+Omitting `seed_env` is not the same risk. Without a seed there is no mapping to
+reproduce, because each run draws fresh. The exposure comes from a seed that
+someone else can obtain or guess.
 
 A seeded rule does not need its field in `[consistency]`. The derivation
 already guarantees one input maps to one output everywhere.
+
+Do not mix rule shapes on one consistency field. A seeded rule derives its
+value and never touches the consistency map, so pairing it with an unseeded
+rule, a different seed or a different generator on the same field means one
+input can leave with two different values depending on which rule matched. The
+import reports it, because nothing in the output would.
 
 ### Generated values and collisions
 
@@ -136,8 +159,14 @@ the other.
 
 Generated addresses now carry a derived suffix in the local part, so
 `alice@example.com` becomes something of the form
-`juvenal.3f2a91b8@example.com`. It is still an address, and there is enough
-room that repeats do not happen at any realistic size.
+`juvenal.3f2a91b8c4d5e6f7@example.com`. It is still an address, and the space
+is around 1.7e23.
+
+That is a probabilistic bound rather than a guarantee. Duplicates become
+likely far sooner than the size of the space suggests, so the number matters:
+a shorter suffix would still give roughly a one in a hundred chance of some
+duplicate across a million distinct inputs, which is an ordinary export. The
+import counts collisions either way, because a merged identity is silent.
 
 The other generators keep their pools. `word`, `first_name` and the rest are
 small, so prefer `hash` or a seeded `safe_email` for anything a key is built

--- a/src/import/anonymise.rs
+++ b/src/import/anonymise.rs
@@ -6,7 +6,7 @@
 use crate::expressions::{resolve_path, set_path};
 use crate::types::{AttributeValue, Item};
 
-use super::config::{ValidatedAction, ValidatedRule, matches_item};
+use super::config::{Salt, ValidatedAction, ValidatedRule, matches_item};
 use super::consistency::ConsistencyMap;
 
 use fake::Fake;
@@ -16,6 +16,8 @@ use fake::faker::internet::en::SafeEmail;
 use fake::faker::lorem::en::{Sentence, Word};
 use fake::faker::name::en::{FirstName, LastName, Name};
 use fake::faker::phone_number::en::PhoneNumber;
+use fake::rand::rngs::StdRng;
+use fake::rand::{Rng, SeedableRng};
 use sha2::{Digest, Sha256};
 
 /// Apply all matching rules to an item, mutating it in place.
@@ -50,7 +52,13 @@ pub fn apply_rules(
         // Hash actions are deterministic (same input → same output), so they
         // don't need the consistency map: skip it entirely to avoid unbounded
         // memory growth on high-cardinality fields.
-        let is_deterministic = matches!(rule.action, ValidatedAction::Hash { .. });
+        // A seeded fake is a pure function of the input, like hash, so the
+        // consistency map would only duplicate what the derivation already
+        // guarantees and grow unboundedly doing it.
+        let is_deterministic = matches!(
+            rule.action,
+            ValidatedAction::Hash { .. } | ValidatedAction::Fake { seed: Some(_), .. }
+        );
         let new_value = if is_consistency_field && !is_deterministic {
             // Check consistency map first
             if let Some(cached) = consistency_map.get(&field_name, &current_value) {
@@ -98,7 +106,9 @@ fn path_to_field_name(path: &[crate::expressions::PathElement]) -> String {
 /// Generate an anonymised value based on the action type.
 fn generate_value(action: &ValidatedAction, original: &AttributeValue) -> AttributeValue {
     match action {
-        ValidatedAction::Fake { generator } => generate_fake(generator, original),
+        ValidatedAction::Fake { generator, seed } => {
+            generate_fake(generator, original, seed.as_ref())
+        }
         ValidatedAction::Mask {
             keep_last,
             mask_char,
@@ -110,18 +120,29 @@ fn generate_value(action: &ValidatedAction, original: &AttributeValue) -> Attrib
 }
 
 /// Generate fake data based on the generator name.
-fn generate_fake(generator: &str, original: &AttributeValue) -> AttributeValue {
+///
+/// With a seed the value is a function of the original, so the same input
+/// gives the same output on every run and a committed fixture can be
+/// refreshed without churn. Without one each call re-rolls, which is the
+/// original behaviour and why the consistency map exists.
+fn generate_fake(
+    generator: &str,
+    original: &AttributeValue,
+    seed: Option<&Salt>,
+) -> AttributeValue {
+    let mut rng = seeded_rng(generator, original, seed);
+
     // Generate a fake string value
     let fake_string: String = match generator {
-        "safe_email" => SafeEmail().fake(),
-        "name" => Name().fake(),
-        "first_name" => FirstName().fake(),
-        "last_name" => LastName().fake(),
-        "phone_number" => PhoneNumber().fake(),
-        "address" => CityName().fake(), // Simplified to city name
-        "company_name" => CompanyName().fake(),
-        "sentence" => Sentence(3..8).fake(),
-        "word" => Word().fake(),
+        "safe_email" => widen_email(SafeEmail().fake_with_rng(&mut rng), &mut rng),
+        "name" => Name().fake_with_rng(&mut rng),
+        "first_name" => FirstName().fake_with_rng(&mut rng),
+        "last_name" => LastName().fake_with_rng(&mut rng),
+        "phone_number" => PhoneNumber().fake_with_rng(&mut rng),
+        "address" => CityName().fake_with_rng(&mut rng), // Simplified to city name
+        "company_name" => CompanyName().fake_with_rng(&mut rng),
+        "sentence" => Sentence(3..8).fake_with_rng(&mut rng),
+        "word" => Word().fake_with_rng(&mut rng),
         _ => format!("[FAKE:{generator}]"),
     };
 
@@ -130,10 +151,69 @@ fn generate_fake(generator: &str, original: &AttributeValue) -> AttributeValue {
         AttributeValue::S(_) => AttributeValue::S(fake_string),
         AttributeValue::N(_) => {
             // For numbers, generate a random number string
-            let n: u32 = (1000..9999).fake();
+            let n: u32 = (1000..9999).fake_with_rng(&mut rng);
             AttributeValue::N(n.to_string())
         }
         _ => AttributeValue::S(fake_string),
+    }
+}
+
+/// An RNG for one generated value.
+///
+/// Seeded from the original value when a secret is configured, so generation
+/// is a pure function of what went in. The generator name is mixed in too, so
+/// two rules over the same attribute do not produce the same draw.
+fn seeded_rng(generator: &str, original: &AttributeValue, seed: Option<&Salt>) -> StdRng {
+    match seed {
+        Some(seed) => {
+            let mut hasher = Sha256::new();
+            // Length-prefixed, and the value's type tagged. Concatenating the
+            // three fields directly would leave their boundaries ambiguous, so
+            // a seed of "ab" with generator "c" would derive the same value as
+            // a seed of "a" with generator "bc", and the string "123" would
+            // derive the same value as the number 123. Two different
+            // configurations sharing a mapping is not something the output
+            // would ever show you.
+            let mut field = |tag: u8, bytes: &[u8]| {
+                hasher.update([tag]);
+                hasher.update((bytes.len() as u64).to_be_bytes());
+                hasher.update(bytes);
+            };
+            field(b'k', seed.as_bytes());
+            field(b'g', generator.as_bytes());
+            match original {
+                AttributeValue::S(s) => field(b's', s.as_bytes()),
+                AttributeValue::N(n) => field(b'n', n.as_bytes()),
+                AttributeValue::B(b) => field(b'b', b),
+                other => {
+                    let json = serde_json::to_string(other).unwrap_or_default();
+                    field(b'j', json.as_bytes());
+                }
+            }
+            let digest = hasher.finalize();
+            let mut bytes = [0u8; 32];
+            bytes.copy_from_slice(&digest);
+            StdRng::from_seed(bytes)
+        }
+        None => StdRng::from_entropy(),
+    }
+}
+
+/// Put enough room in the local part that two people do not land on one
+/// address.
+///
+/// `SafeEmail` draws a first name from about three thousand, across three
+/// `example.` domains, so roughly nine thousand values in total. That is small
+/// enough that a few hundred items collide, and a collision on an attribute a
+/// key is built from merges two identities onto one row. Eight hex characters
+/// take it past a hundred billion, which is not a guarantee but is far past
+/// the point where it happens in practice.
+fn widen_email(address: String, rng: &mut StdRng) -> String {
+    let discriminator: u32 = rng.r#gen();
+    match address.split_once('@') {
+        Some((local, domain)) => format!("{local}.{discriminator:08x}@{domain}"),
+        // Not an address after all; leave it rather than corrupt it.
+        None => address,
     }
 }
 
@@ -275,15 +355,106 @@ mod tests {
         );
     }
 
+    fn seed(bytes: &str) -> Salt {
+        Salt::new(bytes.as_bytes().to_vec())
+    }
+
+    #[test]
+    fn seeded_fake_is_a_function_of_the_input() {
+        let s = seed("a-secret");
+        let alice = AttributeValue::S("alice@example.com".to_string());
+        let bob = AttributeValue::S("bob@example.com".to_string());
+
+        // Same input, same seed, same answer, however many times.
+        let first = generate_fake("safe_email", &alice, Some(&s));
+        for _ in 0..5 {
+            assert_eq!(generate_fake("safe_email", &alice, Some(&s)), first);
+        }
+        // Different input diverges, so identities stay distinct.
+        assert_ne!(generate_fake("safe_email", &bob, Some(&s)), first);
+        // A different secret gives a different mapping entirely.
+        let other = seed("another-secret");
+        assert_ne!(generate_fake("safe_email", &alice, Some(&other)), first);
+    }
+
+    /// The first draw from the derived stream, which is what every generated
+    /// value is a function of.
+    fn derived(generator: &str, original: &AttributeValue, s: &Salt) -> u64 {
+        seeded_rng(generator, original, Some(s)).r#gen()
+    }
+
+    #[test]
+    fn the_derivation_separates_its_fields() {
+        // Tested against seeded_rng rather than generate_fake on purpose: the
+        // generator name also selects the generator, and the original's type
+        // also picks the returned variant, so comparing generated values would
+        // pass whether or not the derivation kept its fields apart.
+
+        // Without length prefixes both of these hash "ab" + "word" + "x".
+        assert_ne!(
+            derived("word", &AttributeValue::S("x".into()), &seed("ab")),
+            derived("bword", &AttributeValue::S("x".into()), &seed("a")),
+            "seed and generator boundaries must be unambiguous"
+        );
+
+        // Without a type tag these hash the same bytes.
+        let s = seed("a-secret");
+        assert_ne!(
+            derived("word", &AttributeValue::S("123".into()), &s),
+            derived("word", &AttributeValue::N("123".into()), &s),
+            "the attribute type is part of the input"
+        );
+    }
+
+    #[test]
+    fn unseeded_fake_still_re_rolls() {
+        let alice = AttributeValue::S("alice@example.com".to_string());
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..20 {
+            seen.insert(format!("{:?}", generate_fake("safe_email", &alice, None)));
+        }
+        assert!(seen.len() > 1, "without a seed each call should re-roll");
+    }
+
+    #[test]
+    fn generated_emails_have_room_to_avoid_collisions() {
+        // SafeEmail alone draws from roughly nine thousand values, so a few
+        // hundred items collide and merge two identities onto one key. The
+        // widened local part is what stops that.
+        let s = seed("a-secret");
+        let mut seen = std::collections::HashSet::new();
+        for n in 0..2_000 {
+            let original = AttributeValue::S(format!("person{n}@real.example"));
+            match generate_fake("safe_email", &original, Some(&s)) {
+                AttributeValue::S(v) => {
+                    assert!(v.contains('@'), "still an address: {v}");
+                    assert!(seen.insert(v), "collision within 2000 values");
+                }
+                other => panic!("expected a string, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn a_non_address_generator_is_not_mangled_by_widening() {
+        let s = seed("a-secret");
+        let v = generate_fake("word", &AttributeValue::S("x".to_string()), Some(&s));
+        match v {
+            AttributeValue::S(w) => assert!(!w.contains('@'), "word should stay a word: {w}"),
+            other => panic!("expected a string, got {other:?}"),
+        }
+    }
+
     #[test]
     fn test_generate_fake_preserves_type() {
         let result = generate_fake(
             "safe_email",
             &AttributeValue::S("old@example.com".to_string()),
+            None,
         );
         matches!(result, AttributeValue::S(_));
 
-        let result = generate_fake("name", &AttributeValue::N("42".to_string()));
+        let result = generate_fake("name", &AttributeValue::N("42".to_string()), None);
         matches!(result, AttributeValue::N(_));
     }
 }

--- a/src/import/anonymise.rs
+++ b/src/import/anonymise.rs
@@ -185,10 +185,13 @@ fn seeded_rng(generator: &str, original: &AttributeValue, seed: Option<&Salt>) -
                 AttributeValue::S(s) => field(b's', s.as_bytes()),
                 AttributeValue::N(n) => field(b'n', n.as_bytes()),
                 AttributeValue::B(b) => field(b'b', b),
-                other => {
-                    let json = serde_json::to_string(other).unwrap_or_default();
-                    field(b'j', json.as_bytes());
-                }
+                // Anything else is a map, a list or a set, and their
+                // serialised bytes are not stable: `AttributeValue::M` holds a
+                // HashMap, so one value can serialise two ways and derive two
+                // different pseudonyms. Falling back to entropy is honest
+                // about that, where hashing an unstable encoding would claim a
+                // determinism it does not have.
+                _ => return StdRng::from_entropy(),
             }
             let digest = hasher.finalize();
             let mut bytes = [0u8; 32];
@@ -205,13 +208,18 @@ fn seeded_rng(generator: &str, original: &AttributeValue, seed: Option<&Salt>) -
 /// `SafeEmail` draws a first name from about three thousand, across three
 /// `example.` domains, so roughly nine thousand values in total. That is small
 /// enough that a few hundred items collide, and a collision on an attribute a
-/// key is built from merges two identities onto one row. Eight hex characters
-/// take it past a hundred billion, which is not a guarantee but is far past
-/// the point where it happens in practice.
+/// key is built from merges two identities onto one row.
+///
+/// Sixteen hex characters take the space to roughly 1.7e23. That is a
+/// probabilistic bound, not a guarantee: a 32-bit suffix would still give
+/// about a one in a hundred chance of some duplicate across a million
+/// distinct inputs, which is an ordinary export size. The importer's collision
+/// counter stays as the backstop either way, because a merged identity is
+/// silent.
 fn widen_email(address: String, rng: &mut StdRng) -> String {
-    let discriminator: u32 = rng.r#gen();
+    let discriminator: u64 = rng.r#gen();
     match address.split_once('@') {
-        Some((local, domain)) => format!("{local}.{discriminator:08x}@{domain}"),
+        Some((local, domain)) => format!("{local}.{discriminator:016x}@{domain}"),
         // Not an address after all; leave it rather than corrupt it.
         None => address,
     }
@@ -389,20 +397,72 @@ mod tests {
         // generator name also selects the generator, and the original's type
         // also picks the returned variant, so comparing generated values would
         // pass whether or not the derivation kept its fields apart.
+        let text = |v: &str| AttributeValue::S(v.into());
 
-        // Without length prefixes both of these hash "ab" + "word" + "x".
+        // Length prefixes. With tags but no lengths both of these feed the
+        // hasher the identical byte string
+        // "k" "a" "g" "words" "s" "x" ... run together.
         assert_ne!(
-            derived("word", &AttributeValue::S("x".into()), &seed("ab")),
-            derived("bword", &AttributeValue::S("x".into()), &seed("a")),
-            "seed and generator boundaries must be unambiguous"
+            derived("word", &text("gsafe_emailsx"), &seed("a")),
+            derived("safe_email", &text("x"), &seed("agwords")),
+            "field lengths must be part of the input"
         );
 
-        // Without a type tag these hash the same bytes.
+        // Type tags. Without them these hash the same bytes.
         let s = seed("a-secret");
         assert_ne!(
-            derived("word", &AttributeValue::S("123".into()), &s),
+            derived("word", &text("123"), &s),
             derived("word", &AttributeValue::N("123".into()), &s),
             "the attribute type is part of the input"
+        );
+
+        // The generator itself must reach the hash, not merely select the
+        // generator function.
+        assert_ne!(
+            derived("word", &text("x"), &s),
+            derived("safe_email", &text("x"), &s),
+            "the generator name is part of the input"
+        );
+    }
+
+    #[test]
+    fn the_email_suffix_is_a_full_64_bits() {
+        // A weaker suffix still produces distinct values across a small
+        // sample, so counting uniques cannot establish the width. Read the
+        // suffix instead.
+        let s = seed("a-secret");
+        match generate_fake("safe_email", &AttributeValue::S("a@b.c".into()), Some(&s)) {
+            AttributeValue::S(v) => {
+                let (local, _) = v.split_once('@').expect("an address");
+                let suffix = local.rsplit('.').next().expect("a suffix");
+                assert_eq!(suffix.len(), 16, "expected 16 hex characters in {v}");
+                assert!(
+                    suffix.chars().all(|c| c.is_ascii_hexdigit()),
+                    "expected hex in {v}"
+                );
+            }
+            other => panic!("expected a string, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_value_whose_bytes_are_not_stable_does_not_claim_determinism() {
+        // A map serialises in HashMap order, so hashing it would derive a
+        // different pseudonym for the same value on a different run. Better to
+        // draw fresh than to promise a stability that is not there.
+        let s = seed("a-secret");
+        let mut map = std::collections::HashMap::new();
+        map.insert("a".to_string(), AttributeValue::S("x".to_string()));
+        map.insert("b".to_string(), AttributeValue::S("y".to_string()));
+        let value = AttributeValue::M(map);
+
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..20 {
+            seen.insert(format!("{:?}", generate_fake("word", &value, Some(&s))));
+        }
+        assert!(
+            seen.len() > 1,
+            "a non-scalar should draw fresh rather than pretend to be deterministic"
         );
     }
 
@@ -436,11 +496,18 @@ mod tests {
     }
 
     #[test]
-    fn a_non_address_generator_is_not_mangled_by_widening() {
+    fn a_non_address_generator_is_left_exactly_as_the_generator_produced_it() {
+        // Asserting only "no @ in it" would pass for an empty string or for a
+        // word with digits stapled on. Compare against the generator driven by
+        // an identically derived stream instead.
         let s = seed("a-secret");
-        let v = generate_fake("word", &AttributeValue::S("x".to_string()), Some(&s));
-        match v {
-            AttributeValue::S(w) => assert!(!w.contains('@'), "word should stay a word: {w}"),
+        let original = AttributeValue::S("x".to_string());
+        let expected: String = Word().fake_with_rng(&mut seeded_rng("word", &original, Some(&s)));
+
+        match generate_fake("word", &original, Some(&s)) {
+            AttributeValue::S(w) => {
+                assert_eq!(w, expected, "widening must not touch a non-address")
+            }
             other => panic!("expected a string, got {other:?}"),
         }
     }
@@ -452,9 +519,9 @@ mod tests {
             &AttributeValue::S("old@example.com".to_string()),
             None,
         );
-        matches!(result, AttributeValue::S(_));
+        assert!(matches!(result, AttributeValue::S(_)), "got {result:?}");
 
         let result = generate_fake("name", &AttributeValue::N("42".to_string()), None);
-        matches!(result, AttributeValue::N(_));
+        assert!(matches!(result, AttributeValue::N(_)), "got {result:?}");
     }
 }

--- a/src/import/config.rs
+++ b/src/import/config.rs
@@ -43,6 +43,10 @@ pub enum ActionConfig {
         /// Generator name: `safe_email`, `name`, `phone_number`, `address`,
         /// `company_name`, `sentence`, `word`, `first_name`, `last_name`.
         generator: String,
+        /// Environment variable holding a secret that makes the generated
+        /// value a function of the original, so the same input gives the same
+        /// output on every run. Without it each run re-rolls.
+        seed_env: Option<String>,
     },
     /// Mask characters, keeping the last N.
     Mask {
@@ -115,9 +119,18 @@ impl std::fmt::Debug for Salt {
 /// A validated action with resolved values (e.g., salt from env).
 #[derive(Debug, Clone)]
 pub enum ValidatedAction {
-    Fake { generator: String },
-    Mask { keep_last: usize, mask_char: char },
-    Hash { salt: Salt },
+    Fake {
+        generator: String,
+        /// Present when `seed_env` was set: makes generation deterministic.
+        seed: Option<Salt>,
+    },
+    Mask {
+        keep_last: usize,
+        mask_char: char,
+    },
+    Hash {
+        salt: Salt,
+    },
     Redact,
     Null,
 }
@@ -220,7 +233,10 @@ const VALID_GENERATORS: &[&str] = &[
 
 fn validate_action(action: &ActionConfig, rule_num: usize) -> Result<ValidatedAction, String> {
     match action {
-        ActionConfig::Fake { generator } => {
+        ActionConfig::Fake {
+            generator,
+            seed_env,
+        } => {
             if !VALID_GENERATORS.contains(&generator.as_str()) {
                 return Err(format!(
                     "Rule {rule_num}: unknown generator '{}'. Valid generators: {}",
@@ -228,8 +244,31 @@ fn validate_action(action: &ActionConfig, rule_num: usize) -> Result<ValidatedAc
                     VALID_GENERATORS.join(", ")
                 ));
             }
+            // Same rule as the hash salt: an empty variable is the shape an
+            // unset CI secret takes, and a seed anyone can guess makes the
+            // mapping from original to fake reproducible by anyone holding
+            // the source data.
+            let seed = match seed_env {
+                Some(env_var) => {
+                    let value = std::env::var(env_var).map_err(|_| {
+                        format!(
+                            "Rule {rule_num}: environment variable '{env_var}' not set (required for the fake seed)"
+                        )
+                    })?;
+                    if value.is_empty() {
+                        return Err(format!(
+                            "Rule {rule_num}: environment variable '{env_var}' is empty. \
+                             The seed is what stops anyone with the original data reproducing \
+                             the anonymised values, so set it to a secret value"
+                        ));
+                    }
+                    Some(Salt::new(value.into_bytes()))
+                }
+                None => None,
+            };
             Ok(ValidatedAction::Fake {
                 generator: generator.clone(),
+                seed,
             })
         }
         ActionConfig::Mask {
@@ -351,6 +390,7 @@ mod tests {
     fn test_validate_fake_action() {
         let action = ActionConfig::Fake {
             generator: "safe_email".to_string(),
+            seed_env: None,
         };
         assert!(validate_action(&action, 1).is_ok());
     }
@@ -359,6 +399,7 @@ mod tests {
     fn test_validate_fake_unknown_generator() {
         let action = ActionConfig::Fake {
             generator: "unknown".to_string(),
+            seed_env: None,
         };
         assert!(validate_action(&action, 1).is_err());
     }

--- a/src/import/config.rs
+++ b/src/import/config.rs
@@ -244,10 +244,10 @@ fn validate_action(action: &ActionConfig, rule_num: usize) -> Result<ValidatedAc
                     VALID_GENERATORS.join(", ")
                 ));
             }
-            // Same rule as the hash salt: an empty variable is the shape an
-            // unset CI secret takes, and a seed anyone can guess makes the
-            // mapping from original to fake reproducible by anyone holding
-            // the source data.
+            // An empty variable is the shape an unset CI secret takes, and a
+            // seed anyone can guess makes the mapping from original to fake
+            // reproducible by anyone holding the source data, which is the
+            // whole thing the seed is for.
             let seed = match seed_env {
                 Some(env_var) => {
                     let value = std::env::var(env_var).map_err(|_| {
@@ -402,6 +402,63 @@ mod tests {
             seed_env: None,
         };
         assert!(validate_action(&action, 1).is_err());
+    }
+
+    #[test]
+    fn test_seed_env_is_resolved_and_required_to_be_non_empty() {
+        // SAFETY: single-threaded test, no concurrent env reads
+        unsafe { std::env::set_var("DYNOXIDE_TEST_SEED", "a-secret") };
+        let action = ActionConfig::Fake {
+            generator: "safe_email".to_string(),
+            seed_env: Some("DYNOXIDE_TEST_SEED".to_string()),
+        };
+        match validate_action(&action, 1).unwrap() {
+            ValidatedAction::Fake { seed, .. } => assert_eq!(
+                seed.expect("seed should be resolved").as_bytes(),
+                b"a-secret",
+                "the configured seed must reach the action"
+            ),
+            other => panic!("expected Fake, got {other:?}"),
+        }
+
+        unsafe { std::env::set_var("DYNOXIDE_TEST_SEED", "") };
+        let err = validate_action(&action, 1).unwrap_err();
+        assert!(err.contains("is empty"), "{err}");
+
+        unsafe { std::env::remove_var("DYNOXIDE_TEST_SEED") };
+        let err = validate_action(&action, 1).unwrap_err();
+        assert!(err.contains("not set"), "{err}");
+    }
+
+    #[test]
+    fn test_fake_without_seed_env_has_no_seed() {
+        let action = ActionConfig::Fake {
+            generator: "safe_email".to_string(),
+            seed_env: None,
+        };
+        match validate_action(&action, 1).unwrap() {
+            ValidatedAction::Fake { seed, .. } => assert!(seed.is_none()),
+            other => panic!("expected Fake, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_seed_env_parses_from_a_rules_file() {
+        let config: ImportConfig = toml::from_str(
+            r#"
+[[rules]]
+match = "attribute_exists(email)"
+path = "email"
+action = { type = "fake", generator = "safe_email", seed_env = "SOME_SEED" }
+"#,
+        )
+        .unwrap();
+        match &config.rules[0].action {
+            ActionConfig::Fake { seed_env, .. } => {
+                assert_eq!(seed_env.as_deref(), Some("SOME_SEED"))
+            }
+            other => panic!("expected Fake, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -168,6 +168,14 @@ pub fn run_into(db: &Database, cmd: ImportCommand) -> Result<ImportSummary, Impo
         .unwrap_or_default();
     let mut consistency_map = ConsistencyMap::new();
 
+    // A seeded fake derives its value and does not populate the consistency
+    // map, because it does not need to. That only holds while every rule
+    // writing a given field agrees: mix a seeded rule with an unseeded one, or
+    // two different seeds or generators, and the same input can leave with two
+    // different values depending on which rule matched. Nothing downstream
+    // would show that, so say it here.
+    let mixed = mixed_consistency_rules(&rules, &consistency_fields);
+
     // 2. Load table schemas (returns both parsed schemas and raw JSON)
     let (schemas, schema_json) = schema::load_schemas(&cmd.schema)?;
     eprintln!(
@@ -225,6 +233,10 @@ pub fn run_into(db: &Database, cmd: ImportCommand) -> Result<ImportSummary, Impo
         warnings: Vec::new(),
         output_path: cmd.output.clone(),
     };
+
+    for message in mixed {
+        summary.warnings.push(message);
+    }
 
     let mut seen_warnings: HashSet<String> = HashSet::new();
 
@@ -504,6 +516,52 @@ fn unwrap_describe_table_shapes(table: &mut serde_json::Value) {
             }
         }
     }
+}
+
+/// Consistency fields written by rules that do not agree on how they generate.
+///
+/// Returns one message per offending field. A field is fine when every rule
+/// targeting it uses the same action shape; it is not when a seeded fake sits
+/// beside an unseeded one, or beside a different seed or generator, because
+/// the seeded rule bypasses the map the other one depends on.
+fn mixed_consistency_rules(
+    rules: &[config::ValidatedRule],
+    consistency_fields: &HashSet<String>,
+) -> Vec<String> {
+    use crate::expressions::PathElement;
+
+    let mut messages = Vec::new();
+    for field in consistency_fields {
+        let mut shapes: Vec<String> = rules
+            .iter()
+            .filter(|rule| {
+                matches!(rule.path.first(), Some(PathElement::Attribute(name)) if name == field)
+            })
+            .map(|rule| match &rule.action {
+                config::ValidatedAction::Fake { generator, seed } => {
+                    let seeded = if seed.is_some() { "seeded" } else { "unseeded" };
+                    format!("{seeded} fake '{generator}'")
+                }
+                other => format!("{other:?}")
+                    .split_whitespace()
+                    .next()
+                    .unwrap_or("action")
+                    .to_lowercase(),
+            })
+            .collect();
+        shapes.sort();
+        shapes.dedup();
+        if shapes.len() > 1 {
+            messages.push(format!(
+                "'{field}' is in [consistency] fields but its rules do not agree on how they \
+                 generate ({}). A seeded fake derives its value and does not use the consistency \
+                 map, so mixing it with anything else can give one input two different values",
+                shapes.join(", ")
+            ));
+        }
+    }
+    messages.sort();
+    messages
 }
 
 /// Extract key attribute names from a CreateTableRequest.

--- a/tests/import.rs
+++ b/tests/import.rs
@@ -986,4 +986,111 @@ fields = ["email"]
             .unwrap();
         assert_eq!(scan.count, 2);
     }
+
+    #[test]
+    fn test_mixed_rules_on_a_consistency_field_are_reported() {
+        // A seeded fake derives its value and skips the consistency map, so
+        // pairing it with an unseeded rule on the same field means one input
+        // can leave with two values. Nothing in the output shows that.
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("export");
+        let schema_file = tmp.path().join("schema.json");
+        let rules_file = tmp.path().join("rules.toml");
+
+        setup_export_dir(
+            &source,
+            "Users",
+            &[
+                r#"{"Item": {"pk": {"S": "U#1"}, "sk": {"S": "P"}, "email": {"S": "a@x.co"}, "vip": {"BOOL": true}}}"#,
+            ],
+        );
+        create_schema_file(&schema_file, &[simple_table_schema("Users")]);
+        // SAFETY: single-threaded test, no concurrent env reads
+        unsafe { std::env::set_var("TEST_MIXED_SEED", "s3cret") };
+        std::fs::write(
+            &rules_file,
+            r#"
+[[rules]]
+match = "attribute_exists(vip)"
+path = "email"
+action = { type = "fake", generator = "safe_email", seed_env = "TEST_MIXED_SEED" }
+
+[[rules]]
+match = "attribute_not_exists(vip)"
+path = "email"
+action = { type = "fake", generator = "safe_email" }
+
+[consistency]
+fields = ["email"]
+"#,
+        )
+        .unwrap();
+
+        let summary = import::run(ImportCommand {
+            source,
+            output: Some(tmp.path().join("out.db")),
+            schema: schema_file,
+            rules: Some(rules_file),
+            tables: None,
+            compress: false,
+            force: false,
+            continue_on_error: false,
+        })
+        .unwrap();
+
+        assert!(
+            summary
+                .warnings
+                .iter()
+                .any(|w| w.contains("'email'") && w.contains("do not agree")),
+            "expected the mixed-rule warning: {:?}",
+            summary.warnings
+        );
+    }
+
+    #[test]
+    fn test_consistent_rules_on_a_consistency_field_are_quiet() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("export");
+        let schema_file = tmp.path().join("schema.json");
+        let rules_file = tmp.path().join("rules.toml");
+
+        setup_export_dir(
+            &source,
+            "Users",
+            &[r#"{"Item": {"pk": {"S": "U#1"}, "sk": {"S": "P"}, "email": {"S": "a@x.co"}}}"#],
+        );
+        create_schema_file(&schema_file, &[simple_table_schema("Users")]);
+        std::fs::write(
+            &rules_file,
+            r#"
+[[rules]]
+match = "attribute_exists(email)"
+path = "email"
+action = { type = "fake", generator = "safe_email" }
+
+[consistency]
+fields = ["email"]
+"#,
+        )
+        .unwrap();
+
+        let summary = import::run(ImportCommand {
+            source,
+            output: Some(tmp.path().join("out.db")),
+            schema: schema_file,
+            rules: Some(rules_file),
+            tables: None,
+            compress: false,
+            force: false,
+            continue_on_error: false,
+        })
+        .unwrap();
+
+        assert!(
+            !summary.warnings.iter().any(|w| w.contains("do not agree")),
+            "one rule shape should not warn: {:?}",
+            summary.warnings
+        );
+    }
 }


### PR DESCRIPTION
## What this changes

Two faults in the `fake` anonymisation action, fixed together because fixing either alone leaves the command in a worse state than it looks.

**`fake` re-rolled on every run.** Re-importing an export to pick up new data rewrote every generated name and address, so an anonymised database kept as a committed test fixture could not be refreshed without a diff of pure churn, and a reviewer could not separate that churn from a real change. A rule can now name a `seed_env`, and the generated value becomes a function of the original, so the same input gives the same output on every run. Without one the previous per-run randomness stands, so existing rules files are unaffected. A seeded rule no longer needs its field in `[consistency]`, because the derivation already guarantees one input maps to one output.

The seed is a secret for the same reason the hash salt is: without it, anyone holding the original data could reproduce the mapping and undo the anonymisation. An empty variable is rejected, which is the shape an unset CI secret takes.

**`safe_email` collided at ordinary sizes.** It drew from roughly nine thousand values, a first name against three `example.` domains. A security review measured four collisions in three hundred items, and a collision is not cosmetic: where the attribute is one a key is built from, two people collapse onto the same key and one row overwrites the other. Determinism alone would have made those collisions stable rather than absent, so the generated address now carries a derived suffix in its local part. It still reads as an address, and there is room past a hundred billion. The other generators keep their small pools and remain unsuitable for an attribute a key is built from, which the docs now say.

Verified end to end on 400 items: two runs with the same seed are byte-identical, all 400 values are distinct, a different seed gives a different mapping, and an unseeded run still re-rolls.

## Guidance reconciliation

#204 currently tells people to prefer `hash` over `fake` for an attribute a key is built from, giving the small output space as the reason. That reason no longer holds for `safe_email` once this lands, though it still holds for `word`, `first_name` and the rest. The wording is reconciled on the release branch rather than left for merge order to decide.

## Checklist

- [x] Tests added or updated
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` pass locally
- [x] `CHANGELOG.md` updated if this is a user-visible change
- [x] Linked issue, discussion, or a short note explaining the
  motivation
- [x] I agree my contribution is licensed under the project's terms
  (MIT License and Apache License, Version 2.0)

Closes #203
